### PR TITLE
chore: Fix `cargo deny check` by allowing the usage of dtolnay/paste

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -32,6 +32,8 @@ yanked = "warn"
 #
 # e.g. "RUSTSEC-0000-0000",
 ignore = [
+    # We need to use dtolnay/paste even though it is not maintained
+    "RUSTSEC-2024-0436"
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
This crate is used to generate unit tests and there is no known issue using it.