### PR TITLE
chore: Fix a bunch of new Clippy lints

### DIFF
--- a/avro/examples/specific_single_object.rs
+++ b/avro/examples/specific_single_object.rs
@@ -41,7 +41,7 @@ fn main() -> anyhow::Result<()> {
             );
         }
         Err(err) => {
-            panic!("Error during serialization: {:?}", err);
+            panic!("Error during serialization: {err:?}");
         }
     }
 

--- a/avro/src/encode.rs
+++ b/avro/src/encode.rs
@@ -180,7 +180,7 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
                 encode_long(*idx as i64, &mut *writer)?;
                 encode_internal(item, inner_schema, names, enclosing_namespace, &mut *writer)
             } else {
-                error!("invalid schema type for Union: {:?}", schema);
+                error!("invalid schema type for Union: {schema:?}");
                 Err(Error::EncodeValueAsSchemaError {
                     value_kind: ValueKind::Union,
                     supported_schema: vec![SchemaKind::Union],
@@ -203,7 +203,7 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
                 }
                 writer.write(&[0u8]).map_err(Error::WriteBytes)
             } else {
-                error!("invalid schema type for Array: {:?}", schema);
+                error!("invalid schema type for Array: {schema:?}");
                 Err(Error::EncodeValueAsSchemaError {
                     value_kind: ValueKind::Array,
                     supported_schema: vec![SchemaKind::Array],
@@ -227,7 +227,7 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
                 }
                 writer.write(&[0u8]).map_err(Error::WriteBytes)
             } else {
-                error!("invalid schema type for Map: {:?}", schema);
+                error!("invalid schema type for Map: {schema:?}");
                 Err(Error::EncodeValueAsSchemaError {
                     value_kind: ValueKind::Map,
                     supported_schema: vec![SchemaKind::Map],
@@ -302,7 +302,7 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
                     supported_schema: vec![SchemaKind::Record, SchemaKind::Union],
                 });
             } else {
-                error!("invalid schema type for Record: {:?}", schema);
+                error!("invalid schema type for Record: {schema:?}");
                 return Err(Error::EncodeValueAsSchemaError {
                     value_kind: ValueKind::Record,
                     supported_schema: vec![SchemaKind::Record, SchemaKind::Union],

--- a/avro/src/error.rs
+++ b/avro/src/error.rs
@@ -577,7 +577,7 @@ impl fmt::Debug for Error {
         if let Some(e) = self.source() {
             msg.extend([": ", &e.to_string()]);
         }
-        write!(f, "{}", msg)
+        write!(f, "{msg}")
     }
 }
 
@@ -587,6 +587,6 @@ impl fmt::Debug for CompatibilityError {
         if let Some(e) = self.source() {
             msg.extend([": ", &e.to_string()]);
         }
-        write!(f, "{}", msg)
+        write!(f, "{msg}")
     }
 }

--- a/avro/src/reader.rs
+++ b/avro/src/reader.rs
@@ -97,7 +97,7 @@ impl<'r, R: Read> Block<'r, R> {
                 {
                     // already processed
                 } else if key.starts_with("avro.") {
-                    warn!("Ignoring unknown metadata key: {}", key);
+                    warn!("Ignoring unknown metadata key: {key}");
                 } else {
                     self.read_user_metadata(key, value);
                 }
@@ -241,10 +241,7 @@ impl<'r, R: Read> Block<'r, R> {
                 self.user_metadata.insert(key, vec.clone());
             }
             wrong => {
-                warn!(
-                    "User metadata values must be Value::Bytes, found {:?}",
-                    wrong
-                );
+                warn!("User metadata values must be Value::Bytes, found {wrong:?}");
             }
         }
     }

--- a/avro/src/schema.rs
+++ b/avro/src/schema.rs
@@ -1532,8 +1532,7 @@ impl Parser {
                 convert(schema)
             } else {
                 warn!(
-                    "Ignoring unknown logical type '{}' for schema of type: {:?}!",
-                    logical_type, schema
+                    "Ignoring unknown logical type '{logical_type}' for schema of type: {schema:?}!"
                 );
                 Ok(schema)
             }
@@ -1554,7 +1553,7 @@ impl Parser {
                                     inner: Box::new(inner),
                                 })),
                                 Err(err) => {
-                                    warn!("Ignoring invalid decimal logical type: {}", err);
+                                    warn!("Ignoring invalid decimal logical type: {err}");
                                     Ok(inner)
                                 }
                             }
@@ -1578,14 +1577,11 @@ impl Parser {
                             Schema::String => Ok(Schema::Uuid),
                             Schema::Fixed(FixedSchema { size: 16, .. }) => Ok(Schema::Uuid),
                             Schema::Fixed(FixedSchema { size, .. }) => {
-                                warn!("Ignoring uuid logical type for a Fixed schema because its size ({size:?}) is not 16! Schema: {:?}", schema);
+                                warn!("Ignoring uuid logical type for a Fixed schema because its size ({size:?}) is not 16! Schema: {schema:?}");
                                 Ok(schema)
                             }
                             _ => {
-                                warn!(
-                                    "Ignoring invalid uuid logical type for schema: {:?}",
-                                    schema
-                                );
+                                warn!("Ignoring invalid uuid logical type for schema: {schema:?}");
                                 Ok(schema)
                             }
                         },
@@ -5385,8 +5381,7 @@ mod tests {
         let parse_result = Schema::parse(&schema);
         assert!(
             parse_result.is_ok(),
-            "parse result must be ok, got: {:?}",
-            parse_result
+            "parse result must be ok, got: {parse_result:?}"
         );
 
         Ok(())
@@ -5633,8 +5628,7 @@ mod tests {
         let parse_result = Schema::parse(&schema);
         assert!(
             parse_result.is_ok(),
-            "parse result must be ok, got: {:?}",
-            parse_result
+            "parse result must be ok, got: {parse_result:?}"
         );
         match parse_result? {
             Schema::BigDecimal => (),
@@ -6380,7 +6374,7 @@ mod tests {
         let expected = vec![Alias::new("ns1.r1")?, Alias::new("ns2.r2")?];
         match schema.aliases() {
             Some(aliases) => assert_eq!(aliases, &expected),
-            None => panic!("Expected Some({:?}), got None", expected),
+            None => panic!("Expected Some({expected:?}), got None"),
         }
 
         let schema_str = r#"
@@ -6414,7 +6408,7 @@ mod tests {
         let expected = vec![Alias::new("ns1.en1")?, Alias::new("ns2.en2")?];
         match schema.aliases() {
             Some(aliases) => assert_eq!(aliases, &expected),
-            None => panic!("Expected Some({:?}), got None", expected),
+            None => panic!("Expected Some({expected:?}), got None"),
         }
 
         let schema_str = r#"
@@ -6445,7 +6439,7 @@ mod tests {
         let expected = vec![Alias::new("ns1.fx1")?, Alias::new("ns2.fx2")?];
         match schema.aliases() {
             Some(aliases) => assert_eq!(aliases, &expected),
-            None => panic!("Expected Some({:?}), got None", expected),
+            None => panic!("Expected Some({expected:?}), got None"),
         }
 
         let schema_str = r#"
@@ -6490,7 +6484,7 @@ mod tests {
         let expected = "Record Document";
         match schema.doc() {
             Some(doc) => assert_eq!(doc, expected),
-            None => panic!("Expected Some({:?}), got None", expected),
+            None => panic!("Expected Some({expected:?}), got None"),
         }
 
         let schema_str = r#"
@@ -6522,7 +6516,7 @@ mod tests {
         let expected = "Enum Document";
         match schema.doc() {
             Some(doc) => assert_eq!(doc, expected),
-            None => panic!("Expected Some({:?}), got None", expected),
+            None => panic!("Expected Some({expected:?}), got None"),
         }
 
         let schema_str = r#"
@@ -6551,7 +6545,7 @@ mod tests {
         let expected = "Fixed Document";
         match schema.doc() {
             Some(doc) => assert_eq!(doc, expected),
-            None => panic!("Expected Some({:?}), got None", expected),
+            None => panic!("Expected Some({expected:?}), got None"),
         }
 
         let schema_str = r#"
@@ -6858,7 +6852,7 @@ mod tests {
                 let scale = attrs
                     .get("scale")
                     .expect("The 'scale' attribute is missing");
-                assert_logged(&format!("Ignoring invalid decimal logical type: The decimal precision ({}) must be bigger or equal to the scale ({})", precision, scale));
+                assert_logged(&format!("Ignoring invalid decimal logical type: The decimal precision ({precision}) must be bigger or equal to the scale ({scale})"));
             }
             _ => unreachable!("Expected Schema::Fixed, got {:?}", schema),
         }

--- a/avro/src/schema_compatibility.rs
+++ b/avro/src/schema_compatibility.rs
@@ -42,8 +42,8 @@ fn match_ref_schemas(
             }
         }
         _ => Err(CompatibilityError::WrongType {
-            writer_schema_type: format!("{:#?}", writers_schema),
-            reader_schema_type: format!("{:#?}", readers_schema),
+            writer_schema_type: format!("{writers_schema:#?}"),
+            reader_schema_type: format!("{readers_schema:#?}"),
         }),
     }
 }
@@ -109,8 +109,8 @@ impl Checker {
                     match readers_schema {
                         Schema::Map(r_m) => self.full_match_schemas(&w_m.types, &r_m.types),
                         _ => Err(CompatibilityError::WrongType {
-                            writer_schema_type: format!("{:#?}", writers_schema),
-                            reader_schema_type: format!("{:#?}", readers_schema),
+                            writer_schema_type: format!("{writers_schema:#?}"),
+                            reader_schema_type: format!("{readers_schema:#?}"),
                         }),
                     }
                 } else {
@@ -125,8 +125,8 @@ impl Checker {
                     match readers_schema {
                         Schema::Array(r_a) => self.full_match_schemas(&w_a.items, &r_a.items),
                         _ => Err(CompatibilityError::WrongType {
-                            writer_schema_type: format!("{:#?}", writers_schema),
-                            reader_schema_type: format!("{:#?}", readers_schema),
+                            writer_schema_type: format!("{writers_schema:#?}"),
+                            reader_schema_type: format!("{readers_schema:#?}"),
                         }),
                     }
                 } else {
@@ -318,7 +318,7 @@ impl SchemaCompatibility {
             allowed_reader_types: Vec<SchemaKind>,
             writer_type: SchemaKind,
         ) -> Result<(), CompatibilityError> {
-            if allowed_reader_types.iter().any(|&t| t == reader_type) {
+            if allowed_reader_types.contains(&reader_type) {
                 Ok(())
             } else {
                 let mut allowed_types: Vec<SchemaKind> = vec![writer_type];
@@ -374,7 +374,7 @@ impl SchemaCompatibility {
 
             match r_type {
                 SchemaKind::Record | SchemaKind::Enum => {
-                    let msg = format!("A {} type must always has a name", readers_schema);
+                    let msg = format!("A {readers_schema} type must always has a name");
                     let writers_name = writers_schema.name().expect(&msg);
                     let readers_name = readers_schema.name().expect(&msg);
 

--- a/avro/src/schema_equality.rs
+++ b/avro/src/schema_equality.rs
@@ -205,8 +205,7 @@ impl SchemataEq for StructFieldEq {
         error!(
             "This is a bug in schema_equality.rs! The following schemata types are not checked! \
             Please report it to the Avro library maintainers! \
-            \n{:?}\n\n{:?}",
-            schema_one, schema_two
+            \n{schema_one:?}\n\n{schema_two:?}"
         );
         false
     }
@@ -234,10 +233,7 @@ static SCHEMATA_COMPARATOR_ONCE: OnceLock<Box<dyn SchemataEq>> = OnceLock::new()
 pub fn set_schemata_equality_comparator(
     comparator: Box<dyn SchemataEq>,
 ) -> Result<(), Box<dyn SchemataEq>> {
-    debug!(
-        "Setting a custom schemata equality comparator: {:?}.",
-        comparator
-    );
+    debug!("Setting a custom schemata equality comparator: {comparator:?}.");
     SCHEMATA_COMPARATOR_ONCE.set(comparator)
 }
 

--- a/avro/src/ser_schema.rs
+++ b/avro/src/ser_schema.rs
@@ -963,7 +963,7 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
             use std::fmt::Write;
             let mut v_str = String::with_capacity(value.len());
             for b in value {
-                if write!(&mut v_str, "{:x}", b).is_err() {
+                if write!(&mut v_str, "{b:x}").is_err() {
                     v_str.push_str("??");
                 }
             }
@@ -1118,8 +1118,7 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
             Schema::Record(sch) => match sch.fields.len() {
                 0 => Ok(0),
                 too_many => Err(create_error(format!(
-                    "Too many fields: {}. Expected: 0",
-                    too_many
+                    "Too many fields: {too_many}. Expected: 0"
                 ))),
             },
             Schema::Null => Ok(0),
@@ -1196,8 +1195,7 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
                 self.serialize_unit_variant_with_schema(name, variant_index, variant, ref_schema)
             }
             unsupported => Err(create_error(format!(
-                "Unsupported schema: {:?}. Expected: Enum, Union or Ref",
-                unsupported
+                "Unsupported schema: {unsupported:?}. Expected: Enum, Union or Ref"
             ))),
         }
     }
@@ -1438,7 +1436,7 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
     ) -> Result<SchemaAwareWriteSerializeMap<'a, 's, W>, Error> {
         let create_error = |cause: String| {
             let len_str = len
-                .map(|l| format!("{}", l))
+                .map(|l| format!("{l}"))
                 .unwrap_or_else(|| String::from("?"));
 
             Error::SerializeValueWithSchema {
@@ -2600,8 +2598,7 @@ mod tests {
                     assert_eq!(
                         value,
                         format!(
-                            "10000. Cause: Expected: Timestamp{}. Got: Double",
-                            capital_precision
+                            "10000. Cause: Expected: Timestamp{capital_precision}. Got: Double"
                         )
                     );
                     assert_eq!(schema, schema);

--- a/avro/src/types.rs
+++ b/avro/src/types.rs
@@ -390,14 +390,12 @@ impl Value {
 
             match self.validate_internal(schema, rs.get_names(), &enclosing_namespace) {
                 Some(reason) => {
-                    let log_message = format!(
-                        "Invalid value: {:?} for schema: {:?}. Reason: {}",
-                        self, schema, reason
-                    );
+                    let log_message =
+                        format!("Invalid value: {self:?} for schema: {schema:?}. Reason: {reason}");
                     if schemata_len == 1 {
-                        error!("{}", log_message);
+                        error!("{log_message}");
                     } else {
-                        debug!("{}", log_message);
+                        debug!("{log_message}");
                     };
                     false
                 }
@@ -623,8 +621,7 @@ impl Value {
                 })
             }
             (v, s) => Some(format!(
-                "Unsupported value-schema combination! Value: {:?}, schema: {:?}",
-                v, s
+                "Unsupported value-schema combination! Value: {v:?}, schema: {s:?}"
             )),
         }
     }
@@ -678,10 +675,10 @@ impl Value {
                 let name = name.fully_qualified_name(enclosing_namespace);
 
                 if let Some(resolved) = names.get(&name) {
-                    debug!("Resolved {:?}", name);
+                    debug!("Resolved {name:?}");
                     self.resolve_internal(resolved.borrow(), names, &name.namespace, field_default)
                 } else {
-                    error!("Failed to resolve schema {:?}", name);
+                    error!("Failed to resolve schema {name:?}");
                     Err(Error::SchemaResolutionError(name.clone()))
                 }
             }
@@ -2978,15 +2975,13 @@ Field with name '"b"' is not a member of the map items"#,
 
         assert!(
             resolve_result.is_ok(),
-            "result of resolving with schemata should be ok, got: {:?}",
-            resolve_result
+            "result of resolving with schemata should be ok, got: {resolve_result:?}"
         );
 
         let resolve_result = avro_value.resolve(main_schema);
         assert!(
             resolve_result.is_err(),
-            "result of resolving without schemata should be err, got: {:?}",
-            resolve_result
+            "result of resolving without schemata should be err, got: {resolve_result:?}"
         );
 
         Ok(())
@@ -3020,8 +3015,7 @@ Field with name '"b"' is not a member of the map items"#,
 
         assert!(
             resolve_result.is_ok(),
-            "result of resolving with schemata should be ok, got: {:?}",
-            resolve_result
+            "result of resolving with schemata should be ok, got: {resolve_result:?}"
         );
 
         assert!(

--- a/avro/src/writer.rs
+++ b/avro/src/writer.rs
@@ -1553,7 +1553,7 @@ mod tests {
         let mut writer = Writer::new(&schema, Vec::new());
 
         match writer.append_ser(conf) {
-            Ok(bytes) => panic!("Expected an error, but got {} bytes written", bytes),
+            Ok(bytes) => panic!("Expected an error, but got {bytes} bytes written"),
             Err(e) => {
                 assert_eq!(
                     e.to_string(),


### PR DESCRIPTION
This fixes two lints:
 - `clippy::uninlined_format_args`: which will be moved from `pedantic` to `style` in the next Rust version.
 - `clippy::manual_contains`: which will be added in the next Rust version.
 
 This does not change the MSRV of 1.74.