### PR TITLE
Use miniz_oxide - a better DEFLATE backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,24 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy 0.7.35",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,12 +25,6 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anes"
@@ -82,9 +58,9 @@ dependencies = [
  "criterion",
  "digest",
  "hex-literal",
- "libflate",
  "log",
  "md-5",
+ "miniz_oxide",
  "num-bigint",
  "paste",
  "pretty_assertions",
@@ -346,15 +322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,12 +439,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "dary_heap"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
 
 [[package]]
 name = "diff"
@@ -680,16 +641,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,30 +733,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
-name = "libflate"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
-dependencies = [
- "adler32",
- "core2",
- "crc32fast",
- "dary_heap",
- "libflate_lz77",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
-dependencies = [
- "core2",
- "hashbrown",
- "rle-decode-fast",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -1158,12 +1085,6 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
-name = "rle-decode-fast"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rstest"

--- a/avro/Cargo.toml
+++ b/avro/Cargo.toml
@@ -59,7 +59,7 @@ bon = { default-features = false, version = "3.5.1" }
 bzip2 = { version = "0.5.2", optional = true }
 crc32fast = { default-features = false, version = "1.4.2", optional = true }
 digest = { default-features = false, version = "0.10.7", features = ["core-api"] }
-libflate = { default-features = false, version = "2.1.0", features = ["std"] }
+miniz_oxide = "0.8.5"
 log = { workspace = true }
 num-bigint = { default-features = false, version = "0.4.6", features = ["std", "serde"] }
 regex-lite = { default-features = false, version = "0.1.6", features = ["std", "string"] }

--- a/avro/src/codec.rs
+++ b/avro/src/codec.rs
@@ -17,7 +17,6 @@
 
 //! Logic for all supported compression codecs in Avro.
 use crate::{types::Value, AvroResult, Error};
-use miniz_oxide;
 #[allow(unused_imports)] // may be flagged as unused when only DEFLATE is enabled
 use std::io::{Read, Write};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
@@ -62,7 +61,7 @@ impl Codec {
         match self {
             Codec::Null => (),
             Codec::Deflate => {
-                let compressed = miniz_oxide::deflate::compress_to_vec(&stream, 6);
+                let compressed = miniz_oxide::deflate::compress_to_vec(stream, 6);
                 *stream = compressed;
             }
             #[cfg(feature = "snappy")]
@@ -116,7 +115,7 @@ impl Codec {
     pub fn decompress(self, stream: &mut Vec<u8>) -> AvroResult<()> {
         *stream = match self {
             Codec::Null => return Ok(()),
-            Codec::Deflate => miniz_oxide::inflate::decompress_to_vec(&stream).map_err(|e| {
+            Codec::Deflate => miniz_oxide::inflate::decompress_to_vec(stream).map_err(|e| {
                 use miniz_oxide::inflate::TINFLStatus;
                 use std::io::ErrorKind;
                 let err_kind = match e.status {

--- a/avro/src/codec.rs
+++ b/avro/src/codec.rs
@@ -18,6 +18,7 @@
 //! Logic for all supported compression codecs in Avro.
 use crate::{types::Value, AvroResult, Error};
 use miniz_oxide;
+#[allow(unused_imports)] // may be flagged as unused when only DEFLATE is enabled
 use std::io::{Read, Write};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 

--- a/avro/src/error.rs
+++ b/avro/src/error.rs
@@ -378,7 +378,7 @@ pub enum Error {
     DeflateCompress(#[source] std::io::Error),
 
     // no longer possible after migration from libflate to miniz_oxide
-    // TODO: remove in the next semver-breaking release
+    #[deprecated(since = "0.18.0", note = "This error can no longer occur")]
     #[error("Failed to finish flate compressor: {0}")]
     DeflateCompressFinish(#[source] std::io::Error),
 

--- a/avro/src/error.rs
+++ b/avro/src/error.rs
@@ -377,6 +377,8 @@ pub enum Error {
     #[error("Failed to compress with flate: {0}")]
     DeflateCompress(#[source] std::io::Error),
 
+    // no longer possible after migration from libflate to miniz_oxide
+    // TODO: remove in the next semver-breaking release
     #[error("Failed to finish flate compressor: {0}")]
     DeflateCompressFinish(#[source] std::io::Error),
 

--- a/avro/src/error.rs
+++ b/avro/src/error.rs
@@ -378,7 +378,7 @@ pub enum Error {
     DeflateCompress(#[source] std::io::Error),
 
     // no longer possible after migration from libflate to miniz_oxide
-    #[deprecated(since = "0.18.0", note = "This error can no longer occur")]
+    #[deprecated(since = "0.19.0", note = "This error can no longer occur")]
     #[error("Failed to finish flate compressor: {0}")]
     DeflateCompressFinish(#[source] std::io::Error),
 


### PR DESCRIPTION
Switch from [libflate](https://crates.io/crates/libflate) to [miniz_oxide](https://crates.io/crates/miniz_oxide) as the DEFLATE backend.

miniz_oxide is faster and more widely tested. It is the default backend for the de-facto standard [flate2](https://crates.io/crates/flate2) crate, and has 10x the amount of downloads compared to libflate.

I've taken care to preserve the same public API so that this change would be transparent to users.