### PR TITLE
Support different header types

### DIFF
--- a/avro/src/error.rs
+++ b/avro/src/error.rs
@@ -410,7 +410,7 @@ pub enum Error {
     HeaderMagic,
 
     #[error("Message Header mismatch. Expected: {0:?}. Actual: {1:?}")]
-    SingleObjectHeaderMismatch([u8; 10], [u8; 10]),
+    SingleObjectHeaderMismatch(Vec<u8>, Vec<u8>),
 
     #[error("Failed to get JSON from avro.schema key in map")]
     GetAvroSchemaFromMap,

--- a/avro/src/error.rs
+++ b/avro/src/error.rs
@@ -513,6 +513,9 @@ pub enum Error {
 
     #[error("Invalid Avro data! Cannot read codec type from value that is not Value::Bytes.")]
     BadCodecMetadata,
+
+    #[error("Cannot convert a slice to Uuid: {0}")]
+    UuidFromSlice(#[source] uuid::Error),
 }
 
 #[derive(thiserror::Error, PartialEq)]

--- a/avro/src/headers.rs
+++ b/avro/src/headers.rs
@@ -1,0 +1,73 @@
+use uuid::Uuid;
+
+use crate::{rabin::Rabin, schema::SchemaFingerprint, Schema};
+
+pub trait HeaderBuilder {
+    fn build_header(&self) -> Vec<u8>;
+}
+
+pub struct RabinFingerprintHeader {
+    fingerprint: SchemaFingerprint,
+}
+
+impl RabinFingerprintHeader {
+    pub fn create_from_schema(schema: &Schema) -> Self {
+        let fingerprint = schema.fingerprint::<Rabin>();
+        RabinFingerprintHeader { fingerprint }
+    }
+}
+
+impl HeaderBuilder for RabinFingerprintHeader {
+    fn build_header(&self) -> Vec<u8> {
+        vec![
+            0xC3,
+            0x01,
+            self.fingerprint.bytes[0],
+            self.fingerprint.bytes[1],
+            self.fingerprint.bytes[2],
+            self.fingerprint.bytes[3],
+            self.fingerprint.bytes[4],
+            self.fingerprint.bytes[5],
+            self.fingerprint.bytes[6],
+            self.fingerprint.bytes[7],
+        ]
+    }
+}
+
+pub struct GlueSchemaUuidHeader {
+    schema_uuid: Uuid,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum GlueHeaderError {
+    #[error("Message is too short to have a valid Glue header")]
+    MessageTooShort,
+    #[error("Failed to parse a valid UUID from the header: {0}")]
+    InvalidUuid(#[from] uuid::Error),
+}
+
+impl GlueSchemaUuidHeader {
+    pub fn create_from_uuid(schema_uuid: Uuid) -> Self {
+        GlueSchemaUuidHeader { schema_uuid }
+    }
+
+    pub fn parse_from_raw_avro(message_payload: &[u8]) -> Result<Self, GlueHeaderError> {
+        if message_payload.len() < 19 {
+            return Err(GlueHeaderError::MessageTooShort);
+        }
+        let schema_uuid = Uuid::from_slice(&message_payload[2..18])?;
+        Ok(GlueSchemaUuidHeader { schema_uuid })
+    }
+
+    pub fn schema_uuid(&self) -> Uuid {
+        self.schema_uuid
+    }
+}
+
+impl HeaderBuilder for GlueSchemaUuidHeader {
+    fn build_header(&self) -> Vec<u8> {
+        let mut output_vec: Vec<u8> = vec![3, 0];
+        output_vec.extend_from_slice(self.schema_uuid.as_bytes());
+        output_vec
+    }
+}

--- a/avro/src/headers.rs
+++ b/avro/src/headers.rs
@@ -1,6 +1,6 @@
 use uuid::Uuid;
 
-use crate::{rabin::Rabin, schema::SchemaFingerprint, Schema};
+use crate::{rabin::Rabin, schema::SchemaFingerprint, AvroResult, Schema};
 
 pub trait HeaderBuilder {
     fn build_header(&self) -> Vec<u8>;
@@ -38,24 +38,18 @@ pub struct GlueSchemaUuidHeader {
     schema_uuid: Uuid,
 }
 
-#[derive(thiserror::Error, Debug)]
-pub enum GlueHeaderError {
-    #[error("Message is too short to have a valid Glue header")]
-    MessageTooShort,
-    #[error("Failed to parse a valid UUID from the header: {0}")]
-    InvalidUuid(#[from] uuid::Error),
-}
-
 impl GlueSchemaUuidHeader {
     pub fn create_from_uuid(schema_uuid: Uuid) -> Self {
         GlueSchemaUuidHeader { schema_uuid }
     }
 
-    pub fn parse_from_raw_avro(message_payload: &[u8]) -> Result<Self, GlueHeaderError> {
+    pub fn parse_from_raw_avro(message_payload: &[u8]) -> AvroResult<Self> {
         if message_payload.len() < 19 {
-            return Err(GlueHeaderError::MessageTooShort);
+            return Err(crate::error::Error::HeaderMagic);
         }
-        let schema_uuid = Uuid::from_slice(&message_payload[2..18])?;
+        // The only possible error is invalid length, and we just checked the length,
+        // so unwrap is safe
+        let schema_uuid = Uuid::from_slice(&message_payload[2..18]).unwrap();
         Ok(GlueSchemaUuidHeader { schema_uuid })
     }
 
@@ -69,5 +63,72 @@ impl HeaderBuilder for GlueSchemaUuidHeader {
         let mut output_vec: Vec<u8> = vec![3, 0];
         output_vec.extend_from_slice(self.schema_uuid.as_bytes());
         output_vec
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use apache_avro_test_helper::TestResult;
+
+    #[test]
+    fn test_rabin_fingerprint_header() -> TestResult {
+        let schema_str = r#"
+            {
+            "type": "record",
+            "name": "test",
+            "fields": [
+                {
+                "name": "a",
+                "type": "long",
+                "default": 42
+                },
+                {
+                "name": "b",
+                "type": "string"
+                }
+            ]
+            }
+            "#;
+        let schema = Schema::parse_str(schema_str)?;
+        let header_builder = RabinFingerprintHeader::create_from_schema(&schema);
+        let computed_header = header_builder.build_header();
+        let expected_header: Vec<u8> = vec![195, 1, 232, 198, 194, 12, 97, 95, 44, 71];
+        assert_eq!(computed_header, expected_header);
+        Ok(())
+    }
+
+    #[test]
+    fn test_glue_schema_header() -> TestResult {
+        let schema_uuid = Uuid::parse_str("b2f1cf00-0434-013e-439a-125eb8485a5f")?;
+        let header_builder = GlueSchemaUuidHeader::create_from_uuid(schema_uuid);
+        let computed_header = header_builder.build_header();
+        let expected_header: Vec<u8> = vec![
+            3, 0, 178, 241, 207, 0, 4, 52, 1, 62, 67, 154, 18, 94, 184, 72, 90, 95,
+        ];
+        assert_eq!(computed_header, expected_header);
+        Ok(())
+    }
+
+    #[test]
+    fn test_glue_header_parse() -> TestResult {
+        let incoming_message: Vec<u8> = vec![
+            3, 0, 178, 241, 207, 0, 4, 52, 1, 62, 67, 154, 18, 94, 184, 72, 90, 95, 65, 65, 65,
+        ];
+        let header_builder = GlueSchemaUuidHeader::parse_from_raw_avro(&incoming_message)?;
+        let expected_schema_uuid = Uuid::parse_str("b2f1cf00-0434-013e-439a-125eb8485a5f")?;
+        assert_eq!(header_builder.schema_uuid(), expected_schema_uuid);
+        Ok(())
+    }
+
+    #[test]
+    fn test_glue_header_parse_err_on_message_too_short() -> TestResult {
+        let incoming_message: Vec<u8> = vec![3, 0, 178, 241, 207, 0, 4, 52, 1];
+        let header_builder = GlueSchemaUuidHeader::parse_from_raw_avro(&incoming_message);
+        assert!(matches!(
+            header_builder,
+            Err(crate::error::Error::HeaderMagic)
+        ));
+        Ok(())
     }
 }

--- a/avro/src/headers.rs
+++ b/avro/src/headers.rs
@@ -70,6 +70,11 @@ impl GlueSchemaUuidHeader {
     pub fn from_uuid(schema_uuid: Uuid) -> Self {
         GlueSchemaUuidHeader { schema_uuid }
     }
+    
+    /// The minimum length of a Glue header.
+    /// 2 bytes for the special prefix (3, 0) plus
+    /// 16 bytes for the Uuid
+    const GLUE_HEADER_LENGTH: usize = 18;
 
     /// Create an instance of the struct based on parsing the UUID out of the header of a raw
     /// message
@@ -80,7 +85,7 @@ impl GlueSchemaUuidHeader {
     /// schema for the message. You can then use the raw message, the schema, and the struct
     /// instance to read the message.
     pub fn parse_from_raw_avro(message_payload: &[u8]) -> AvroResult<Self> {
-        if message_payload.len() < 18 {
+        if message_payload.len() < Self::GLUE_HEADER_LENGTH {
             return Err(crate::error::Error::HeaderMagic);
         }
         let schema_uuid =

--- a/avro/src/headers.rs
+++ b/avro/src/headers.rs
@@ -11,7 +11,7 @@ pub struct RabinFingerprintHeader {
 }
 
 impl RabinFingerprintHeader {
-    pub fn create_from_schema(schema: &Schema) -> Self {
+    pub fn from_schema(schema: &Schema) -> Self {
         let fingerprint = schema.fingerprint::<Rabin>();
         RabinFingerprintHeader { fingerprint }
     }
@@ -39,7 +39,7 @@ pub struct GlueSchemaUuidHeader {
 }
 
 impl GlueSchemaUuidHeader {
-    pub fn create_from_uuid(schema_uuid: Uuid) -> Self {
+    pub fn from_uuid(schema_uuid: Uuid) -> Self {
         GlueSchemaUuidHeader { schema_uuid }
     }
 
@@ -91,7 +91,7 @@ mod test {
             }
             "#;
         let schema = Schema::parse_str(schema_str)?;
-        let header_builder = RabinFingerprintHeader::create_from_schema(&schema);
+        let header_builder = RabinFingerprintHeader::from_schema(&schema);
         let computed_header = header_builder.build_header();
         let expected_header: Vec<u8> = vec![195, 1, 232, 198, 194, 12, 97, 95, 44, 71];
         assert_eq!(computed_header, expected_header);
@@ -101,7 +101,7 @@ mod test {
     #[test]
     fn test_glue_schema_header() -> TestResult {
         let schema_uuid = Uuid::parse_str("b2f1cf00-0434-013e-439a-125eb8485a5f")?;
-        let header_builder = GlueSchemaUuidHeader::create_from_uuid(schema_uuid);
+        let header_builder = GlueSchemaUuidHeader::from_uuid(schema_uuid);
         let computed_header = header_builder.build_header();
         let expected_header: Vec<u8> = vec![
             3, 0, 178, 241, 207, 0, 4, 52, 1, 62, 67, 154, 18, 94, 184, 72, 90, 95,

--- a/avro/src/headers.rs
+++ b/avro/src/headers.rs
@@ -70,7 +70,7 @@ impl GlueSchemaUuidHeader {
     pub fn from_uuid(schema_uuid: Uuid) -> Self {
         GlueSchemaUuidHeader { schema_uuid }
     }
-    
+
     /// The minimum length of a Glue header.
     /// 2 bytes for the special prefix (3, 0) plus
     /// 16 bytes for the Uuid

--- a/avro/src/headers.rs
+++ b/avro/src/headers.rs
@@ -80,7 +80,7 @@ impl GlueSchemaUuidHeader {
     /// schema for the message. You can then use the raw message, the schema, and the struct
     /// instance to read the message.
     pub fn parse_from_raw_avro(message_payload: &[u8]) -> AvroResult<Self> {
-        if message_payload.len() < 19 {
+        if message_payload.len() < 18 {
             return Err(crate::error::Error::HeaderMagic);
         }
         let schema_uuid =

--- a/avro/src/lib.rs
+++ b/avro/src/lib.rs
@@ -871,6 +871,7 @@ mod ser_schema;
 mod util;
 mod writer;
 
+pub mod headers;
 pub mod rabin;
 pub mod schema;
 pub mod schema_compatibility;

--- a/avro/src/reader.rs
+++ b/avro/src/reader.rs
@@ -512,9 +512,9 @@ impl GenericSingleObjectReader {
         Self::new_with_header_builder(schema, header_builder)
     }
 
-    pub fn new_with_header_builder<H: HeaderBuilder>(
+    pub fn new_with_header_builder<HB: HeaderBuilder>(
         schema: Schema,
-        header_builder: H,
+        header_builder: HB,
     ) -> AvroResult<GenericSingleObjectReader> {
         let expected_header = header_builder.build_header();
         Ok(GenericSingleObjectReader {

--- a/avro/src/reader.rs
+++ b/avro/src/reader.rs
@@ -508,7 +508,7 @@ pub struct GenericSingleObjectReader {
 
 impl GenericSingleObjectReader {
     pub fn new(schema: Schema) -> AvroResult<GenericSingleObjectReader> {
-        let header_builder = RabinFingerprintHeader::create_from_schema(&schema);
+        let header_builder = RabinFingerprintHeader::from_schema(&schema);
         Self::new_with_header_builder(schema, header_builder)
     }
 
@@ -1032,9 +1032,9 @@ mod tests {
     }
 
     #[test]
-    fn test_avro_generic_reader_alternate_header() -> TestResult {
+    fn avro_rs_164_generic_reader_alternate_header() -> TestResult {
         let schema_uuid = Uuid::parse_str("b2f1cf00-0434-013e-439a-125eb8485a5f")?;
-        let header_builder = GlueSchemaUuidHeader::create_from_uuid(schema_uuid);
+        let header_builder = GlueSchemaUuidHeader::from_uuid(schema_uuid);
         let generic_reader = GenericSingleObjectReader::new_with_header_builder(
             TestSingleObjectReader::get_schema(),
             header_builder,

--- a/avro/src/writer.rs
+++ b/avro/src/writer.rs
@@ -488,7 +488,7 @@ impl GenericSingleObjectWriter {
         schema: &Schema,
         initial_buffer_cap: usize,
     ) -> AvroResult<GenericSingleObjectWriter> {
-        let header_builder = RabinFingerprintHeader::create_from_schema(schema);
+        let header_builder = RabinFingerprintHeader::from_schema(schema);
         Self::new_with_capacity_and_header_builder(schema, initial_buffer_cap, header_builder)
     }
 
@@ -1394,7 +1394,7 @@ mod tests {
             c: vec!["cat".into(), "dog".into()],
         };
         let schema_uuid = Uuid::parse_str("b2f1cf00-0434-013e-439a-125eb8485a5f")?;
-        let header_builder = GlueSchemaUuidHeader::create_from_uuid(schema_uuid);
+        let header_builder = GlueSchemaUuidHeader::from_uuid(schema_uuid);
         let mut writer = GenericSingleObjectWriter::new_with_capacity_and_header_builder(
             &TestSingleObjectWriter::get_schema(),
             1024,


### PR DESCRIPTION
Addresses #164 

I didn't get any response when I asked about preferred designs, so I went ahead and created one that seemed reasonable to me.

I created a new Header module with a HeaderBuilder trait, then reimplemented the existing Rabin fingerprint header as a struct impling this trait, and also another one with the Glue schema header type that I used. This design should be sufficiently generic to allow for the future implementation of more header types.

I also added a new method to the GenericSingleObjectReader and GenericSingleObjectWriter to allow the creation of each object type with a HeaderBuilder instance. I then modified the existing creator methods to keep the same signature but call these new methods with the RabinFingerprintHeader struct to maintain the current behavior, and I added a couple of new tests to exercise the functionality.