### PR TITLE
chore: Use `use abc` to replace `extern crate abc`

### DIFF
--- a/avro/src/encode.rs
+++ b/avro/src/encode.rs
@@ -25,6 +25,7 @@ use crate::{
     util::{zig_i32, zig_i64},
     AvroResult, Error,
 };
+use log::error;
 use std::{borrow::Borrow, collections::HashMap};
 
 /// Encode a `Value` into avro format.

--- a/avro/src/lib.rs
+++ b/avro/src/lib.rs
@@ -894,9 +894,6 @@ pub use writer::{
 #[cfg(feature = "derive")]
 pub use apache_avro_derive::*;
 
-#[macro_use]
-extern crate log;
-
 /// A convenience type alias for `Result`s with `Error`s.
 pub type AvroResult<T> = Result<T, Error>;
 

--- a/avro/src/reader.rs
+++ b/avro/src/reader.rs
@@ -27,6 +27,7 @@ use crate::{
     types::Value,
     util, AvroResult, Codec, Error,
 };
+use log::warn;
 use serde::de::DeserializeOwned;
 use serde_json::from_slice;
 use std::{

--- a/avro/src/schema.rs
+++ b/avro/src/schema.rs
@@ -27,6 +27,7 @@ use crate::{
     AvroResult,
 };
 use digest::Digest;
+use log::{debug, error, warn};
 use serde::{
     ser::{SerializeMap, SerializeSeq},
     Deserialize, Serialize, Serializer,

--- a/avro/src/schema_equality.rs
+++ b/avro/src/schema_equality.rs
@@ -22,6 +22,7 @@ use crate::{
     },
     Schema,
 };
+use log::{debug, error};
 use std::{fmt::Debug, sync::OnceLock};
 
 /// A trait that compares two schemata for equality.

--- a/avro/src/types.rs
+++ b/avro/src/types.rs
@@ -27,6 +27,7 @@ use crate::{
     AvroResult, Error,
 };
 use bigdecimal::BigDecimal;
+use log::{debug, error};
 use serde_json::{Number, Value as JsonValue};
 use std::{
     borrow::Borrow,

--- a/avro/src/validator.rs
+++ b/avro/src/validator.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::{schema::Namespace, AvroResult, Error};
+use log::debug;
 use regex_lite::Regex;
 use std::sync::OnceLock;
 

--- a/avro_derive/tests/derive.rs
+++ b/avro_derive/tests/derive.rs
@@ -22,11 +22,8 @@ use apache_avro::{
 };
 use apache_avro_derive::*;
 use proptest::prelude::*;
-use serde::{de::DeserializeOwned, ser::Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::HashMap;
-
-#[macro_use]
-extern crate serde;
 
 #[cfg(test)]
 mod test_derive {

--- a/wasm-demo/tests/demos.rs
+++ b/wasm-demo/tests/demos.rs
@@ -17,8 +17,6 @@
 
 #![cfg(target_arch = "wasm32")]
 
-extern crate wasm_bindgen_test;
-
 use std::io::BufWriter;
 use wasm_bindgen_test::*;
 


### PR DESCRIPTION
This PR will use Rust 2021 edition's `use abc` to replace `extern crate abc`.