### PR TITLE
chore: Update repository and remove deprecated authors field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,8 @@ resolver = "2"
 
 [workspace.package]
 version = "0.18.0"
-authors = ["Apache Avro team <dev@avro.apache.org>"]
 license = "Apache-2.0"
-repository = "https://github.com/apache/avro"
+repository = "https://github.com/apache/avro-rs"
 edition = "2021"
 rust-version = "1.73.0"
 keywords = ["avro", "data", "serialization"]

--- a/avro/Cargo.toml
+++ b/avro/Cargo.toml
@@ -20,7 +20,6 @@ name = "apache-avro"
 description = "A library for working with Apache Avro in Rust"
 readme = "README.md"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 repository.workspace = true
 edition.workspace = true

--- a/avro_derive/Cargo.toml
+++ b/avro_derive/Cargo.toml
@@ -18,7 +18,6 @@
 [package]
 name = "apache-avro-derive"
 version.workspace = true
-authors.workspace = true
 description = "A library for deriving Avro schemata from Rust structs and enums"
 license.workspace = true
 repository.workspace = true

--- a/avro_test_helper/Cargo.toml
+++ b/avro_test_helper/Cargo.toml
@@ -21,7 +21,6 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "Apache Avro tests helper."
-authors.workspace = true
 license.workspace = true
 repository.workspace = true
 keywords = ["avro", "data", "serialization", "test"]

--- a/wasm-demo/Cargo.toml
+++ b/wasm-demo/Cargo.toml
@@ -18,7 +18,6 @@
 [package]
 name = "hello-wasm"
 version = "0.1.0"
-authors.workspace = true
 description = "A demo project for testing apache_avro in WebAssembly"
 license.workspace = true
 readme = "README.md"


### PR DESCRIPTION
This PR contains two changes:

- Update repository field to `apache/avro-rs`
- Remove [deprecated authors field](https://github.com/rust-lang/rfcs/blob/master/text/3052-optional-authors-field.md)