### PR TITLE
chore: Fix the build with latest nightly compiler (06.06.2025)

### DIFF
--- a/avro/examples/generate_interop_data.rs
+++ b/avro/examples/generate_interop_data.rs
@@ -27,7 +27,7 @@ use std::{
 };
 use strum::IntoEnumIterator;
 
-fn create_datum(schema: &Schema) -> Record {
+fn create_datum(schema: &Schema) -> Record<'_> {
     let mut datum = Record::new(schema).unwrap();
     datum.put("intField", 12_i32);
     datum.put("longField", 15234324_i64);

--- a/avro/src/types.rs
+++ b/avro/src/types.rs
@@ -235,7 +235,7 @@ impl Record<'_> {
     /// Create a `Record` given a `Schema`.
     ///
     /// If the `Schema` is not a `Schema::Record` variant, `None` will be returned.
-    pub fn new(schema: &Schema) -> Option<Record> {
+    pub fn new(schema: &Schema) -> Option<Record<'_>> {
         match *schema {
             Schema::Record(RecordSchema {
                 fields: ref schema_fields,

--- a/avro/tests/append_to_existing.rs
+++ b/avro/tests/append_to_existing.rs
@@ -90,7 +90,7 @@ fn get_avro_bytes(schema: &Schema) -> Vec<u8> {
 }
 
 /// Creates a new datum to write
-fn create_datum(schema: &Schema, value: i32) -> Record {
+fn create_datum(schema: &Schema, value: i32) -> Record<'_> {
     let mut datum = Record::new(schema).unwrap();
     datum.put("a", value);
     datum


### PR DESCRIPTION
Error:
```
error: lifetime flowing from input to output with different syntax can be confusing
   --> avro/src/types.rs:238:24
    |
238 |     pub fn new(schema: &Schema) -> Option<Record> {
    |                        ^^^^^^^            ------ the lifetime gets resolved as `'_`
    |                        |
    |                        this lifetime flows to the output
    |
    = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
238 |     pub fn new(schema: &Schema) -> Option<Record<'_>> {
    |                                                 ++++
```