### PR TITLE
feat: Expose the capability to do headerless avro encoding with serde

### DIFF
--- a/avro/src/lib.rs
+++ b/avro/src/lib.rs
@@ -906,8 +906,8 @@ pub use ser::to_value;
 pub use util::{max_allocation_bytes, set_serde_human_readable};
 pub use uuid::Uuid;
 pub use writer::{
-    to_avro_datum, to_avro_datum_schemata, GenericSingleObjectWriter, SpecificSingleObjectWriter,
-    Writer,
+    to_avro_datum, to_avro_datum_schemata, write_avro_datum_ref, GenericSingleObjectWriter,
+    SpecificSingleObjectWriter, Writer,
 };
 
 #[cfg(feature = "derive")]

--- a/avro/src/writer.rs
+++ b/avro/src/writer.rs
@@ -656,10 +656,10 @@ pub fn to_avro_datum<T: Into<Value>>(schema: &Schema, value: T) -> AvroResult<Ve
     Ok(buffer)
 }
 
-/// Write the referenced `Serialize` object to the provided `Write` object. Returns a result with
-/// the number of bytes written.
+/// Write the referenced [Serialize]able object to the provided [Write] object.
+/// Returns a result with the number of bytes written.
 ///
-/// **NOTE** This function has a quite small niche of usage and does NOT generate headers and sync
+/// **NOTE** This function has a quite small niche of usage and does **NOT** generate headers and sync
 /// markers; use [`append_ser`](struct.Writer.html#method.append_ser) to be fully Avro-compatible
 /// if you don't know what you are doing, instead.
 pub fn write_avro_datum_ref<T: Serialize, W: Write>(
@@ -750,12 +750,6 @@ mod tests {
     }
     "#;
 
-    #[derive(Serialize)]
-    struct TestStruct {
-        a: i64,
-        b: String,
-    }
-
     const UNION_SCHEMA: &str = r#"["null", "long"]"#;
 
     #[test]
@@ -776,7 +770,13 @@ mod tests {
     }
 
     #[test]
-    fn test_write_avro_datum_ref() -> TestResult {
+    fn avro_rs_193_write_avro_datum_ref() -> TestResult {
+        #[derive(Serialize)]
+        struct TestStruct {
+            a: i64,
+            b: String,
+        }
+
         let schema = Schema::parse_str(SCHEMA)?;
         let mut writer: Vec<u8> = Vec::new();
         let data = TestStruct {

--- a/avro/src/writer.rs
+++ b/avro/src/writer.rs
@@ -571,7 +571,7 @@ impl<T> SpecificSingleObjectWriter<T>
 where
     T: AvroSchema + Serialize,
 {
-    /// Write the referenced `Serialize` object to the provided Write object. Returns a result with
+    /// Write the referenced `Serialize` object to the provided `Write` object. Returns a result with
     /// the number of bytes written including the header
     pub fn write_ref<W: Write>(&mut self, data: &T, writer: &mut W) -> AvroResult<usize> {
         let mut bytes_written: usize = 0;
@@ -656,13 +656,17 @@ pub fn to_avro_datum<T: Into<Value>>(schema: &Schema, value: T) -> AvroResult<Ve
     Ok(buffer)
 }
 
-/// Write the referenced `Serialize` object to the provided Write object. Returns a result with
+/// Write the referenced `Serialize` object to the provided `Write` object. Returns a result with
 /// the number of bytes written.
 ///
 /// **NOTE** This function has a quite small niche of usage and does NOT generate headers and sync
-/// markers; use [`Writer`](struct.Writer.html) to be fully Avro-compatible if you don't know what
-/// you are doing, instead.
-pub fn write_avro_datum_ref<T: Serialize, W: Write>(schema: &Schema, data: &T, writer: &mut W) -> AvroResult<usize> {
+/// markers; use [`append_ser`](struct.Writer.html#method.append_ser) to be fully Avro-compatible
+/// if you don't know what you are doing, instead.
+pub fn write_avro_datum_ref<T: Serialize, W: Write>(
+    schema: &Schema,
+    data: &T,
+    writer: &mut W,
+) -> AvroResult<usize> {
     let names: HashMap<Name, &Schema> = HashMap::new();
     let mut serializer = SchemaAwareWriteSerializer::new(writer, schema, &names, None);
     let bytes_written = data.serialize(&mut serializer)?;
@@ -745,6 +749,13 @@ mod tests {
       ]
     }
     "#;
+
+    #[derive(Serialize)]
+    struct TestStruct {
+        a: i64,
+        b: String,
+    }
+
     const UNION_SCHEMA: &str = r#"["null", "long"]"#;
 
     #[test]
@@ -760,6 +771,28 @@ mod tests {
         expected.extend([b'f', b'o', b'o']);
 
         assert_eq!(to_avro_datum(&schema, record)?, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_avro_datum_ref() -> TestResult {
+        let schema = Schema::parse_str(SCHEMA)?;
+        let mut writer: Vec<u8> = Vec::new();
+        let data = TestStruct {
+            a: 27,
+            b: "foo".to_string(),
+        };
+
+        let mut expected = Vec::new();
+        zig_i64(27, &mut expected)?;
+        zig_i64(3, &mut expected)?;
+        expected.extend([b'f', b'o', b'o']);
+
+        let bytes = write_avro_datum_ref(&schema, &data, &mut writer)?;
+
+        assert_eq!(bytes, expected.len());
+        assert_eq!(writer, expected);
 
         Ok(())
     }


### PR DESCRIPTION
My use case is I'm serializing large counts of individual objects to publish to google pubsub in an async setting where the "real" work being done elsewhere is so inexpensive to do that overhead dominates performance concerns.

Basically I want to use avro-rs to serialize with minimal allocation/cloning and I must not have headers or markers in the output.

Specifics you can skip:

> google's pubsub uses a stripped down version of the single record format (v1) - it is without any of the headers or markers, it only wants avro's raw binary encoding. Topics are configured with a the avro schema and the format so they are assumed when trying to publish to that topic.
> 
> The high volume makes it undesirable to construct a SpecificSingleObjectWriter per call as it clones the avro schema.
> The async setting prevents sharing the `SpecificSingleObjectWriter` safely as write_ref mutably borrows self.
> 
> My current workaround is using SyncUnsafeCell to share a mutable reference to a SpecificSingleObjectWriter that has already written a header once is not future proof in the slightest.

I'm not in love with `write_avro_datum_ref` as the name but it was close to the language of `SpecificSingleObjectWriter.write_ref` and `to_avro_datum`. I had `write_avro_datum_ref` take in a writer rather than make a Vec since that seems more sensible for serialization/allows it to be used in SpecificSingleObjectWriter.