### PR TITLE
AVRO-4063: Call `flush` on the inner `writer` during `Writer::flush`

### DIFF
--- a/avro/src/error.rs
+++ b/avro/src/error.rs
@@ -446,6 +446,9 @@ pub enum Error {
     #[error("Failed to write buffer bytes during flush: {0}")]
     WriteBytes(#[source] std::io::Error),
 
+    #[error("Failed to flush inner writer during flush: {0}")]
+    FlushWriter(#[source] std::io::Error),
+
     #[error("Failed to write marker: {0}")]
     WriteMarker(#[source] std::io::Error),
 

--- a/avro/src/writer.rs
+++ b/avro/src/writer.rs
@@ -315,6 +315,8 @@ impl<'a, W: Write> Writer<'a, W> {
         self.buffer.clear();
         self.num_values = 0;
 
+        self.writer.flush().map_err(Error::FlushWriter)?;
+
         Ok(num_bytes)
     }
 

--- a/avro/src/writer.rs
+++ b/avro/src/writer.rs
@@ -659,7 +659,7 @@ fn generate_sync_marker() -> [u8; 16] {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
+    use std::{cell::RefCell, rc::Rc};
 
     use super::*;
     use crate::{
@@ -1462,17 +1462,17 @@ mod tests {
         "#;
 
         #[derive(Clone, Default)]
-        struct TestBuffer(Arc<Mutex<Vec<u8>>>);
+        struct TestBuffer(Rc<RefCell<Vec<u8>>>);
 
         impl TestBuffer {
             fn len(&self) -> usize {
-                self.0.try_lock().unwrap().len()
+                self.0.borrow().len()
             }
         }
 
         impl Write for TestBuffer {
             fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-                self.0.try_lock().unwrap().write(buf)
+                self.0.borrow_mut().write(buf)
             }
 
             fn flush(&mut self) -> std::io::Result<()> {

--- a/avro/src/writer.rs
+++ b/avro/src/writer.rs
@@ -659,6 +659,8 @@ fn generate_sync_marker() -> [u8; 16] {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
     use super::*;
     use crate::{
         decimal::Decimal,
@@ -1445,5 +1447,53 @@ mod tests {
             }
         }
         Ok(())
+    }
+
+    #[test]
+    fn avro_4063_flush_applies_to_inner_writer() {
+        const SCHEMA: &str = r#"
+        {
+            "type": "record",
+            "name": "ExampleSchema",
+            "fields": [
+                {"name": "exampleField", "type": "string"}
+            ]
+        }
+        "#;
+
+        #[derive(Clone, Default)]
+        struct TestBuffer(Arc<Mutex<Vec<u8>>>);
+
+        impl TestBuffer {
+            fn len(&self) -> usize {
+                self.0.try_lock().unwrap().len()
+            }
+        }
+
+        impl std::io::Write for TestBuffer {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.try_lock().unwrap().write(buf)
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let shared_buffer = TestBuffer::default();
+
+        let buffered_writer = std::io::BufWriter::new(shared_buffer.clone());
+
+        let schema = Schema::parse_str(SCHEMA).unwrap();
+
+        let mut writer = Writer::new(&schema, buffered_writer);
+
+        let mut record = Record::new(writer.schema()).unwrap();
+        record.put("exampleField", "value");
+
+        writer.append(record).unwrap();
+        writer.flush().unwrap();
+
+        assert_eq!(shared_buffer.len(), 167, "the test buffer was not fully written to after Writer::flush was called");
     }
 }


### PR DESCRIPTION
## Overview

Fixes #10.

## Description

This PR calls `std::io::Write::flush` on the inner `writer` of `apache_avro::Writer` at the end of `apache_avro::Writer::flush`. This ensures that the flush is propagated and the previously written bytes are fully sent.

This PR also includes a unit test that confirms `Writer::flush` now works as expected.