### PR TITLE
fix: flush Writer on drop

### DIFF
--- a/avro/tests/to_from_avro_datum_schemata.rs
+++ b/avro/tests/to_from_avro_datum_schemata.rs
@@ -110,10 +110,10 @@ fn test_avro_3683_multiple_schemata_writer_reader() -> TestResult {
     let mut writer = Writer::with_schemata(schema_b, schemata.clone(), &mut output, Codec::Null);
     writer.append(record.clone())?;
     writer.flush()?;
-    drop(writer); // Ensure the writer is dropped to finalize the output
+    drop(writer); //drop the writer so that `output` is no more referenced mutably
 
     let reader = Reader::with_schemata(schema_b, schemata, output.as_slice())?;
-    let value = reader.into_iter().next().unwrap().unwrap();
+    let value = reader.into_iter().next().unwrap()?;
     assert_eq!(value, record);
 
     Ok(())

--- a/avro/tests/to_from_avro_datum_schemata.rs
+++ b/avro/tests/to_from_avro_datum_schemata.rs
@@ -110,7 +110,7 @@ fn test_avro_3683_multiple_schemata_writer_reader() -> TestResult {
     let mut writer = Writer::with_schemata(schema_b, schemata.clone(), &mut output, Codec::Null);
     writer.append(record.clone())?;
     writer.flush()?;
-    let _ = writer.into_inner()?;
+    drop(writer); // Ensure the writer is dropped to finalize the output
 
     let reader = Reader::with_schemata(schema_b, schemata, output.as_slice())?;
     let value = reader.into_iter().next().unwrap().unwrap();

--- a/avro/tests/to_from_avro_datum_schemata.rs
+++ b/avro/tests/to_from_avro_datum_schemata.rs
@@ -110,6 +110,7 @@ fn test_avro_3683_multiple_schemata_writer_reader() -> TestResult {
     let mut writer = Writer::with_schemata(schema_b, schemata.clone(), &mut output, Codec::Null);
     writer.append(record.clone())?;
     writer.flush()?;
+    let _ = writer.into_inner()?;
 
     let reader = Reader::with_schemata(schema_b, schemata, output.as_slice())?;
     let value = reader.into_iter().next().unwrap().unwrap();

--- a/avro/tests/union_schema.rs
+++ b/avro/tests/union_schema.rs
@@ -74,7 +74,7 @@ where
         Writer::with_schemata(schema, schemata.iter().collect(), &mut encoded, Codec::Null);
     writer.append_ser(input)?;
     writer.flush()?;
-    drop(writer); // Ensure the writer is dropped to finalize the output
+    drop(writer); //drop the writer so that `encoded` is no more referenced mutably
 
     let mut reader = Reader::with_schemata(schema, schemata.iter().collect(), encoded.as_slice())?;
     from_value::<T>(&reader.next().expect("")?)

--- a/avro/tests/union_schema.rs
+++ b/avro/tests/union_schema.rs
@@ -74,7 +74,7 @@ where
         Writer::with_schemata(schema, schemata.iter().collect(), &mut encoded, Codec::Null);
     writer.append_ser(input)?;
     writer.flush()?;
-    let _ = writer.into_inner()?;
+    drop(writer); // Ensure the writer is dropped to finalize the output
 
     let mut reader = Reader::with_schemata(schema, schemata.iter().collect(), encoded.as_slice())?;
     from_value::<T>(&reader.next().expect("")?)

--- a/avro/tests/union_schema.rs
+++ b/avro/tests/union_schema.rs
@@ -74,6 +74,7 @@ where
         Writer::with_schemata(schema, schemata.iter().collect(), &mut encoded, Codec::Null);
     writer.append_ser(input)?;
     writer.flush()?;
+    let _ = writer.into_inner()?;
 
     let mut reader = Reader::with_schemata(schema, schemata.iter().collect(), encoded.as_slice())?;
     from_value::<T>(&reader.next().expect("")?)


### PR DESCRIPTION
This brings the writer in line with standard library types like `BufWriter` and `LineWriter`.

This is a breaking change when the inner writer is `&mut W` and used later in the scope without dropping the writer or calling `into_inner` (as seen in the fixed tests).