### PR TITLE
Fixes #219: Use `serde` as a feature for bigdecimal decimal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/avro/Cargo.toml
+++ b/avro/Cargo.toml
@@ -54,7 +54,7 @@ name = "single"
 
 [dependencies]
 apache-avro-derive = { default-features = false, version = "0.19.0", path = "../avro_derive", optional = true }
-bigdecimal = { default-features = false, version = "0.4.8", features = ["std", "serde-json"] }
+bigdecimal = { default-features = false, version = "0.4.8", features = ["std", "serde"] }
 bon = { default-features = false, version = "3.6.4" }
 bzip2 = { version = "0.6.0", optional = true }
 crc32fast = { default-features = false, version = "1.4.2", optional = true }

--- a/avro/tests/avro-rs-219.rs
+++ b/avro/tests/avro-rs-219.rs
@@ -1,0 +1,26 @@
+use serde::Deserialize;
+
+#[test]
+fn avro_rs_219_failing_deserialization_due_to_bigdecimal_dependency() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct S3 {
+        f1: Option<f64>,
+
+        #[serde(flatten)]
+        inner: Inner,
+    }
+
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Inner {
+        f2: f64,
+    }
+
+    let test = r#"{
+      "f1": 0.3,
+      "f2": 3.76
+    }"#;
+
+    let result = serde_json::from_str::<S3>(test);
+    println!("result : {result:#?}");
+    result.unwrap();
+}


### PR DESCRIPTION
See https://github.com/akubera/bigdecimal-rs/issues/151