### PR TITLE
Added Schema::independent_canonical_form

### DIFF
--- a/avro/src/schema.rs
+++ b/avro/src/schema.rs
@@ -1266,15 +1266,12 @@ impl Schema {
         match self {
             Ref { name } => {
                 let repl = schemata.iter().find(|s| {
-                    if let Some(n) = s.name() {
-                        if *n == *name {
-                            return true;
-                        }
-                    }
-                    false
+                    s.name().map(|n| *n == *name).unwrap_or(false)
                 });
                 if let Some(r) = repl {
-                    *self = r.clone();
+                    let mut denorm = r.clone();
+                    denorm.denormalize(schemata);
+                    *self = denorm;
                 }
             }
             Schema::Record(r) => {

--- a/avro/src/schema.rs
+++ b/avro/src/schema.rs
@@ -43,8 +43,6 @@ use std::{
     io::Read,
     str::FromStr,
 };
-#[allow(unused_imports)]
-use std::borrow::Cow;
 use strum_macros::{Display, EnumDiscriminants, EnumString};
 
 /// Represents an Avro schema fingerprint
@@ -1265,9 +1263,9 @@ impl Schema {
     fn denormalize(&mut self, schemata: &Vec<Schema>) {
         match self {
             Ref { name } => {
-                let repl = schemata.iter().find(|s| {
-                    s.name().map(|n| *n == *name).unwrap_or(false)
-                });
+                let repl = schemata
+                    .iter()
+                    .find(|s| s.name().map(|n| *n == *name).unwrap_or(false));
                 if let Some(r) = repl {
                     let mut denorm = r.clone();
                     denorm.denormalize(schemata);
@@ -2440,6 +2438,7 @@ pub trait AvroSchema {
 #[cfg(feature = "derive")]
 pub mod derive {
     use super::*;
+    use std::borrow::Cow;
 
     /// Trait for types that serve as fully defined components inside an Avro data model. Derive
     /// implementation available through `derive` feature. This is what is implemented by

--- a/avro/src/schema.rs
+++ b/avro/src/schema.rs
@@ -35,7 +35,7 @@ use serde::{
 };
 use serde_json::{Map, Value};
 use std::{
-    borrow::{Borrow, Cow},
+    borrow::Borrow,
     collections::{BTreeMap, HashMap, HashSet},
     fmt,
     fmt::Debug,
@@ -43,6 +43,8 @@ use std::{
     io::Read,
     str::FromStr,
 };
+#[allow(unused_imports)]
+use std::borrow::Cow;
 use strum_macros::{Display, EnumDiscriminants, EnumString};
 
 /// Represents an Avro schema fingerprint

--- a/avro/src/schema.rs
+++ b/avro/src/schema.rs
@@ -2349,7 +2349,7 @@ fn pcf_map(schema: &Map<String, Value>, defined_names: &mut HashSet<String>) -> 
         // Fully qualify the name, if it isn't already ([FULLNAMES] rule).
         if k == "name" {
             if let Some(ref n) = name {
-                fields.push((k, format!("{}:{}", pcf_string(k), pcf_string(&n))));
+                fields.push((k, format!("{}:{}", pcf_string(k), pcf_string(n))));
                 continue;
             }
         }

--- a/avro/src/schema.rs
+++ b/avro/src/schema.rs
@@ -1276,18 +1276,18 @@ impl Schema {
             }
             Schema::Record(r) => {
                 for rr in &mut r.fields {
-                    let _ = rr.schema.denormalize(schemata)?;
+                    rr.schema.denormalize(schemata)?;
                 }
             }
             Schema::Array(a) => {
-                let _ = a.items.denormalize(schemata)?;
+                a.items.denormalize(schemata)?;
             }
             Schema::Map(m) => {
-                let _ = m.types.denormalize(schemata)?;
+                m.types.denormalize(schemata)?;
             }
             Schema::Union(u) => {
                 for uu in &mut u.schemas {
-                    let _ = uu.denormalize(schemata)?;
+                    uu.denormalize(schemata)?;
                 }
             }
             _ => (),

--- a/avro/src/schema.rs
+++ b/avro/src/schema.rs
@@ -25,6 +25,7 @@ use crate::{
         validate_schema_name,
     },
     AvroResult,
+    Schema::Ref,
 };
 use digest::Digest;
 use log::{debug, error, warn};
@@ -1041,8 +1042,21 @@ impl Schema {
     pub fn canonical_form(&self) -> String {
         let json = serde_json::to_value(self)
             .unwrap_or_else(|e| panic!("Cannot parse Schema from JSON: {e}"));
-        parsing_canonical_form(&json)
+        let mut defined_names = HashSet::new();
+        parsing_canonical_form(&json,&mut defined_names)
     }
+
+    /// Returns the [Parsing Canonical Form] of `self` that is self contained (not dependent on
+    /// any definitions in `schemata`)
+    ///
+    /// [Parsing Canonical Form]:
+    /// https://avro.apache.org/docs/current/specification/#parsing-canonical-form-for-schemas
+    pub fn independent_canonical_form(&self,schemata: &Vec<Schema>) -> String {
+        let mut d = self.clone();
+        d.denormalize(schemata);
+        d.canonical_form()
+    }
+
 
     /// Generate [fingerprint] of Schema's [Parsing Canonical Form].
     ///
@@ -1245,6 +1259,39 @@ impl Schema {
             items: Box::new(items),
             attributes,
         })
+    }
+
+    fn denormalize(&mut self,schemata: &Vec<Schema>)  {
+        match self {
+            Ref{name} => {
+                let repl = schemata.iter().find(|s| {
+                    if let Some(n) = s.name() {
+                        if *n == *name {
+                            return true;
+                        }
+                    }
+                    false
+                });
+                if let Some(r) = repl { *self = r.clone(); }
+            },
+            Schema::Record(r) => {
+                for rr in &mut r.fields {
+                    rr.schema.denormalize(schemata);
+                }
+            },
+            Schema::Array(a) => {
+                a.items.denormalize(schemata);
+            },
+            Schema::Map(m) => {
+                m.types.denormalize(schemata);
+            },
+            Schema::Union(u) => {
+                for uu in &mut u.schemas {
+                    uu.denormalize(schemata);
+                }
+            },
+            _ => (),
+        }
     }
 }
 
@@ -2245,19 +2292,35 @@ impl Serialize for RecordField {
 
 /// Parses a **valid** avro schema into the Parsing Canonical Form.
 /// https://avro.apache.org/docs/current/specification/#parsing-canonical-form-for-schemas
-fn parsing_canonical_form(schema: &Value) -> String {
+fn parsing_canonical_form(schema: &Value, defined_names: &mut HashSet<String>) -> String {
     match schema {
-        Value::Object(map) => pcf_map(map),
+        Value::Object(map) => pcf_map(map, defined_names),
         Value::String(s) => pcf_string(s),
-        Value::Array(v) => pcf_array(v),
+        Value::Array(v) => pcf_array(v, defined_names),
         json => panic!("got invalid JSON value for canonical form of schema: {json}"),
     }
 }
 
-fn pcf_map(schema: &Map<String, Value>) -> String {
+fn pcf_map(schema: &Map<String, Value>,defined_names: &mut HashSet<String>) -> String {
     // Look for the namespace variant up front.
     let ns = schema.get("namespace").and_then(|v| v.as_str());
     let typ = schema.get("type").and_then(|v| v.as_str());
+    let raw_name = schema.get("name").and_then(|v| v.as_str());
+    let name = if is_named_type(typ) {
+        Some(format!("{}{}", ns.map_or("".to_string(), |n| { format!("{n}.") }), raw_name.unwrap_or_default()))
+    } else {
+        None
+    };
+
+    //if this is already a defined type, early return
+    if let Some(ref n) = name {
+        if defined_names.get(n).is_some() {
+            return pcf_string(n);
+        } else {
+            defined_names.insert(n.clone());
+        }
+    }
+
     let mut fields = Vec::new();
     for (k, v) in schema {
         // Reduce primitive types to their simple form. ([PRIMITIVE] rule)
@@ -2280,17 +2343,10 @@ fn pcf_map(schema: &Map<String, Value>) -> String {
 
         // Fully qualify the name, if it isn't already ([FULLNAMES] rule).
         if k == "name" {
-            // Invariant: Only valid schemas. Must be a string.
-            let name = v.as_str().unwrap();
-            let n = match ns {
-                Some(namespace) if is_named_type(typ) && !name.contains('.') => {
-                    Cow::Owned(format!("{namespace}.{name}"))
-                }
-                _ => Cow::Borrowed(name),
-            };
-
-            fields.push((k, format!("{}:{}", pcf_string(k), pcf_string(&n))));
-            continue;
+            if let Some(ref n) = name {
+                fields.push((k, format!("{}:{}", pcf_string(k), pcf_string(&n))));
+                continue;
+            }
         }
 
         // Strip off quotes surrounding "size" type, if they exist ([INTEGERS] rule).
@@ -2306,7 +2362,7 @@ fn pcf_map(schema: &Map<String, Value>) -> String {
         // For anything else, recursively process the result.
         fields.push((
             k,
-            format!("{}:{}", pcf_string(k), parsing_canonical_form(v)),
+            format!("{}:{}", pcf_string(k), parsing_canonical_form(v,defined_names)),
         ));
     }
 
@@ -2327,10 +2383,10 @@ fn is_named_type(typ: Option<&str>) -> bool {
     )
 }
 
-fn pcf_array(arr: &[Value]) -> String {
+fn pcf_array(arr: &[Value],defined_names: &mut HashSet<String>) -> String {
     let inter = arr
         .iter()
-        .map(parsing_canonical_form)
+        .map(|a|parsing_canonical_form(a,defined_names))
         .collect::<Vec<String>>()
         .join(",");
     format!("[{inter}]")
@@ -3424,7 +3480,7 @@ mod tests {
         assert_eq!(schema, expected);
 
         let canonical_form = &schema.canonical_form();
-        let expected = r#"{"name":"record","type":"record","fields":[{"name":"enum","type":{"name":"enum","type":"enum","symbols":["one","two","three"]}},{"name":"next","type":{"name":"enum","type":"enum","symbols":["one","two","three"]}}]}"#;
+        let expected = r#"{"name":"record","type":"record","fields":[{"name":"enum","type":{"name":"enum","type":"enum","symbols":["one","two","three"]}},{"name":"next","type":"enum"}]}"#;
         assert_eq!(canonical_form, &expected);
 
         Ok(())
@@ -3508,7 +3564,7 @@ mod tests {
         assert_eq!(schema, expected);
 
         let canonical_form = &schema.canonical_form();
-        let expected = r#"{"name":"record","type":"record","fields":[{"name":"fixed","type":{"name":"fixed","type":"fixed","size":456}},{"name":"next","type":{"name":"fixed","type":"fixed","size":456}}]}"#;
+        let expected = r#"{"name":"record","type":"record","fields":[{"name":"fixed","type":{"name":"fixed","type":"fixed","size":456}},{"name":"next","type":"fixed"}]}"#;
         assert_eq!(canonical_form, &expected);
 
         Ok(())

--- a/avro/tests/schema.rs
+++ b/avro/tests/schema.rs
@@ -2344,11 +2344,12 @@ fn test_independent_canonical_form_missing_ref() -> TestResult {
 
     let schema_strs = [record_primitive, record_usage];
     let schemata = Schema::parse_list(&schema_strs)?;
-    assert!(
-        matches!(
-            schemata[1].independent_canonical_form(&vec![]).err().unwrap(),  //NOTE - we're passing in an empty schemata
-            Error::SchemaResolutionError(..)
-        )
-    );
+    assert!(matches!(
+        schemata[1]
+            .independent_canonical_form(&vec![])
+            .err()
+            .unwrap(), //NOTE - we're passing in an empty schemata
+        Error::SchemaResolutionError(..)
+    ));
     Ok(())
 }

--- a/avro/tests/schema.rs
+++ b/avro/tests/schema.rs
@@ -2305,20 +2305,19 @@ fn test_independent_canonical_form_deep_recursion() -> TestResult {
 
     }"#;
 
-
-    let schema_strs = [
-        record_primitive,
-        record_usage,
-        record_usage_usage,
-    ];
+    let schema_strs = [record_primitive, record_usage, record_usage_usage];
 
     for schema_str_perm in permutations(&schema_strs) {
         let schema_str_perm: Vec<&str> = schema_str_perm.iter().map(|s| **s).collect();
         let schemata = Schema::parse_list(&schema_str_perm)?;
-        let ruu = schemata.iter().find(|s|s.name().unwrap().to_string().as_str() == "RecUsageUsage").unwrap();
+        let ruu = schemata
+            .iter()
+            .find(|s| s.name().unwrap().to_string().as_str() == "RecUsageUsage")
+            .unwrap();
         assert_eq!(
             ruu.independent_canonical_form(&schemata),
-            Schema::parse_str(record_usage_usage_independent)?.canonical_form());
+            Schema::parse_str(record_usage_usage_independent)?.canonical_form()
+        );
     }
     Ok(())
 }

--- a/avro/tests/schema.rs
+++ b/avro/tests/schema.rs
@@ -2019,7 +2019,7 @@ fn test_avro_3851_read_default_value_for_enum() -> TestResult {
 }
 
 #[test]
-fn test_independent_canonical_form_primitives() -> TestResult {
+fn avro_rs_66_test_independent_canonical_form_primitives() -> TestResult {
     init();
     let record_primitive = r#"{
         "name": "Rec",
@@ -2100,7 +2100,7 @@ fn test_independent_canonical_form_primitives() -> TestResult {
     for schema_str_perm in permutations(&schema_strs) {
         let schema_str_perm: Vec<&str> = schema_str_perm.iter().map(|s| **s).collect();
         let schemata = Schema::parse_list(&schema_str_perm)?;
-        assert_eq!(schemata.len(), 4);
+        assert_eq!(schemata.len(), schema_strs.len());
         let test_schema = schemata
             .iter()
             .find(|a| a.name().unwrap().to_string() == *"RecWithDeps")
@@ -2120,7 +2120,7 @@ fn test_independent_canonical_form_primitives() -> TestResult {
 }
 
 #[test]
-fn test_independent_canonical_form_usages() -> TestResult {
+fn avro_rs_66_test_independent_canonical_form_usages() -> TestResult {
     init();
     let record_primitive = r#"{
         "name": "Rec",
@@ -2218,36 +2218,39 @@ fn test_independent_canonical_form_usages() -> TestResult {
     for schema_str_perm in permutations(&schema_strs) {
         let schema_str_perm: Vec<&str> = schema_str_perm.iter().map(|s| **s).collect();
         let schemata = Schema::parse_list(&schema_str_perm)?;
-        for s in &schemata {
-            match s.name().unwrap().to_string().as_str() {
+        for schema in &schemata {
+            match schema.name().unwrap().to_string().as_str() {
                 "RecUsage" => {
                     assert_eq!(
-                        s.independent_canonical_form(&schemata)?,
+                        schema.independent_canonical_form(&schemata)?,
                         Schema::parse_str(record_usage_independent)?.canonical_form()
                     );
                 }
                 "ArrayUsage" => {
                     assert_eq!(
-                        s.independent_canonical_form(&schemata)?,
+                        schema.independent_canonical_form(&schemata)?,
                         Schema::parse_str(array_usage_independent)?.canonical_form()
                     );
                 }
                 "UnionUsage" => {
                     assert_eq!(
-                        s.independent_canonical_form(&schemata)?,
+                        schema.independent_canonical_form(&schemata)?,
                         Schema::parse_str(union_usage_independent)?.canonical_form()
                     );
                 }
                 "MapUsage" => {
                     assert_eq!(
-                        s.independent_canonical_form(&schemata)?,
+                        schema.independent_canonical_form(&schemata)?,
                         Schema::parse_str(map_usage_independent)?.canonical_form()
                     );
                 }
                 "ns.Rec" => {
-                    assert_eq!(s.independent_canonical_form(&schemata)?, s.canonical_form());
+                    assert_eq!(
+                        schema.independent_canonical_form(&schemata)?,
+                        schema.canonical_form()
+                    );
                 }
-                _ => panic!(),
+                other => unreachable!("Unknown schema name: {}", other),
             }
         }
     }
@@ -2255,7 +2258,7 @@ fn test_independent_canonical_form_usages() -> TestResult {
 }
 
 #[test]
-fn test_independent_canonical_form_deep_recursion() -> TestResult {
+fn avro_rs_66_test_independent_canonical_form_deep_recursion() -> TestResult {
     init();
     let record_primitive = r#"{
         "name": "Rec",
@@ -2323,7 +2326,7 @@ fn test_independent_canonical_form_deep_recursion() -> TestResult {
 }
 
 #[test]
-fn test_independent_canonical_form_missing_ref() -> TestResult {
+fn avro_rs_66_test_independent_canonical_form_missing_ref() -> TestResult {
     init();
     let record_primitive = r#"{
         "name": "Rec",
@@ -2345,11 +2348,8 @@ fn test_independent_canonical_form_missing_ref() -> TestResult {
     let schema_strs = [record_primitive, record_usage];
     let schemata = Schema::parse_list(&schema_strs)?;
     assert!(matches!(
-        schemata[1]
-            .independent_canonical_form(&vec![])
-            .err()
-            .unwrap(), //NOTE - we're passing in an empty schemata
-        Error::SchemaResolutionError(..)
+        schemata[1].independent_canonical_form(&Vec::with_capacity(0)), //NOTE - we're passing in an empty schemata
+        Err(Error::SchemaResolutionError(..))
     ));
     Ok(())
 }

--- a/avro/tests/schema.rs
+++ b/avro/tests/schema.rs
@@ -2103,7 +2103,7 @@ fn test_independent_canonical_form_primitives() -> TestResult {
         assert_eq!(schemata.len(), 4);
         let test_schema = schemata
             .iter()
-            .find(|a| a.name().unwrap().to_string() == "RecWithDeps".to_string())
+            .find(|a| a.name().unwrap().to_string() == *"RecWithDeps")
             .unwrap();
 
         assert_eq!(
@@ -2247,7 +2247,7 @@ fn test_independent_canonical_form_usages() -> TestResult {
                 "ns.Rec" => {
                     assert_eq!(s.independent_canonical_form(&schemata), s.canonical_form());
                 }
-                _ => assert!(false),
+                _ => panic!(),
             }
         }
     }

--- a/avro/tests/schema.rs
+++ b/avro/tests/schema.rs
@@ -2089,13 +2089,13 @@ fn test_independent_canonical_form_primitives() -> TestResult {
         ]
     }"#;
 
-
     let independent_schema = Schema::parse_str(record_with_no_dependencies)?;
     let schema_strs = [
         fixed_primitive,
         enum_primitive,
         record_primitive,
-        record_with_dependencies];
+        record_with_dependencies,
+    ];
 
     for schema_str_perm in permutations(&schema_strs) {
         let schema_str_perm: Vec<&str> = schema_str_perm.iter().map(|s| **s).collect();
@@ -2103,7 +2103,8 @@ fn test_independent_canonical_form_primitives() -> TestResult {
         assert_eq!(schemata.len(), 4);
         let test_schema = schemata
             .iter()
-            .find(|a|a.name().unwrap().to_string() == "RecWithDeps".to_string()).unwrap();
+            .find(|a| a.name().unwrap().to_string() == "RecWithDeps".to_string())
+            .unwrap();
 
         assert_eq!(
             independent_schema.independent_canonical_form(&schemata),
@@ -2112,7 +2113,8 @@ fn test_independent_canonical_form_primitives() -> TestResult {
 
         assert_eq!(
             independent_schema.canonical_form(),
-            test_schema.independent_canonical_form(&schemata));
+            test_schema.independent_canonical_form(&schemata)
+        );
     }
     Ok(())
 }
@@ -2210,7 +2212,8 @@ fn test_independent_canonical_form_usages() -> TestResult {
         record_usage,
         array_usage,
         map_usage,
-        union_usage];
+        union_usage,
+    ];
 
     for schema_str_perm in permutations(&schema_strs) {
         let schema_str_perm: Vec<&str> = schema_str_perm.iter().map(|s| **s).collect();
@@ -2222,31 +2225,28 @@ fn test_independent_canonical_form_usages() -> TestResult {
                         s.independent_canonical_form(&schemata),
                         Schema::parse_str(record_usage_independent)?.canonical_form()
                     );
-                },
+                }
                 "ArrayUsage" => {
                     assert_eq!(
                         s.independent_canonical_form(&schemata),
                         Schema::parse_str(array_usage_independent)?.canonical_form()
                     );
-                },
+                }
                 "UnionUsage" => {
                     assert_eq!(
                         s.independent_canonical_form(&schemata),
                         Schema::parse_str(union_usage_independent)?.canonical_form()
                     );
-                },
+                }
                 "MapUsage" => {
                     assert_eq!(
                         s.independent_canonical_form(&schemata),
                         Schema::parse_str(map_usage_independent)?.canonical_form()
                     );
-                },
+                }
                 "ns.Rec" => {
-                    assert_eq!(
-                        s.independent_canonical_form(&schemata),
-                        s.canonical_form()
-                    );
-                },
+                    assert_eq!(s.independent_canonical_form(&schemata), s.canonical_form());
+                }
                 _ => assert!(false),
             }
         }


### PR DESCRIPTION
Added independent_canonical_form, which populates types available in the schemata, so that the given schema can be encoded for PCF without the schemata.

See https://github.com/apache/avro-rs/issues/64
