### PR TITLE
feat: Accept more inputs for `Schema::parse_(str_with)_list`

### DIFF
--- a/avro/src/schema_compatibility.rs
+++ b/avro/src/schema_compatibility.rs
@@ -1766,7 +1766,7 @@ mod tests {
         "#,
         ];
 
-        let schemas = Schema::parse_list(&schema_strs).unwrap();
+        let schemas = Schema::parse_list(schema_strs).unwrap();
         SchemaCompatibility::can_read(&schemas[1], &schemas[1])?;
 
         Ok(())

--- a/avro/src/types.rs
+++ b/avro/src/types.rs
@@ -2969,7 +2969,7 @@ Field with name '"b"' is not a member of the map items"#,
 
         let avro_value = Value::from(value);
 
-        let schemas = Schema::parse_list(&[main_schema, referenced_schema])?;
+        let schemas = Schema::parse_list([main_schema, referenced_schema])?;
 
         let main_schema = schemas.first().unwrap();
         let schemata: Vec<_> = schemas.iter().skip(1).collect();
@@ -3011,7 +3011,7 @@ Field with name '"b"' is not a member of the map items"#,
 
         let avro_value = Value::from(value);
 
-        let schemata = Schema::parse_list(&[referenced_enum, referenced_record, main_schema])?;
+        let schemata = Schema::parse_list([referenced_enum, referenced_record, main_schema])?;
 
         let main_schema = schemata.last().unwrap();
         let other_schemata: Vec<&Schema> = schemata.iter().take(2).collect();

--- a/avro/tests/schema.rs
+++ b/avro/tests/schema.rs
@@ -187,7 +187,7 @@ fn test_parse_list_without_cross_deps() -> TestResult {
         "size": 16
     }"#;
     let schema_strs = [schema_str_1, schema_str_2];
-    let schemas = Schema::parse_list(&schema_strs)?;
+    let schemas = Schema::parse_list(schema_strs)?;
 
     for schema_str in &schema_strs {
         let parsed = Schema::parse_str(schema_str)?;
@@ -220,8 +220,8 @@ fn test_parse_list_with_cross_deps_basic() -> TestResult {
 
     let schema_strs_first = [schema_a_str, schema_b_str];
     let schema_strs_second = [schema_b_str, schema_a_str];
-    let schemas_first = Schema::parse_list(&schema_strs_first)?;
-    let schemas_second = Schema::parse_list(&schema_strs_second)?;
+    let schemas_first = Schema::parse_list(schema_strs_first)?;
+    let schemas_second = Schema::parse_list(schema_strs_second)?;
 
     assert_eq!(schemas_first[0], schemas_second[1]);
     assert_eq!(schemas_first[1], schemas_second[0]);
@@ -249,8 +249,8 @@ fn test_parse_list_recursive_type() -> TestResult {
     }"#;
     let schema_strs_first = [schema_str_1, schema_str_2];
     let schema_strs_second = [schema_str_2, schema_str_1];
-    let _ = Schema::parse_list(&schema_strs_first)?;
-    let _ = Schema::parse_list(&schema_strs_second)?;
+    let _ = Schema::parse_list(schema_strs_first)?;
+    let _ = Schema::parse_list(schema_strs_second)?;
     Ok(())
 }
 
@@ -274,8 +274,8 @@ fn test_parse_list_with_cross_deps_and_namespaces() -> TestResult {
         ]
     }"#;
 
-    let schemas_first = Schema::parse_list(&[schema_a_str, schema_b_str])?;
-    let schemas_second = Schema::parse_list(&[schema_b_str, schema_a_str])?;
+    let schemas_first = Schema::parse_list([schema_a_str, schema_b_str])?;
+    let schemas_second = Schema::parse_list([schema_b_str, schema_a_str])?;
 
     assert_eq!(schemas_first[0], schemas_second[1]);
     assert_eq!(schemas_first[1], schemas_second[0]);
@@ -305,8 +305,8 @@ fn test_parse_list_with_cross_deps_and_namespaces_error() -> TestResult {
 
     let schema_strs_first = [schema_str_1, schema_str_2];
     let schema_strs_second = [schema_str_2, schema_str_1];
-    let _ = Schema::parse_list(&schema_strs_first).expect_err("Test failed");
-    let _ = Schema::parse_list(&schema_strs_second).expect_err("Test failed");
+    let _ = Schema::parse_list(schema_strs_first).expect_err("Test failed");
+    let _ = Schema::parse_list(schema_strs_second).expect_err("Test failed");
 
     Ok(())
 }
@@ -453,7 +453,7 @@ fn test_parse_list_multiple_dependencies() -> TestResult {
         ]
     }"#;
 
-    let parsed = Schema::parse_list(&[schema_a_str, schema_b_str, schema_c_str])?;
+    let parsed = Schema::parse_list([schema_a_str, schema_b_str, schema_c_str])?;
     let schema_strs = vec![schema_a_str, schema_b_str, schema_c_str];
     for schema_str_perm in permutations(&schema_strs) {
         let schema_str_perm: Vec<&str> = schema_str_perm.iter().map(|s| **s).collect();
@@ -493,7 +493,7 @@ fn test_parse_list_shared_dependency() -> TestResult {
         ]
     }"#;
 
-    let parsed = Schema::parse_list(&[schema_a_str, schema_b_str, schema_c_str])?;
+    let parsed = Schema::parse_list([schema_a_str, schema_b_str, schema_c_str])?;
     let schema_strs = vec![schema_a_str, schema_b_str, schema_c_str];
     for schema_str_perm in permutations(&schema_strs) {
         let schema_str_perm: Vec<&str> = schema_str_perm.iter().map(|s| **s).collect();
@@ -526,7 +526,7 @@ fn test_name_collision_error() -> TestResult {
         ]
     }"#;
 
-    let _ = Schema::parse_list(&[schema_str_1, schema_str_2]).expect_err("Test failed");
+    let _ = Schema::parse_list([schema_str_1, schema_str_2]).expect_err("Test failed");
     Ok(())
 }
 
@@ -550,7 +550,7 @@ fn test_namespace_prevents_collisions() -> TestResult {
         ]
     }"#;
 
-    let parsed = Schema::parse_list(&[schema_str_1, schema_str_2])?;
+    let parsed = Schema::parse_list([schema_str_1, schema_str_2])?;
     let parsed_1 = Schema::parse_str(schema_str_1)?;
     let parsed_2 = Schema::parse_str(schema_str_2)?;
     assert_eq!(parsed, vec!(parsed_1, parsed_2));
@@ -2346,7 +2346,7 @@ fn avro_rs_66_test_independent_canonical_form_missing_ref() -> TestResult {
     }"#;
 
     let schema_strs = [record_primitive, record_usage];
-    let schemata = Schema::parse_list(&schema_strs)?;
+    let schemata = Schema::parse_list(schema_strs)?;
     assert!(matches!(
         schemata[1].independent_canonical_form(&Vec::with_capacity(0)), //NOTE - we're passing in an empty schemata
         Err(Error::SchemaResolutionError(..))

--- a/avro/tests/to_from_avro_datum_schemata.rs
+++ b/avro/tests/to_from_avro_datum_schemata.rs
@@ -46,7 +46,7 @@ fn test_avro_3683_multiple_schemata_to_from_avro_datum() -> TestResult {
         Value::Record(vec![(String::from("field_a"), Value::Float(1.0))]),
     )]);
 
-    let schemata: Vec<Schema> = Schema::parse_list(&[SCHEMA_A_STR, SCHEMA_B_STR])?;
+    let schemata: Vec<Schema> = Schema::parse_list([SCHEMA_A_STR, SCHEMA_B_STR])?;
     let schemata: Vec<&Schema> = schemata.iter().collect();
 
     // this is the Schema we want to use for write/read
@@ -70,7 +70,7 @@ fn avro_rs_106_test_multiple_schemata_to_from_avro_datum_with_resolution() -> Te
         Value::Record(vec![(String::from("field_a"), Value::Float(1.0))]),
     )]);
 
-    let schemata: Vec<Schema> = Schema::parse_list(&[SCHEMA_A_STR, SCHEMA_B_STR])?;
+    let schemata: Vec<Schema> = Schema::parse_list([SCHEMA_A_STR, SCHEMA_B_STR])?;
     let schemata: Vec<&Schema> = schemata.iter().collect();
 
     // this is the Schema we want to use for write/read
@@ -100,7 +100,7 @@ fn test_avro_3683_multiple_schemata_writer_reader() -> TestResult {
         Value::Record(vec![(String::from("field_a"), Value::Float(1.0))]),
     )]);
 
-    let schemata: Vec<Schema> = Schema::parse_list(&[SCHEMA_A_STR, SCHEMA_B_STR])?;
+    let schemata: Vec<Schema> = Schema::parse_list([SCHEMA_A_STR, SCHEMA_B_STR])?;
     let schemata: Vec<&Schema> = schemata.iter().collect();
 
     // this is the Schema we want to use for write/read

--- a/avro/tests/union_schema.rs
+++ b/avro/tests/union_schema.rs
@@ -82,7 +82,7 @@ where
 #[test]
 fn test_avro_3901_union_schema_round_trip_no_null() -> AvroResult<()> {
     let schemata: Vec<Schema> =
-        Schema::parse_list(&[SCHEMA_A_STR, SCHEMA_B_STR, SCHEMA_C_STR]).expect("parsing schemata");
+        Schema::parse_list([SCHEMA_A_STR, SCHEMA_B_STR, SCHEMA_C_STR]).expect("parsing schemata");
 
     let input = C {
         field_union: (UnionAB::A(A { field_a: 45.5 })),
@@ -126,7 +126,7 @@ struct D {
 #[test]
 fn test_avro_3901_union_schema_round_trip_null_at_start() -> AvroResult<()> {
     let schemata: Vec<Schema> =
-        Schema::parse_list(&[SCHEMA_A_STR, SCHEMA_B_STR, SCHEMA_D_STR]).expect("parsing schemata");
+        Schema::parse_list([SCHEMA_A_STR, SCHEMA_B_STR, SCHEMA_D_STR]).expect("parsing schemata");
 
     let input = D {
         field_union: UnionNoneAB::A(A { field_a: 54.25 }),
@@ -177,7 +177,7 @@ struct E {
 #[test]
 fn test_avro_3901_union_schema_round_trip_with_out_of_order_null() -> AvroResult<()> {
     let schemata: Vec<Schema> =
-        Schema::parse_list(&[SCHEMA_A_STR, SCHEMA_B_STR, SCHEMA_E_STR]).expect("parsing schemata");
+        Schema::parse_list([SCHEMA_A_STR, SCHEMA_B_STR, SCHEMA_E_STR]).expect("parsing schemata");
 
     let input = E {
         field_union: UnionANoneB::A(A { field_a: 23.75 }),
@@ -228,7 +228,7 @@ struct F {
 #[test]
 fn test_avro_3901_union_schema_round_trip_with_end_null() -> AvroResult<()> {
     let schemata: Vec<Schema> =
-        Schema::parse_list(&[SCHEMA_A_STR, SCHEMA_B_STR, SCHEMA_F_STR]).expect("parsing schemata");
+        Schema::parse_list([SCHEMA_A_STR, SCHEMA_B_STR, SCHEMA_F_STR]).expect("parsing schemata");
 
     let input = F {
         field_union: UnionABNone::A(A { field_a: 23.75 }),
@@ -318,7 +318,7 @@ struct H {
 
 #[test]
 fn test_avro_3901_union_schema_as_optional() -> AvroResult<()> {
-    let schemata: Vec<Schema> = Schema::parse_list(&[SCHEMA_H_STR]).expect("parsing schemata");
+    let schemata: Vec<Schema> = Schema::parse_list([SCHEMA_H_STR]).expect("parsing schemata");
 
     let input = H {
         field_union: Some(23),


### PR DESCRIPTION
They now accept anything that can iterate over types that can be converted into strings. For example: `Vec<String>`, `&[&str]`, and `files.iter().map(std::fs::read_to_string).filter_map(Result::ok)`.