### PR TITLE
feat: Add support for rename_all in AvroSchema macro

### DIFF
--- a/avro_derive/src/case.rs
+++ b/avro_derive/src/case.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 //! Code to convert the Rust-styled field/variant (e.g. `my_field`, `MyType`) to the
 //! case of the source (e.g. `my-field`, `MY_FIELD`).
 //! Code copied from serde https://github.com/serde-rs/serde/blob/master/serde_derive/src/internals/case.rs

--- a/avro_derive/src/case.rs
+++ b/avro_derive/src/case.rs
@@ -17,7 +17,7 @@
 
 //! Code to convert the Rust-styled field/variant (e.g. `my_field`, `MyType`) to the
 //! case of the source (e.g. `my-field`, `MY_FIELD`).
-//! Code copied from serde https://github.com/serde-rs/serde/blob/master/serde_derive/src/internals/case.rs
+//! Code copied from serde <https://github.com/serde-rs/serde/blob/master/serde_derive/src/internals/case.rs>
 use self::RenameRule::*;
 use std::fmt::{self, Debug, Display};
 

--- a/avro_derive/src/case.rs
+++ b/avro_derive/src/case.rs
@@ -1,0 +1,192 @@
+//! Code to convert the Rust-styled field/variant (e.g. `my_field`, `MyType`) to the
+//! case of the source (e.g. `my-field`, `MY_FIELD`).
+//! Code copied from serde https://github.com/serde-rs/serde/blob/master/serde_derive/src/internals/case.rs
+use self::RenameRule::*;
+use std::fmt::{self, Debug, Display};
+
+/// The different possible ways to change case of fields in a struct, or variants in an enum.
+#[derive(Copy, Clone, PartialEq)]
+pub enum RenameRule {
+    /// Don't apply a default rename rule.
+    None,
+    /// Rename direct children to "lowercase" style.
+    LowerCase,
+    /// Rename direct children to "UPPERCASE" style.
+    UpperCase,
+    /// Rename direct children to "PascalCase" style, as typically used for
+    /// enum variants.
+    PascalCase,
+    /// Rename direct children to "camelCase" style.
+    CamelCase,
+    /// Rename direct children to "snake_case" style, as commonly used for
+    /// fields.
+    SnakeCase,
+    /// Rename direct children to "SCREAMING_SNAKE_CASE" style, as commonly
+    /// used for constants.
+    ScreamingSnakeCase,
+    /// Rename direct children to "kebab-case" style.
+    KebabCase,
+    /// Rename direct children to "SCREAMING-KEBAB-CASE" style.
+    ScreamingKebabCase,
+}
+
+static RENAME_RULES: &[(&str, RenameRule)] = &[
+    ("lowercase", LowerCase),
+    ("UPPERCASE", UpperCase),
+    ("PascalCase", PascalCase),
+    ("camelCase", CamelCase),
+    ("snake_case", SnakeCase),
+    ("SCREAMING_SNAKE_CASE", ScreamingSnakeCase),
+    ("kebab-case", KebabCase),
+    ("SCREAMING-KEBAB-CASE", ScreamingKebabCase),
+];
+
+impl RenameRule {
+    pub fn from_str(rename_all_str: &str) -> Result<Self, ParseError<'_>> {
+        for (name, rule) in RENAME_RULES {
+            if rename_all_str == *name {
+                return Ok(*rule);
+            }
+        }
+        Err(ParseError {
+            unknown: rename_all_str,
+        })
+    }
+
+    /// Apply a renaming rule to an enum variant, returning the version expected in the source.
+    pub fn apply_to_variant(self, variant: &str) -> String {
+        match self {
+            None | PascalCase => variant.to_owned(),
+            LowerCase => variant.to_ascii_lowercase(),
+            UpperCase => variant.to_ascii_uppercase(),
+            CamelCase => variant[..1].to_ascii_lowercase() + &variant[1..],
+            SnakeCase => {
+                let mut snake = String::new();
+                for (i, ch) in variant.char_indices() {
+                    if i > 0 && ch.is_uppercase() {
+                        snake.push('_');
+                    }
+                    snake.push(ch.to_ascii_lowercase());
+                }
+                snake
+            }
+            ScreamingSnakeCase => SnakeCase.apply_to_variant(variant).to_ascii_uppercase(),
+            KebabCase => SnakeCase.apply_to_variant(variant).replace('_', "-"),
+            ScreamingKebabCase => ScreamingSnakeCase
+                .apply_to_variant(variant)
+                .replace('_', "-"),
+        }
+    }
+
+    /// Apply a renaming rule to a struct field, returning the version expected in the source.
+    pub fn apply_to_field(self, field: &str) -> String {
+        match self {
+            None | LowerCase | SnakeCase => field.to_owned(),
+            UpperCase => field.to_ascii_uppercase(),
+            PascalCase => {
+                let mut pascal = String::new();
+                let mut capitalize = true;
+                for ch in field.chars() {
+                    if ch == '_' {
+                        capitalize = true;
+                    } else if capitalize {
+                        pascal.push(ch.to_ascii_uppercase());
+                        capitalize = false;
+                    } else {
+                        pascal.push(ch);
+                    }
+                }
+                pascal
+            }
+            CamelCase => {
+                let pascal = PascalCase.apply_to_field(field);
+                pascal[..1].to_ascii_lowercase() + &pascal[1..]
+            }
+            ScreamingSnakeCase => field.to_ascii_uppercase(),
+            KebabCase => field.replace('_', "-"),
+            ScreamingKebabCase => ScreamingSnakeCase.apply_to_field(field).replace('_', "-"),
+        }
+    }
+}
+
+pub struct ParseError<'a> {
+    unknown: &'a str,
+}
+
+impl<'a> Display for ParseError<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("unknown rename rule `rename_all = ")?;
+        Debug::fmt(self.unknown, f)?;
+        f.write_str("`, expected one of ")?;
+        for (i, (name, _rule)) in RENAME_RULES.iter().enumerate() {
+            if i > 0 {
+                f.write_str(", ")?;
+            }
+            Debug::fmt(name, f)?;
+        }
+        Ok(())
+    }
+}
+
+#[test]
+fn rename_variants() {
+    for &(original, lower, upper, camel, snake, screaming, kebab, screaming_kebab) in &[
+        (
+            "Outcome", "outcome", "OUTCOME", "outcome", "outcome", "OUTCOME", "outcome", "OUTCOME",
+        ),
+        (
+            "VeryTasty",
+            "verytasty",
+            "VERYTASTY",
+            "veryTasty",
+            "very_tasty",
+            "VERY_TASTY",
+            "very-tasty",
+            "VERY-TASTY",
+        ),
+        ("A", "a", "A", "a", "a", "A", "a", "A"),
+        ("Z42", "z42", "Z42", "z42", "z42", "Z42", "z42", "Z42"),
+    ] {
+        assert_eq!(None.apply_to_variant(original), original);
+        assert_eq!(LowerCase.apply_to_variant(original), lower);
+        assert_eq!(UpperCase.apply_to_variant(original), upper);
+        assert_eq!(PascalCase.apply_to_variant(original), original);
+        assert_eq!(CamelCase.apply_to_variant(original), camel);
+        assert_eq!(SnakeCase.apply_to_variant(original), snake);
+        assert_eq!(ScreamingSnakeCase.apply_to_variant(original), screaming);
+        assert_eq!(KebabCase.apply_to_variant(original), kebab);
+        assert_eq!(
+            ScreamingKebabCase.apply_to_variant(original),
+            screaming_kebab
+        );
+    }
+}
+
+#[test]
+fn rename_fields() {
+    for &(original, upper, pascal, camel, screaming, kebab, screaming_kebab) in &[
+        (
+            "outcome", "OUTCOME", "Outcome", "outcome", "OUTCOME", "outcome", "OUTCOME",
+        ),
+        (
+            "very_tasty",
+            "VERY_TASTY",
+            "VeryTasty",
+            "veryTasty",
+            "VERY_TASTY",
+            "very-tasty",
+            "VERY-TASTY",
+        ),
+        ("a", "A", "A", "a", "A", "a", "A"),
+        ("z42", "Z42", "Z42", "z42", "Z42", "z42", "Z42"),
+    ] {
+        assert_eq!(None.apply_to_field(original), original);
+        assert_eq!(UpperCase.apply_to_field(original), upper);
+        assert_eq!(PascalCase.apply_to_field(original), pascal);
+        assert_eq!(CamelCase.apply_to_field(original), camel);
+        assert_eq!(SnakeCase.apply_to_field(original), original);
+        assert_eq!(ScreamingSnakeCase.apply_to_field(original), screaming);
+        assert_eq!(KebabCase.apply_to_field(original), kebab);
+        assert_eq!(ScreamingKebabCase.apply_to_field(original), screaming_kebab);
+    }
+}

--- a/avro_derive/src/lib.rs
+++ b/avro_derive/src/lib.rs
@@ -710,7 +710,7 @@ mod tests {
     }
 
     #[test]
-    fn test_avro_3709_record_attributes() {
+    fn test_avro_rs_207_rename_all_attribute() {
         let test_struct = quote! {
             #[avro(rename_all="SCREAMING_SNAKE_CASE")]
             struct A {


### PR DESCRIPTION
Supports the same settings as serde. 

Because we need to have the same behavior as serde, the case conversion code was copied from serde crate. 