### PR TITLE
Draft: feat: Shrink `Error` type by `Box`ing large types

### DIFF
--- a/avro/src/de.rs
+++ b/avro/src/de.rs
@@ -277,7 +277,7 @@ impl<'de> de::VariantAccess<'de> for UnionDeserializer<'de> {
     fn unit_variant(self) -> Result<(), Self::Error> {
         match self.value {
             Value::Null => Ok(()),
-            _ => Err(Error::GetNull(self.value.clone())),
+            _ => Err(Error::GetNull(Box::new(self.value.clone()))),
         }
     }
 

--- a/avro/src/encode.rs
+++ b/avro/src/encode.rs
@@ -67,7 +67,7 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
         let fully_qualified_name = name.fully_qualified_name(enclosing_namespace);
         let resolved = names
             .get(&fully_qualified_name)
-            .ok_or(Error::SchemaResolutionError(fully_qualified_name))?;
+            .ok_or(Error::SchemaResolutionError(Box::new(fully_qualified_name)))?;
         return encode_internal(value, resolved.borrow(), names, enclosing_namespace, writer);
     }
 
@@ -269,8 +269,8 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
                         )?;
                     } else {
                         return Err(Error::NoEntryInLookupTable(
-                            name.clone(),
-                            format!("{lookup:?}"),
+                            Box::new(name.clone()),
+                            Box::new(format!("{lookup:?}")),
                         ));
                     }
                 }

--- a/avro/src/error.rs
+++ b/avro/src/error.rs
@@ -30,13 +30,13 @@ pub enum Error {
     BoolValue(u8),
 
     #[error("Not a fixed value, required for decimal with fixed schema: {0:?}")]
-    FixedValue(Value),
+    FixedValue(Box<Value>),
 
     #[error("Not a bytes value, required for decimal with bytes schema: {0:?}")]
-    BytesValue(Value),
+    BytesValue(Box<Value>),
 
     #[error("Not a string value, required for uuid: {0:?}")]
-    GetUuidFromStringValue(Value),
+    GetUuidFromStringValue(Box<Value>),
 
     #[error("Two schemas with the same fullname were given: {0:?}")]
     NameCollision(String),
@@ -45,7 +45,7 @@ pub enum Error {
     ResolveDecimalSchema(SchemaKind),
 
     #[error("Invalid utf-8 string")]
-    ConvertToUtf8(#[source] std::string::FromUtf8Error),
+    ConvertToUtf8(#[source] Box<std::string::FromUtf8Error>),
 
     #[error("Invalid utf-8 string")]
     ConvertToUtf8Error(#[source] std::str::Utf8Error),
@@ -57,9 +57,9 @@ pub enum Error {
     /// Describes errors happened while validating Avro data.
     #[error("Value {value:?} does not match schema {schema:?}: Reason: {reason}")]
     ValidationWithReason {
-        value: Value,
+        value: Box<Value>,
         schema: Box<Schema>,
-        reason: String,
+        reason: Box<String>,
     },
 
     #[error("Unable to allocate {desired} bytes (maximum allowed: {maximum})")]
@@ -93,13 +93,13 @@ pub enum Error {
     ReadFixed(#[source] std::io::Error, usize),
 
     #[error("Failed to convert &str to UUID: {0}")]
-    ConvertStrToUuid(#[source] uuid::Error),
+    ConvertStrToUuid(#[source] Box<uuid::Error>),
 
     #[error("Failed to convert Fixed bytes to UUID. It must be exactly 16 bytes, got {0}")]
     ConvertFixedToUuid(usize),
 
     #[error("Failed to convert Fixed bytes to UUID: {0}")]
-    ConvertSliceToUuid(#[source] uuid::Error),
+    ConvertSliceToUuid(#[source] Box<uuid::Error>),
 
     #[error("Map key is not a string; key type is {0:?}")]
     MapKeyType(ValueKind),
@@ -125,25 +125,25 @@ pub enum Error {
     GetScaleWithFixedSize { size: usize, precision: usize },
 
     #[error("Expected Value::Uuid, got: {0:?}")]
-    GetUuid(Value),
+    GetUuid(Box<Value>),
 
     #[error("Expected Value::BigDecimal, got: {0:?}")]
-    GetBigDecimal(Value),
+    GetBigDecimal(Box<Value>),
 
     #[error("Fixed bytes of size 12 expected, got Fixed of size {0}")]
     GetDecimalFixedBytes(usize),
 
     #[error("Expected Value::Duration or Value::Fixed(12), got: {0:?}")]
-    ResolveDuration(Value),
+    ResolveDuration(Box<Value>),
 
     #[error("Expected Value::Decimal, Value::Bytes or Value::Fixed, got: {0:?}")]
-    ResolveDecimal(Value),
+    ResolveDecimal(Box<Value>),
 
     #[error("Missing field in record: {0:?}")]
     GetField(String),
 
     #[error("Unable to convert to u8, got {0:?}")]
-    GetU8(Value),
+    GetU8(Box<Value>),
 
     #[error("Precision {precision} too small to hold decimal values with {num_bytes} bytes")]
     ComparePrecisionAndSize { precision: usize, num_bytes: usize },
@@ -152,69 +152,69 @@ pub enum Error {
     ConvertLengthToI32(#[source] std::num::TryFromIntError, usize),
 
     #[error("Expected Value::Date or Value::Int, got: {0:?}")]
-    GetDate(Value),
+    GetDate(Box<Value>),
 
     #[error("Expected Value::TimeMillis or Value::Int, got: {0:?}")]
-    GetTimeMillis(Value),
+    GetTimeMillis(Box<Value>),
 
     #[error("Expected Value::TimeMicros, Value::Long or Value::Int, got: {0:?}")]
-    GetTimeMicros(Value),
+    GetTimeMicros(Box<Value>),
 
     #[error("Expected Value::TimestampMillis, Value::Long or Value::Int, got: {0:?}")]
-    GetTimestampMillis(Value),
+    GetTimestampMillis(Box<Value>),
 
     #[error("Expected Value::TimestampMicros, Value::Long or Value::Int, got: {0:?}")]
-    GetTimestampMicros(Value),
+    GetTimestampMicros(Box<Value>),
 
     #[error("Expected Value::TimestampNanos, Value::Long or Value::Int, got: {0:?}")]
-    GetTimestampNanos(Value),
+    GetTimestampNanos(Box<Value>),
 
     #[error("Expected Value::LocalTimestampMillis, Value::Long or Value::Int, got: {0:?}")]
-    GetLocalTimestampMillis(Value),
+    GetLocalTimestampMillis(Box<Value>),
 
     #[error("Expected Value::LocalTimestampMicros, Value::Long or Value::Int, got: {0:?}")]
-    GetLocalTimestampMicros(Value),
+    GetLocalTimestampMicros(Box<Value>),
 
     #[error("Expected Value::LocalTimestampNanos, Value::Long or Value::Int, got: {0:?}")]
-    GetLocalTimestampNanos(Value),
+    GetLocalTimestampNanos(Box<Value>),
 
     #[error("Expected Value::Null, got: {0:?}")]
-    GetNull(Value),
+    GetNull(Box<Value>),
 
     #[error("Expected Value::Boolean, got: {0:?}")]
-    GetBoolean(Value),
+    GetBoolean(Box<Value>),
 
     #[error("Expected Value::Int, got: {0:?}")]
-    GetInt(Value),
+    GetInt(Box<Value>),
 
     #[error("Expected Value::Long or Value::Int, got: {0:?}")]
-    GetLong(Value),
+    GetLong(Box<Value>),
 
     #[error(r#"Expected Value::Double, Value::Float, Value::Int, Value::Long or Value::String ("NaN", "INF", "Infinity", "-INF" or "-Infinity"), got: {0:?}"#)]
-    GetDouble(Value),
+    GetDouble(Box<Value>),
 
     #[error(r#"Expected Value::Float, Value::Double, Value::Int, Value::Long or Value::String ("NaN", "INF", "Infinity", "-INF" or "-Infinity"), got: {0:?}"#)]
-    GetFloat(Value),
+    GetFloat(Box<Value>),
 
     #[error("Expected Value::Bytes, got: {0:?}")]
-    GetBytes(Value),
+    GetBytes(Box<Value>),
 
     #[error("Expected Value::String, Value::Bytes or Value::Fixed, got: {0:?}")]
-    GetString(Value),
+    GetString(Box<Value>),
 
     #[error("Expected Value::Enum, got: {0:?}")]
-    GetEnum(Value),
+    GetEnum(Box<Value>),
 
     #[error("Fixed size mismatch, expected: {size}, got: {n}")]
     CompareFixedSizes { size: usize, n: usize },
 
     #[error("String expected for fixed, got: {0:?}")]
-    GetStringForFixed(Value),
+    GetStringForFixed(Box<Value>),
 
     #[error("Enum default {symbol:?} is not among allowed symbols {symbols:?}")]
     GetEnumDefault {
-        symbol: String,
-        symbols: Vec<String>,
+        symbol: Box<String>,
+        symbols: Box<Vec<String>>,
     },
 
     #[error("Enum value index {index} is out of bounds {nsymbols}")]
@@ -224,21 +224,30 @@ pub enum Error {
     GetDecimalMetadataFromJson(&'static str),
 
     #[error("Could not find matching type in {schema:?} for {value:?}")]
-    FindUnionVariant { schema: UnionSchema, value: Value },
+    FindUnionVariant {
+        schema: Box<UnionSchema>,
+        value: Box<Value>,
+    },
 
     #[error("Union type should not be empty")]
     EmptyUnion,
 
     #[error("Array({expected:?}) expected, got {other:?}")]
-    GetArray { expected: SchemaKind, other: Value },
+    GetArray {
+        expected: SchemaKind,
+        other: Box<Value>,
+    },
 
     #[error("Map({expected:?}) expected, got {other:?}")]
-    GetMap { expected: SchemaKind, other: Value },
+    GetMap {
+        expected: SchemaKind,
+        other: Box<Value>,
+    },
 
     #[error("Record with fields {expected:?} expected, got {other:?}")]
     GetRecord {
-        expected: Vec<(String, SchemaKind)>,
-        other: Value,
+        expected: Box<Vec<(String, SchemaKind)>>,
+        other: Box<Value>,
     },
 
     #[error("No `name` field")]
@@ -257,7 +266,7 @@ pub enum Error {
     GetDefaultUnion(SchemaKind, ValueKind),
 
     #[error("`default`'s value type of field {0:?} in {1:?} must be {2:?}")]
-    GetDefaultRecordField(String, String, String),
+    GetDefaultRecordField(Box<String>, Box<String>, Box<String>),
 
     #[error("JSON value {0} claims to be u64 but cannot be converted")]
     GetU64FromJson(serde_json::Number),
@@ -294,8 +303,8 @@ pub enum Error {
 
     #[error("invalid JSON for {key:?}: {value:?}")]
     GetDecimalMetadataValueFromJson {
-        key: String,
-        value: serde_json::Value,
+        key: &'static str,
+        value: Box<serde_json::Value>,
     },
 
     #[error("The decimal precision ({precision}) must be bigger or equal to the scale ({scale})")]
@@ -313,17 +322,18 @@ pub enum Error {
     #[error("Unreadable big decimal scale")]
     BigDecimalScale,
 
+    // TODO: This seems unused?
     #[error("Unexpected `type` {0} variant for `logicalType`")]
-    GetLogicalTypeVariant(serde_json::Value),
+    GetLogicalTypeVariant(Box<serde_json::Value>),
 
     #[error("No `type` field found for `logicalType`")]
     GetLogicalTypeField,
 
     #[error("logicalType must be a string, but is {0:?}")]
-    GetLogicalTypeFieldType(serde_json::Value),
+    GetLogicalTypeFieldType(Box<serde_json::Value>),
 
     #[error("Unknown complex type: {0}")]
-    GetComplexType(serde_json::Value),
+    GetComplexType(Box<serde_json::Value>),
 
     #[error("No `type` in complex type")]
     GetComplexTypeField,
@@ -347,10 +357,10 @@ pub enum Error {
     FieldNameDuplicate(String),
 
     #[error("Invalid schema name {0}. It must match the regex '{1}'")]
-    InvalidSchemaName(String, &'static str),
+    InvalidSchemaName(Box<String>, &'static str),
 
     #[error("Invalid namespace {0}. It must match the regex '{1}'")]
-    InvalidNamespace(String, &'static str),
+    InvalidNamespace(Box<String>, &'static str),
 
     #[error(
         "Invalid schema: There is no type called '{0}', if you meant to define a non-primitive schema, it should be defined inside `type` attribute. Please review the specification"
@@ -361,7 +371,7 @@ pub enum Error {
     EnumSymbolDuplicate(String),
 
     #[error("Default value for enum must be a string! Got: {0}")]
-    EnumDefaultWrongType(serde_json::Value),
+    EnumDefaultWrongType(Box<serde_json::Value>),
 
     #[error("No `items` in array")]
     GetArrayItemsField,
@@ -370,7 +380,7 @@ pub enum Error {
     GetMapValuesField,
 
     #[error("Fixed schema `size` value must be a positive integer: {0}")]
-    GetFixedSizeFieldPositive(serde_json::Value),
+    GetFixedSizeFieldPositive(Box<serde_json::Value>),
 
     #[error("Fixed schema has no `size`")]
     GetFixedSizeField,
@@ -414,7 +424,7 @@ pub enum Error {
     HeaderMagic,
 
     #[error("Message Header mismatch. Expected: {0:?}. Actual: {1:?}")]
-    SingleObjectHeaderMismatch(Vec<u8>, Vec<u8>),
+    SingleObjectHeaderMismatch(Box<Vec<u8>>, Box<Vec<u8>>),
 
     #[error("Failed to get JSON from avro.schema key in map")]
     GetAvroSchemaFromMap,
@@ -451,14 +461,14 @@ pub enum Error {
 
     #[error("Failed to serialize value of type {value_type} using schema {schema:?}: {value}")]
     SerializeValueWithSchema {
-        value_type: &'static str,
-        value: String,
+        value_type: Box<&'static str>,
+        value: Box<String>,
         schema: Box<Schema>,
     },
 
     #[error("Failed to serialize field '{field_name}' for record {record_schema:?}: {error}")]
     SerializeRecordFieldWithSchema {
-        field_name: &'static str,
+        field_name: Box<&'static str>,
         record_schema: Box<Schema>,
         error: Box<Error>,
     },
@@ -484,7 +494,7 @@ pub enum Error {
 
     /// Error while resolving Schema::Ref
     #[error("Unresolved schema reference: {0}")]
-    SchemaResolutionError(Name),
+    SchemaResolutionError(Box<Name>),
 
     #[error("The file metadata is already flushed.")]
     FileHeaderAlreadyWritten,
@@ -494,13 +504,13 @@ pub enum Error {
 
     /// Error when two named schema have the same fully qualified name
     #[error("Two named schema defined for same fullname: {0}.")]
-    AmbiguousSchemaDefinition(Name),
+    AmbiguousSchemaDefinition(Box<Name>),
 
     #[error("Signed decimal bytes length {0} not equal to fixed schema size {1}.")]
     EncodeDecimalAsFixedError(usize, usize),
 
     #[error("There is no entry for '{0}' in the lookup table: {1}.")]
-    NoEntryInLookupTable(String, String),
+    NoEntryInLookupTable(Box<String>, Box<String>),
 
     #[error("Can only encode value type {value_kind:?} as one of {supported_schema:?}")]
     EncodeValueAsSchemaError {
@@ -517,7 +527,7 @@ pub enum Error {
     BadCodecMetadata,
 
     #[error("Cannot convert a slice to Uuid: {0}")]
-    UuidFromSlice(#[source] uuid::Error),
+    UuidFromSlice(#[source] Box<uuid::Error>),
 }
 
 #[derive(thiserror::Error, PartialEq)]

--- a/avro/src/headers.rs
+++ b/avro/src/headers.rs
@@ -88,8 +88,8 @@ impl GlueSchemaUuidHeader {
         if message_payload.len() < Self::GLUE_HEADER_LENGTH {
             return Err(crate::error::Error::HeaderMagic);
         }
-        let schema_uuid =
-            Uuid::from_slice(&message_payload[2..18]).map_err(crate::Error::UuidFromSlice)?;
+        let schema_uuid = Uuid::from_slice(&message_payload[2..18])
+            .map_err(|e| crate::Error::UuidFromSlice(Box::new(e)))?;
         Ok(GlueSchemaUuidHeader { schema_uuid })
     }
 

--- a/avro/src/reader.rs
+++ b/avro/src/reader.rs
@@ -537,8 +537,8 @@ impl GenericSingleObjectReader {
                     )
                 } else {
                     Err(Error::SingleObjectHeaderMismatch(
-                        self.expected_header.clone(),
-                        header,
+                        Box::new(self.expected_header.clone()),
+                        Box::new(header),
                     ))
                 }
             }

--- a/avro/src/ser_schema.rs
+++ b/avro/src/ser_schema.rs
@@ -340,7 +340,7 @@ impl<W: Write> ser::SerializeStruct for SchemaAwareWriteSerializeStruct<'_, '_, 
         if next_field_matches {
             self.serialize_next_field(&value).map_err(|e| {
                 Error::SerializeRecordFieldWithSchema {
-                    field_name: key,
+                    field_name: Box::new(key),
                     record_schema: Box::new(Schema::Record(self.record_schema.clone())),
                     error: Box::new(e),
                 }
@@ -367,7 +367,7 @@ impl<W: Write> ser::SerializeStruct for SchemaAwareWriteSerializeStruct<'_, '_, 
                         );
                         value.serialize(&mut value_ser).map_err(|e| {
                             Error::SerializeRecordFieldWithSchema {
-                                field_name: key,
+                                field_name: Box::new(key),
                                 record_schema: Box::new(Schema::Record(self.record_schema.clone())),
                                 error: Box::new(e),
                             }
@@ -513,7 +513,7 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
 
         let ref_schema = self.names.get(full_name.as_ref()).copied();
 
-        ref_schema.ok_or_else(|| Error::SchemaResolutionError(full_name.as_ref().clone()))
+        ref_schema.ok_or_else(|| Error::SchemaResolutionError(Box::new(full_name.as_ref().clone())))
     }
 
     fn write_bytes(&mut self, bytes: &[u8]) -> Result<usize, Error> {
@@ -527,8 +527,8 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
 
     fn serialize_bool_with_schema(&mut self, value: bool, schema: &Schema) -> Result<usize, Error> {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "bool",
-            value: format!("{value}. Cause: {cause}"),
+            value_type: Box::new("bool"),
+            value: Box::new(format!("{value}. Cause: {cause}")),
             schema: Box::new(schema.clone()),
         };
 
@@ -558,8 +558,8 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
 
     fn serialize_i32_with_schema(&mut self, value: i32, schema: &Schema) -> Result<usize, Error> {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "int (i8 | i16 | i32)",
-            value: format!("{value}. Cause: {cause}"),
+            value_type: Box::new("int (i8 | i16 | i32)"),
+            value: Box::new(format!("{value}. Cause: {cause}")),
             schema: Box::new(schema.clone()),
         };
 
@@ -603,8 +603,8 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
 
     fn serialize_i64_with_schema(&mut self, value: i64, schema: &Schema) -> Result<usize, Error> {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "i64",
-            value: format!("{value}. Cause: {cause}"),
+            value_type: Box::new("i64"),
+            value: Box::new(format!("{value}. Cause: {cause}")),
             schema: Box::new(schema.clone()),
         };
 
@@ -653,8 +653,8 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
 
     fn serialize_u8_with_schema(&mut self, value: u8, schema: &Schema) -> Result<usize, Error> {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "u8",
-            value: format!("{value}. Cause: {cause}"),
+            value_type: Box::new("u8"),
+            value: Box::new(format!("{value}. Cause: {cause}")),
             schema: Box::new(schema.clone()),
         };
 
@@ -702,8 +702,8 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
 
     fn serialize_u32_with_schema(&mut self, value: u32, schema: &Schema) -> Result<usize, Error> {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "unsigned int (u16 | u32)",
-            value: format!("{value}. Cause: {cause}"),
+            value_type: Box::new("unsigned int (u16 | u32)"),
+            value: Box::new(format!("{value}. Cause: {cause}")),
             schema: Box::new(schema.clone()),
         };
 
@@ -751,8 +751,8 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
 
     fn serialize_u64_with_schema(&mut self, value: u64, schema: &Schema) -> Result<usize, Error> {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "u64",
-            value: format!("{value}. Cause: {cause}"),
+            value_type: Box::new("u64"),
+            value: Box::new(format!("{value}. Cause: {cause}")),
             schema: Box::new(schema.clone()),
         };
 
@@ -805,8 +805,8 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
 
     fn serialize_f32_with_schema(&mut self, value: f32, schema: &Schema) -> Result<usize, Error> {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "f32",
-            value: format!("{value}. Cause: {cause}"),
+            value_type: Box::new("f32"),
+            value: Box::new(format!("{value}. Cause: {cause}")),
             schema: Box::new(schema.clone()),
         };
 
@@ -840,8 +840,8 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
 
     fn serialize_f64_with_schema(&mut self, value: f64, schema: &Schema) -> Result<usize, Error> {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "f64",
-            value: format!("{value}. Cause: {cause}"),
+            value_type: Box::new("f64"),
+            value: Box::new(format!("{value}. Cause: {cause}")),
             schema: Box::new(schema.clone()),
         };
 
@@ -875,8 +875,8 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
 
     fn serialize_char_with_schema(&mut self, value: char, schema: &Schema) -> Result<usize, Error> {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "char",
-            value: format!("{value}. Cause: {cause}"),
+            value_type: Box::new("char"),
+            value: Box::new(format!("{value}. Cause: {cause}")),
             schema: Box::new(schema.clone()),
         };
 
@@ -902,8 +902,8 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
 
     fn serialize_str_with_schema(&mut self, value: &str, schema: &Schema) -> Result<usize, Error> {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "string",
-            value: format!("{value}. Cause: {cause}"),
+            value_type: Box::new("string"),
+            value: Box::new(format!("{value}. Cause: {cause}")),
             schema: Box::new(schema.clone()),
         };
 
@@ -970,8 +970,8 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
                 }
             }
             Error::SerializeValueWithSchema {
-                value_type: "bytes",
-                value: format!("{v_str}. Cause: {cause}"),
+                value_type: Box::new("bytes"),
+                value: Box::new(format!("{v_str}. Cause: {cause}")),
                 schema: Box::new(schema.clone()),
             }
         };
@@ -1057,8 +1057,8 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
 
     fn serialize_none_with_schema(&mut self, schema: &Schema) -> Result<usize, Error> {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "none",
-            value: format!("None. Cause: {cause}"),
+            value_type: Box::new("none"),
+            value: Box::new(format!("None. Cause: {cause}")),
             schema: Box::new(schema.clone()),
         };
 
@@ -1087,8 +1087,8 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
         T: ?Sized + ser::Serialize,
     {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "some",
-            value: format!("Some(?). Cause: {cause}"),
+            value_type: Box::new("some"),
+            value: Box::new(format!("Some(?). Cause: {cause}")),
             schema: Box::new(schema.clone()),
         };
 
@@ -1124,8 +1124,8 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
         schema: &Schema,
     ) -> Result<usize, Error> {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "unit struct",
-            value: format!("{name}. Cause: {cause}"),
+            value_type: Box::new("unit struct"),
+            value: Box::new(format!("{name}. Cause: {cause}")),
             schema: Box::new(schema.clone()),
         };
 
@@ -1173,8 +1173,10 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
         schema: &Schema,
     ) -> Result<usize, Error> {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "unit variant",
-            value: format!("{name}::{variant} (index={variant_index}). Cause: {cause}"),
+            value_type: Box::new("unit variant"),
+            value: Box::new(format!(
+                "{name}::{variant} (index={variant_index}). Cause: {cause}"
+            )),
             schema: Box::new(schema.clone()),
         };
 
@@ -1246,8 +1248,10 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
         T: ?Sized + ser::Serialize,
     {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "newtype variant",
-            value: format!("{name}::{variant}(?) (index={variant_index}). Cause: {cause}"),
+            value_type: Box::new("newtype variant"),
+            value: Box::new(format!(
+                "{name}::{variant}(?) (index={variant_index}). Cause: {cause}"
+            )),
             schema: Box::new(schema.clone()),
         };
 
@@ -1282,8 +1286,8 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
                 .unwrap_or_else(|| String::from("?"));
 
             Error::SerializeValueWithSchema {
-                value_type: "sequence",
-                value: format!("sequence (len={len_str}). Cause: {cause}"),
+                value_type: Box::new("sequence"),
+                value: Box::new(format!("sequence (len={len_str}). Cause: {cause}")),
                 schema: Box::new(schema.clone()),
             }
         };
@@ -1318,8 +1322,8 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
         schema: &'s Schema,
     ) -> Result<SchemaAwareWriteSerializeSeq<'a, 's, W>, Error> {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "tuple",
-            value: format!("tuple (len={len}). Cause: {cause}"),
+            value_type: Box::new("tuple"),
+            value: Box::new(format!("tuple (len={len}). Cause: {cause}")),
             schema: Box::new(schema.clone()),
         };
 
@@ -1354,11 +1358,11 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
         schema: &'s Schema,
     ) -> Result<SchemaAwareWriteSerializeTupleStruct<'a, 's, W>, Error> {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "tuple struct",
-            value: format!(
+            value_type: Box::new("tuple struct"),
+            value: Box::new(format!(
                 "{name}({}). Cause: {cause}",
                 vec!["?"; len].as_slice().join(",")
-            ),
+            )),
             schema: Box::new(schema.clone()),
         };
 
@@ -1416,11 +1420,11 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
         schema: &'s Schema,
     ) -> Result<SchemaAwareWriteSerializeTupleStruct<'a, 's, W>, Error> {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "tuple variant",
-            value: format!(
+            value_type: Box::new("tuple variant"),
+            value: Box::new(format!(
                 "{name}::{variant}({}) (index={variant_index}). Cause: {cause}",
                 vec!["?"; len].as_slice().join(",")
-            ),
+            )),
             schema: Box::new(schema.clone()),
         };
 
@@ -1455,8 +1459,8 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
                 .unwrap_or_else(|| String::from("?"));
 
             Error::SerializeValueWithSchema {
-                value_type: "map",
-                value: format!("map (size={len_str}). Cause: {cause}"),
+                value_type: Box::new("map"),
+                value: Box::new(format!("map (size={len_str}). Cause: {cause}")),
                 schema: Box::new(schema.clone()),
             }
         };
@@ -1494,8 +1498,8 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
         schema: &'s Schema,
     ) -> Result<SchemaAwareWriteSerializeStruct<'a, 's, W>, Error> {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "struct",
-            value: format!("{name}{{ ... }}. Cause: {cause}"),
+            value_type: Box::new("struct"),
+            value: Box::new(format!("{name}{{ ... }}. Cause: {cause}")),
             schema: Box::new(schema.clone()),
         };
 
@@ -1544,8 +1548,10 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
         schema: &'s Schema,
     ) -> Result<SchemaAwareWriteSerializeStruct<'a, 's, W>, Error> {
         let create_error = |cause: String| Error::SerializeValueWithSchema {
-            value_type: "struct variant",
-            value: format!("{name}::{variant}{{ ... }} (size={len}. Cause: {cause})"),
+            value_type: Box::new("struct variant"),
+            value: Box::new(format!(
+                "{name}::{variant}{{ ... }} (size={len}. Cause: {cause})"
+            )),
             schema: Box::new(schema.clone()),
         };
 
@@ -2023,8 +2029,8 @@ mod tests {
                 value,
                 schema,
             }) => {
-                assert_eq!(value_type, "none"); // serialize_unit() delegates to serialize_none()
-                assert_eq!(value, "None. Cause: Expected: Record. Got: Null");
+                assert_eq!(*value_type, "none"); // serialize_unit() delegates to serialize_none()
+                assert_eq!(value.as_str(), "None. Cause: Expected: Record. Got: Null");
                 assert_eq!(schema, schema);
             }
             unexpected => panic!("Expected an error. Got: {unexpected:?}"),
@@ -2067,8 +2073,8 @@ mod tests {
                 value,
                 schema,
             }) => {
-                assert_eq!(value_type, "none");
-                assert_eq!(value, "None. Cause: Expected: Enum. Got: Null");
+                assert_eq!(*value_type, "none");
+                assert_eq!(value.as_str(), "None. Cause: Expected: Enum. Got: Null");
                 assert_eq!(schema, schema);
             }
             unexpected => panic!("Expected an error. Got: {unexpected:?}"),
@@ -2101,8 +2107,8 @@ mod tests {
                 value,
                 schema,
             }) => {
-                assert_eq!(value_type, "f32");
-                assert_eq!(value, "1. Cause: Expected: Long. Got: Float");
+                assert_eq!(*value_type, "f32");
+                assert_eq!(value.as_str(), "1. Cause: Expected: Long. Got: Float");
                 assert_eq!(schema, schema);
             }
             unexpected => panic!("Expected an error. Got: {unexpected:?}"),
@@ -2140,8 +2146,8 @@ mod tests {
                 value,
                 schema,
             }) => {
-                assert_eq!(value_type, "string");
-                assert_eq!(value, "value1. Cause: Expected: Long. Got: String");
+                assert_eq!(*value_type, "string");
+                assert_eq!(value.as_str(), "value1. Cause: Expected: Long. Got: String");
                 assert_eq!(schema, schema);
             }
             unexpected => panic!("Expected an error. Got: {unexpected:?}"),
@@ -2187,9 +2193,9 @@ mod tests {
                 value,
                 schema,
             }) => {
-                assert_eq!(value_type, "string");
+                assert_eq!(*value_type, "string");
                 assert_eq!(
-                    value,
+                    value.as_str(),
                     "invalid. Cause: Expected one of the union variants [Null, Long]. Got: String"
                 );
                 assert_eq!(schema, schema);
@@ -2231,9 +2237,9 @@ mod tests {
                 value,
                 schema,
             }) => {
-                assert_eq!(value_type, "f64");
+                assert_eq!(*value_type, "f64");
                 assert_eq!(
-                    value,
+                    value.as_str(),
                     "1. Cause: Cannot find a Double schema in [Null, Long, String]"
                 );
                 assert_eq!(schema, schema);
@@ -2272,9 +2278,9 @@ mod tests {
                 value,
                 schema,
             }) => {
-                assert_eq!(value_type, "bytes");
+                assert_eq!(*value_type, "bytes");
                 assert_eq!(
-                    value,
+                    value.as_str(),
                     "7b. Cause: Fixed schema size (8) does not match the value length (1)"
                 ); // Bytes represents its values as hexadecimals: '7b' is 123
                 assert_eq!(schema, schema);
@@ -2289,8 +2295,11 @@ mod tests {
                 value,
                 schema,
             }) => {
-                assert_eq!(value_type, "tuple"); // TODO: why is this 'tuple' ?!
-                assert_eq!(value, "tuple (len=8). Cause: Expected: Fixed. Got: Array");
+                assert_eq!(*value_type, "tuple"); // TODO: why is this 'tuple' ?!
+                assert_eq!(
+                    value.as_str(),
+                    "tuple (len=8). Cause: Expected: Fixed. Got: Array"
+                );
                 assert_eq!(schema, schema);
             }
             unexpected => panic!("Expected an error. Got: {unexpected:?}"),
@@ -2304,7 +2313,10 @@ mod tests {
                 schema,
             }) => {
                 assert_eq!(*value_type, "tuple"); // TODO: why is this 'tuple' ?!
-                assert_eq!(value, "tuple (len=8). Cause: Expected: Fixed. Got: Array");
+                assert_eq!(
+                    value.as_str(),
+                    "tuple (len=8). Cause: Expected: Fixed. Got: Array"
+                );
                 assert_eq!(schema, schema);
             }
             unexpected => panic!("Expected an error. Got: {unexpected:?}"),
@@ -2339,8 +2351,8 @@ mod tests {
                 value,
                 schema,
             }) => {
-                assert_eq!(value_type, "none");
-                assert_eq!(value, "None. Cause: Expected: Decimal. Got: Null");
+                assert_eq!(*value_type, "none");
+                assert_eq!(value.as_str(), "None. Cause: Expected: Decimal. Got: Null");
                 assert_eq!(schema, schema);
             }
             unexpected => panic!("Expected an error. Got: {unexpected:?}"),
@@ -2377,8 +2389,8 @@ mod tests {
                 value,
                 schema,
             }) => {
-                assert_eq!(value_type, "none");
-                assert_eq!(value, "None. Cause: Expected: Decimal. Got: Null");
+                assert_eq!(*value_type, "none");
+                assert_eq!(value.as_str(), "None. Cause: Expected: Decimal. Got: Null");
                 assert_eq!(schema, schema);
             }
             unexpected => panic!("Expected an error. Got: {unexpected:?}"),
@@ -2437,8 +2449,8 @@ mod tests {
                 value,
                 schema,
             }) => {
-                assert_eq!(value_type, "u8");
-                assert_eq!(value, "1. Cause: Expected: Uuid. Got: Int");
+                assert_eq!(*value_type, "u8");
+                assert_eq!(value.as_str(), "1. Cause: Expected: Uuid. Got: Int");
                 assert_eq!(schema, schema);
             }
             unexpected => panic!("Expected an error. Got: {unexpected:?}"),
@@ -2481,8 +2493,8 @@ mod tests {
                 value,
                 schema,
             }) => {
-                assert_eq!(value_type, "f32");
-                assert_eq!(value, "10000. Cause: Expected: Date. Got: Float");
+                assert_eq!(*value_type, "f32");
+                assert_eq!(value.as_str(), "10000. Cause: Expected: Date. Got: Float");
                 assert_eq!(schema, schema);
             }
             unexpected => panic!("Expected an error. Got: {unexpected:?}"),
@@ -2521,8 +2533,11 @@ mod tests {
                 value,
                 schema,
             }) => {
-                assert_eq!(value_type, "f32");
-                assert_eq!(value, "10000. Cause: Expected: TimeMillis. Got: Float");
+                assert_eq!(*value_type, "f32");
+                assert_eq!(
+                    value.as_str(),
+                    "10000. Cause: Expected: TimeMillis. Got: Float"
+                );
                 assert_eq!(schema, schema);
             }
             unexpected => panic!("Expected an error. Got: {unexpected:?}"),
@@ -2562,8 +2577,11 @@ mod tests {
                 value,
                 schema,
             }) => {
-                assert_eq!(value_type, "f32");
-                assert_eq!(value, "10000. Cause: Expected: TimeMicros. Got: Float");
+                assert_eq!(*value_type, "f32");
+                assert_eq!(
+                    value.as_str(),
+                    "10000. Cause: Expected: TimeMicros. Got: Float"
+                );
                 assert_eq!(schema, schema);
             }
             unexpected => panic!("Expected an error. Got: {unexpected:?}"),
@@ -2611,9 +2629,9 @@ mod tests {
                     if let Some(c) = capital_precision.chars().next() {
                         capital_precision.replace_range(..1, &c.to_uppercase().to_string());
                     }
-                    assert_eq!(value_type, "f64");
+                    assert_eq!(*value_type, "f64");
                     assert_eq!(
-                        value,
+                        value.as_str(),
                         format!(
                             "10000. Cause: Expected: Timestamp{capital_precision}. Got: Double"
                         )
@@ -2659,9 +2677,9 @@ mod tests {
                 value,
                 schema,
             }) => {
-                assert_eq!(value_type, "tuple"); // TODO: why is this 'tuple' ?!
+                assert_eq!(*value_type, "tuple"); // TODO: why is this 'tuple' ?!
                 assert_eq!(
-                    value,
+                    value.as_str(),
                     "tuple (len=12). Cause: Expected: Duration. Got: Array"
                 );
                 assert_eq!(schema, schema);

--- a/avro/src/types.rs
+++ b/avro/src/types.rs
@@ -679,7 +679,7 @@ impl Value {
                     self.resolve_internal(resolved.borrow(), names, &name.namespace, field_default)
                 } else {
                     error!("Failed to resolve schema {name:?}");
-                    Err(Error::SchemaResolutionError(name.clone()))
+                    Err(Error::SchemaResolutionError(Box::new(name.clone())))
                 }
             }
             Schema::Null => self.resolve_null(),
@@ -729,10 +729,10 @@ impl Value {
     fn resolve_uuid(self) -> Result<Self, Error> {
         Ok(match self {
             uuid @ Value::Uuid(_) => uuid,
-            Value::String(ref string) => {
-                Value::Uuid(Uuid::from_str(string).map_err(Error::ConvertStrToUuid)?)
-            }
-            other => return Err(Error::GetUuid(other)),
+            Value::String(ref string) => Value::Uuid(
+                Uuid::from_str(string).map_err(|e| Error::ConvertStrToUuid(Box::new(e)))?,
+            ),
+            other => return Err(Error::GetUuid(Box::new(other))),
         })
     }
 
@@ -740,7 +740,7 @@ impl Value {
         Ok(match self {
             bg @ Value::BigDecimal(_) => bg,
             Value::Bytes(b) => Value::BigDecimal(deserialize_big_decimal(&b).unwrap()),
-            other => return Err(Error::GetBigDecimal(other)),
+            other => return Err(Error::GetBigDecimal(Box::new(other))),
         })
     }
 
@@ -756,7 +756,7 @@ impl Value {
                     bytes[8], bytes[9], bytes[10], bytes[11],
                 ]))
             }
-            other => return Err(Error::ResolveDuration(other)),
+            other => return Err(Error::ResolveDuration(Box::new(other))),
         })
     }
 
@@ -802,21 +802,21 @@ impl Value {
                     Ok(Value::Decimal(Decimal::from(bytes)))
                 }
             }
-            other => Err(Error::ResolveDecimal(other)),
+            other => Err(Error::ResolveDecimal(Box::new(other))),
         }
     }
 
     fn resolve_date(self) -> Result<Self, Error> {
         match self {
             Value::Date(d) | Value::Int(d) => Ok(Value::Date(d)),
-            other => Err(Error::GetDate(other)),
+            other => Err(Error::GetDate(Box::new(other))),
         }
     }
 
     fn resolve_time_millis(self) -> Result<Self, Error> {
         match self {
             Value::TimeMillis(t) | Value::Int(t) => Ok(Value::TimeMillis(t)),
-            other => Err(Error::GetTimeMillis(other)),
+            other => Err(Error::GetTimeMillis(Box::new(other))),
         }
     }
 
@@ -824,7 +824,7 @@ impl Value {
         match self {
             Value::TimeMicros(t) | Value::Long(t) => Ok(Value::TimeMicros(t)),
             Value::Int(t) => Ok(Value::TimeMicros(i64::from(t))),
-            other => Err(Error::GetTimeMicros(other)),
+            other => Err(Error::GetTimeMicros(Box::new(other))),
         }
     }
 
@@ -832,7 +832,7 @@ impl Value {
         match self {
             Value::TimestampMillis(ts) | Value::Long(ts) => Ok(Value::TimestampMillis(ts)),
             Value::Int(ts) => Ok(Value::TimestampMillis(i64::from(ts))),
-            other => Err(Error::GetTimestampMillis(other)),
+            other => Err(Error::GetTimestampMillis(Box::new(other))),
         }
     }
 
@@ -840,7 +840,7 @@ impl Value {
         match self {
             Value::TimestampMicros(ts) | Value::Long(ts) => Ok(Value::TimestampMicros(ts)),
             Value::Int(ts) => Ok(Value::TimestampMicros(i64::from(ts))),
-            other => Err(Error::GetTimestampMicros(other)),
+            other => Err(Error::GetTimestampMicros(Box::new(other))),
         }
     }
 
@@ -848,7 +848,7 @@ impl Value {
         match self {
             Value::TimestampNanos(ts) | Value::Long(ts) => Ok(Value::TimestampNanos(ts)),
             Value::Int(ts) => Ok(Value::TimestampNanos(i64::from(ts))),
-            other => Err(Error::GetTimestampNanos(other)),
+            other => Err(Error::GetTimestampNanos(Box::new(other))),
         }
     }
 
@@ -858,7 +858,7 @@ impl Value {
                 Ok(Value::LocalTimestampMillis(ts))
             }
             Value::Int(ts) => Ok(Value::LocalTimestampMillis(i64::from(ts))),
-            other => Err(Error::GetLocalTimestampMillis(other)),
+            other => Err(Error::GetLocalTimestampMillis(Box::new(other))),
         }
     }
 
@@ -868,7 +868,7 @@ impl Value {
                 Ok(Value::LocalTimestampMicros(ts))
             }
             Value::Int(ts) => Ok(Value::LocalTimestampMicros(i64::from(ts))),
-            other => Err(Error::GetLocalTimestampMicros(other)),
+            other => Err(Error::GetLocalTimestampMicros(Box::new(other))),
         }
     }
 
@@ -876,21 +876,21 @@ impl Value {
         match self {
             Value::LocalTimestampNanos(ts) | Value::Long(ts) => Ok(Value::LocalTimestampNanos(ts)),
             Value::Int(ts) => Ok(Value::LocalTimestampNanos(i64::from(ts))),
-            other => Err(Error::GetLocalTimestampNanos(other)),
+            other => Err(Error::GetLocalTimestampNanos(Box::new(other))),
         }
     }
 
     fn resolve_null(self) -> Result<Self, Error> {
         match self {
             Value::Null => Ok(Value::Null),
-            other => Err(Error::GetNull(other)),
+            other => Err(Error::GetNull(Box::new(other))),
         }
     }
 
     fn resolve_boolean(self) -> Result<Self, Error> {
         match self {
             Value::Boolean(b) => Ok(Value::Boolean(b)),
-            other => Err(Error::GetBoolean(other)),
+            other => Err(Error::GetBoolean(Box::new(other))),
         }
     }
 
@@ -898,7 +898,7 @@ impl Value {
         match self {
             Value::Int(n) => Ok(Value::Int(n)),
             Value::Long(n) => Ok(Value::Int(n as i32)),
-            other => Err(Error::GetInt(other)),
+            other => Err(Error::GetInt(Box::new(other))),
         }
     }
 
@@ -906,7 +906,7 @@ impl Value {
         match self {
             Value::Int(n) => Ok(Value::Long(i64::from(n))),
             Value::Long(n) => Ok(Value::Long(n)),
-            other => Err(Error::GetLong(other)),
+            other => Err(Error::GetLong(Box::new(other))),
         }
     }
 
@@ -918,9 +918,9 @@ impl Value {
             Value::Double(x) => Ok(Value::Float(x as f32)),
             Value::String(ref x) => match Self::parse_special_float(x) {
                 Some(f) => Ok(Value::Float(f)),
-                None => Err(Error::GetFloat(self)),
+                None => Err(Error::GetFloat(Box::new(self))),
             },
-            other => Err(Error::GetFloat(other)),
+            other => Err(Error::GetFloat(Box::new(other))),
         }
     }
 
@@ -932,9 +932,9 @@ impl Value {
             Value::Double(x) => Ok(Value::Double(x)),
             Value::String(ref x) => match Self::parse_special_float(x) {
                 Some(f) => Ok(Value::Double(f64::from(f))),
-                None => Err(Error::GetDouble(self)),
+                None => Err(Error::GetDouble(Box::new(self))),
             },
-            other => Err(Error::GetDouble(other)),
+            other => Err(Error::GetDouble(Box::new(other))),
         }
     }
 
@@ -959,7 +959,7 @@ impl Value {
                     .map(Value::try_u8)
                     .collect::<Result<Vec<_>, _>>()?,
             )),
-            other => Err(Error::GetBytes(other)),
+            other => Err(Error::GetBytes(Box::new(other))),
         }
     }
 
@@ -967,9 +967,9 @@ impl Value {
         match self {
             Value::String(s) => Ok(Value::String(s)),
             Value::Bytes(bytes) | Value::Fixed(_, bytes) => Ok(Value::String(
-                String::from_utf8(bytes).map_err(Error::ConvertToUtf8)?,
+                String::from_utf8(bytes).map_err(|e| Error::ConvertToUtf8(Box::new(e)))?,
             )),
-            other => Err(Error::GetString(other)),
+            other => Err(Error::GetString(Box::new(other))),
         }
     }
 
@@ -990,7 +990,7 @@ impl Value {
                     Err(Error::CompareFixedSizes { size, n: s.len() })
                 }
             }
-            other => Err(Error::GetStringForFixed(other)),
+            other => Err(Error::GetStringForFixed(Box::new(other))),
         }
     }
 
@@ -1010,14 +1010,14 @@ impl Value {
                             Ok(Value::Enum(index as u32, default.clone()))
                         } else {
                             Err(Error::GetEnumDefault {
-                                symbol,
-                                symbols: symbols.into(),
+                                symbol: Box::new(symbol),
+                                symbols: Box::new(Vec::from(symbols)),
                             })
                         }
                     }
                     _ => Err(Error::GetEnumDefault {
-                        symbol,
-                        symbols: symbols.into(),
+                        symbol: Box::new(symbol),
+                        symbols: Box::new(Vec::from(symbols)),
                     }),
                 }
             }
@@ -1026,7 +1026,7 @@ impl Value {
         match self {
             Value::Enum(_raw_index, s) => validate_symbol(s, symbols),
             Value::String(s) => validate_symbol(s, symbols),
-            other => Err(Error::GetEnum(other)),
+            other => Err(Error::GetEnum(Box::new(other))),
         }
     }
 
@@ -1046,8 +1046,8 @@ impl Value {
         let (i, inner) = schema
             .find_schema_with_known_schemata(&v, Some(names), enclosing_namespace)
             .ok_or(Error::FindUnionVariant {
-                schema: schema.clone(),
-                value: v.clone(),
+                schema: Box::new(schema.clone()),
+                value: Box::new(v.clone()),
             })?;
 
         Ok(Value::Union(
@@ -1071,7 +1071,7 @@ impl Value {
             )),
             other => Err(Error::GetArray {
                 expected: schema.into(),
-                other,
+                other: Box::new(other),
             }),
         }
     }
@@ -1095,7 +1095,7 @@ impl Value {
             )),
             other => Err(Error::GetMap {
                 expected: schema.into(),
-                other,
+                other: Box::new(other),
             }),
         }
     }
@@ -1110,11 +1110,13 @@ impl Value {
             Value::Map(items) => Ok(items),
             Value::Record(fields) => Ok(fields.into_iter().collect::<HashMap<_, _>>()),
             other => Err(Error::GetRecord {
-                expected: fields
-                    .iter()
-                    .map(|field| (field.name.clone(), field.schema.clone().into()))
-                    .collect(),
-                other,
+                expected: Box::new(
+                    fields
+                        .iter()
+                        .map(|field| (field.name.clone(), field.schema.clone().into()))
+                        .collect(),
+                ),
+                other: Box::new(other),
             }),
         }?;
 
@@ -1175,7 +1177,7 @@ impl Value {
             }
         }
 
-        Err(Error::GetU8(int))
+        Err(Error::GetU8(Box::new(int)))
     }
 }
 

--- a/avro/src/writer.rs
+++ b/avro/src/writer.rs
@@ -653,9 +653,9 @@ fn write_value_ref_resolved(
 ) -> AvroResult<usize> {
     match value.validate_internal(schema, resolved_schema.get_names(), &schema.namespace()) {
         Some(reason) => Err(Error::ValidationWithReason {
-            value: value.clone(),
+            value: Box::new(value.clone()),
             schema: Box::new(schema.clone()),
-            reason,
+            reason: Box::new(reason),
         }),
         None => encode_internal(
             value,
@@ -679,9 +679,9 @@ fn write_value_ref_owned_resolved(
         &root_schema.namespace(),
     ) {
         return Err(Error::ValidationWithReason {
-            value: value.clone(),
+            value: Box::new(value.clone()),
             schema: Box::new(root_schema.clone()),
-            reason,
+            reason: Box::new(reason),
         });
     }
     encode_internal(


### PR DESCRIPTION
This PR shrinks the error type by 32 bytes to 72 bytes, saving 32 bytes of stack/registers for every function returning a `Result<_, Error>`. The new largest variant is `GetDefaultRecordField` at 72 bytes.

This is still quite large, but I'm not sure how to change `GetDefaultRecordField`. The third `String` can be a `Box<Schema>` which would shrink it to 64 bytes but would require rewriting a few tests. Another option is making it `Box<String>, Box<String>, Box<String>` which is 24 bytes (or `Box<str>, Box<str>, Box<str>` which is more idiomatic but is 48 bytes).

@martin-g feel free to add commits to this PR to shrink more types.

Distribution of the size of `Result::Ok`:
```
      1 0
      1 9
      2 12
      7 16
      5 24
     11 32
      1 40
      1 48
      8 56
      2 64
      2 72
      1 80
      1 176
      1 224
      2 248
      1 320
```
Note: this is a distribution of the size of `Result::Ok`, **not** how often it is used.


<details>
<summary>(Almost) all of the types with the Error type</summary>
Note: I temporarily renamed the Error type to AvroError to make it easier to grep for.

```
print-type-size type: `std::result::Result<schema::Schema, error::AvroError>`: 176 bytes, alignment: 8 bytes
print-type-size     variant `Ok`: 176 bytes
print-type-size         field `.0`: 176 bytes
print-type-size     variant `Err`: 80 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 72 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<schema::ResolvedOwnedSchema, error::AvroError>`: 224 bytes, alignment: 8 bytes
print-type-size     variant `Ok`: 224 bytes
print-type-size         field `.0`: 224 bytes
print-type-size     variant `Err`: 80 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 72 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<schema::RecordField, error::AvroError>`: 320 bytes, alignment: 8 bytes
print-type-size     variant `Ok`: 320 bytes
print-type-size         field `.0`: 320 bytes
print-type-size     variant `Err`: 80 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 72 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<reader::GenericSingleObjectReader, error::AvroError>`: 248 bytes, alignment: 8 bytes
print-type-size     variant `Ok`: 248 bytes
print-type-size         field `.0`: 248 bytes
print-type-size     variant `Err`: 80 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 72 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<writer::GenericSingleObjectWriter, error::AvroError>`: 248 bytes, alignment: 8 bytes
print-type-size     variant `Ok`: 248 bytes
print-type-size         field `.0`: 248 bytes
print-type-size     variant `Err`: 80 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 72 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<(std::string::String, types::Value), error::AvroError>`: 80 bytes, alignment: 8 bytes
print-type-size     variant `Ok`: 80 bytes
print-type-size         field `.0`: 80 bytes
print-type-size     variant `Err`: 80 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 72 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<schema::ResolvedSchema<'_>, error::AvroError>`: 80 bytes, alignment: 8 bytes
print-type-size     discriminant: 8 bytes
print-type-size     variant `Ok`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size type: `std::result::Result<ser::MapSerializer, error::AvroError>`: 80 bytes, alignment: 8 bytes
print-type-size     discriminant: 8 bytes
print-type-size     variant `Ok`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size type: `std::result::Result<&&schema::Schema, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<&schema::Schema, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<&serde_json::Value, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<&std::vec::Vec<serde_json::Value>, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<&str, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 16 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<(), error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 0 bytes
print-type-size         field `.0`: 0 bytes
print-type-size type: `std::result::Result<(std::string::String, serde_json::Value), error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<(std::string::String, std::option::Option<std::string::String>), error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 48 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<(usize, &schema::Schema), error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 16 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<(usize, usize), error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 16 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<bigdecimal::BigDecimal, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 48 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 40 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<codec::Codec, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 12 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 4 bytes, alignment: 4 bytes
print-type-size type: `std::result::Result<headers::GlueSchemaUuidHeader, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 16 bytes, alignment: 1 bytes
print-type-size type: `std::result::Result<i32, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 12 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 4 bytes, alignment: 4 bytes
print-type-size type: `std::result::Result<i64, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<regex_lite::Captures<'_>, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 48 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<schema::Alias, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 48 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<schema::Name, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 48 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<schema::UnionSchema, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 48 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<ser::SeqSerializer, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<ser::SeqVariantSerializer<'_>, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 48 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<ser::StructSerializer, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<ser::StructVariantSerializer<'_>, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 48 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<serde_json::Value, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<std::collections::HashMap<std::string::String, types::Value>, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 48 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<std::convert::Infallible, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size type: `std::result::Result<std::string::String, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<std::vec::Vec<(std::string::String, serde_json::Value)>, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<std::vec::Vec<(std::string::String, types::Value)>, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<std::vec::Vec<schema::RecordField>, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<std::vec::Vec<schema::Schema>, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<std::vec::Vec<serde_json::Value>, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<std::vec::Vec<std::string::String>, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<std::vec::Vec<types::Value>, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<std::vec::Vec<u8>, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<types::Value, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<u64, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<u8, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 9 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 1 bytes, alignment: 1 bytes
print-type-size type: `std::result::Result<usize, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size type: `std::result::Result<uuid::Uuid, error::AvroError>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Err`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Ok`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 16 bytes, alignment: 1 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, schema::RecordField>`: 320 bytes, alignment: 8 bytes
print-type-size     variant `Continue`: 320 bytes
print-type-size         field `.0`: 320 bytes
print-type-size     variant `Break`: 80 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 72 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, schema::ResolvedOwnedSchema>`: 224 bytes, alignment: 8 bytes
print-type-size     variant `Continue`: 224 bytes
print-type-size         field `.0`: 224 bytes
print-type-size     variant `Break`: 80 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 72 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, schema::Schema>`: 176 bytes, alignment: 8 bytes
print-type-size     variant `Continue`: 176 bytes
print-type-size         field `.0`: 176 bytes
print-type-size     variant `Break`: 80 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 72 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, (std::string::String, types::Value)>`: 80 bytes, alignment: 8 bytes
print-type-size     variant `Continue`: 80 bytes
print-type-size         field `.0`: 80 bytes
print-type-size     variant `Break`: 80 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 72 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, schema::ResolvedSchema<'_>>`: 80 bytes, alignment: 8 bytes
print-type-size     discriminant: 8 bytes
print-type-size     variant `Continue`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, &&schema::Schema>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, &schema::Schema>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, (std::string::String, serde_json::Value)>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, (std::string::String, std::option::Option<std::string::String>)>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 48 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, (usize, &schema::Schema)>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 16 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, i32>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 12 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 4 bytes, alignment: 4 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, i64>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, regex_lite::Captures<'_>>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 48 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, schema::Name>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 48 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, schema::UnionSchema>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 48 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, serde_json::Value>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, std::collections::HashMap<std::string::String, types::Value>>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 48 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, std::string::String>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, std::vec::Vec<(std::string::String, types::Value)>>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, std::vec::Vec<schema::RecordField>>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, std::vec::Vec<std::string::String>>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, std::vec::Vec<types::Value>>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, std::vec::Vec<u8>>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, types::Value>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, u64>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, u8>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 9 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 1 bytes, alignment: 1 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, usize>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size type: `std::ops::ControlFlow<std::result::Result<std::convert::Infallible, error::AvroError>, uuid::Uuid>`: 72 bytes, alignment: 8 bytes
print-type-size     variant `Break`: 72 bytes
print-type-size         field `.0`: 72 bytes
print-type-size     variant `Continue`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 16 bytes, alignment: 1 bytes
```
</details>

Old:
<details>
<summary>-Zprint-type-sizes output for the Error type</summary>

From `RUSTFLAGS=-Zprint-type-sizes cargo +nightly build --release > types.txt`

```
print-type-size type: `error::Error`: 104 bytes, alignment: 8 bytes
print-type-size     variant `FindUnionVariant`: 104 bytes
print-type-size         field `.schema`: 48 bytes
print-type-size         field `.value`: 56 bytes
print-type-size     variant `ValidationWithReason`: 96 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.reason`: 24 bytes, alignment: 8 bytes
print-type-size         field `.value`: 56 bytes
print-type-size         field `.schema`: 8 bytes
print-type-size     variant `GetRecord`: 88 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.expected`: 24 bytes, alignment: 8 bytes
print-type-size         field `.other`: 56 bytes
print-type-size     variant `GetDefaultRecordField`: 80 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size         field `.1`: 24 bytes
print-type-size         field `.2`: 24 bytes
print-type-size     variant `GetArray`: 65 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.other`: 56 bytes, alignment: 8 bytes
print-type-size         field `.expected`: 1 bytes
print-type-size     variant `GetMap`: 65 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.other`: 56 bytes, alignment: 8 bytes
print-type-size         field `.expected`: 1 bytes
print-type-size     variant `FixedValue`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `BytesValue`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetUuidFromStringValue`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetUuid`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetBigDecimal`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `ResolveDuration`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `ResolveDecimal`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetU8`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetDate`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetTimeMillis`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetTimeMicros`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetTimestampMillis`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetTimestampMicros`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetTimestampNanos`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetLocalTimestampMillis`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetLocalTimestampMicros`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetLocalTimestampNanos`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetNull`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetBoolean`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetInt`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetLong`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetDouble`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetFloat`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetBytes`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetString`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetEnum`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetStringForFixed`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 56 bytes, alignment: 8 bytes
print-type-size     variant `GetDecimalMetadataValueFromJson`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.key`: 24 bytes, alignment: 8 bytes
print-type-size         field `.value`: 32 bytes
print-type-size     variant `GetEnumDefault`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.symbol`: 24 bytes, alignment: 8 bytes
print-type-size         field `.symbols`: 24 bytes
print-type-size     variant `SingleObjectHeaderMismatch`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size         field `.1`: 24 bytes
print-type-size     variant `SerializeValueWithSchema`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.value`: 24 bytes, alignment: 8 bytes
print-type-size         field `.value_type`: 16 bytes
print-type-size         field `.schema`: 8 bytes
print-type-size     variant `SchemaResolutionError`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 48 bytes, alignment: 8 bytes
print-type-size     variant `AmbiguousSchemaDefinition`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 48 bytes, alignment: 8 bytes
print-type-size     variant `NoEntryInLookupTable`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size         field `.1`: 24 bytes
print-type-size     variant `ConvertToUtf8`: 48 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 40 bytes, alignment: 8 bytes
print-type-size     variant `InvalidSchemaName`: 48 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size         field `.1`: 16 bytes
print-type-size     variant `InvalidNamespace`: 48 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size         field `.1`: 16 bytes
print-type-size     variant `ConvertStrToUuid`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size     variant `ConvertSliceToUuid`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size     variant `GetLogicalTypeVariant`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size     variant `GetLogicalTypeFieldType`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size     variant `GetComplexType`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size     variant `EnumDefaultWrongType`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size     variant `GetFixedSizeFieldPositive`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size     variant `SerializeRecordFieldWithSchema`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.field_name`: 16 bytes, alignment: 8 bytes
print-type-size         field `.record_schema`: 8 bytes
print-type-size         field `.error`: 8 bytes
print-type-size     variant `UuidFromSlice`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size     variant `EncodeValueAsSchemaError`: 33 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.supported_schema`: 24 bytes, alignment: 8 bytes
print-type-size         field `.value_kind`: 1 bytes
print-type-size     variant `NameCollision`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `GetEnumSymbol`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `GetField`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `ParsePrimitive`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `EnumSymbolName`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `FieldName`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `FieldNameDuplicate`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `InvalidSchemaRecord`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `EnumSymbolDuplicate`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `SerializeValue`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `DeserializeValue`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `InvalidMetadataKey`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `CodecNotSupported`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `ConvertToUtf8Error`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 16 bytes, alignment: 8 bytes
print-type-size     variant `MemoryAllocation`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.desired`: 8 bytes, alignment: 8 bytes
print-type-size         field `.maximum`: 8 bytes
print-type-size     variant `SignExtend`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.requested`: 8 bytes, alignment: 8 bytes
print-type-size         field `.needed`: 8 bytes
print-type-size     variant `ReadFixed`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size         field `.1`: 8 bytes
print-type-size     variant `GetUnionVariant`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.index`: 8 bytes, alignment: 8 bytes
print-type-size         field `.num_variants`: 8 bytes
print-type-size     variant `EnumSymbolIndex`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.index`: 8 bytes, alignment: 8 bytes
print-type-size         field `.num_variants`: 8 bytes
print-type-size     variant `GetScaleAndPrecision`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.scale`: 8 bytes, alignment: 8 bytes
print-type-size         field `.precision`: 8 bytes
print-type-size     variant `GetScaleWithFixedSize`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.size`: 8 bytes, alignment: 8 bytes
print-type-size         field `.precision`: 8 bytes
print-type-size     variant `ComparePrecisionAndSize`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.precision`: 8 bytes, alignment: 8 bytes
print-type-size         field `.num_bytes`: 8 bytes
print-type-size     variant `CompareFixedSizes`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.size`: 8 bytes, alignment: 8 bytes
print-type-size         field `.n`: 8 bytes
print-type-size     variant `GetEnumValue`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.index`: 8 bytes, alignment: 8 bytes
print-type-size         field `.nsymbols`: 8 bytes
print-type-size     variant `GetDecimalMetadataFromJson`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 16 bytes, alignment: 8 bytes
print-type-size     variant `GetU64FromJson`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 16 bytes, alignment: 8 bytes
print-type-size     variant `GetI64FromJson`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 16 bytes, alignment: 8 bytes
print-type-size     variant `GetPrecisionOrScaleFromJson`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 16 bytes, alignment: 8 bytes
print-type-size     variant `DecimalPrecisionLessThanScale`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.precision`: 8 bytes, alignment: 8 bytes
print-type-size         field `.scale`: 8 bytes
print-type-size     variant `FixedDefaultLenSizeMismatch`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size         field `.1`: 8 bytes
print-type-size     variant `EncodeDecimalAsFixedError`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size         field `.1`: 8 bytes
print-type-size     variant `SnappyCrc32`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.expected`: 4 bytes, alignment: 4 bytes
print-type-size         field `.actual`: 4 bytes
print-type-size     variant `ReadBoolean`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadBytes`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadString`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadDouble`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadFloat`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadDuration`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ConvertFixedToUuid`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetDecimalFixedBytes`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ConvertLengthToI32`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.1`: 8 bytes, alignment: 8 bytes
print-type-size         field `.0`: 0 bytes
print-type-size     variant `ConvertU64ToUsize`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.1`: 8 bytes, alignment: 8 bytes
print-type-size         field `.0`: 0 bytes
print-type-size     variant `ConvertI64ToUsize`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.1`: 8 bytes, alignment: 8 bytes
print-type-size         field `.0`: 0 bytes
print-type-size     variant `ParseSchemaJson`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadSchemaFromReader`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `DecimalPrecisionMuBePositive`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.precision`: 8 bytes, alignment: 8 bytes
print-type-size     variant `BigDecimalLen`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `DeflateCompress`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `DeflateCompressFinish`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `DeflateDecompress`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ZstdCompress`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ZstdDecompress`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadHeader`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadMarker`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadBlockMarker`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadIntoBuf`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadVariableIntegerBytes`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ZagI32`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.1`: 8 bytes, alignment: 8 bytes
print-type-size         field `.0`: 0 bytes
print-type-size     variant `WriteBytes`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `FlushWriter`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `WriteMarker`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ConvertJsonToString`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ConvertF64ToJson`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ConvertU32ToUsize`: 12 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.1`: 4 bytes, alignment: 4 bytes
print-type-size         field `.0`: 0 bytes
print-type-size     variant `ConvertI32ToUsize`: 12 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.1`: 4 bytes, alignment: 4 bytes
print-type-size         field `.0`: 0 bytes
print-type-size     variant `GetDefaultUnion`: 10 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.1`: 1 bytes, alignment: 1 bytes
print-type-size         field `.0`: 1 bytes
print-type-size     variant `BoolValue`: 9 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 1 bytes, alignment: 1 bytes
print-type-size     variant `ResolveDecimalSchema`: 9 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 1 bytes, alignment: 1 bytes
print-type-size     variant `MapKeyType`: 9 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 1 bytes, alignment: 1 bytes
print-type-size     variant `Validation`: 0 bytes
print-type-size     variant `GetEnumUnknownIndexValue`: 0 bytes
print-type-size     variant `EmptyUnion`: 0 bytes
print-type-size     variant `GetNameField`: 0 bytes
print-type-size     variant `GetNameFieldFromRecord`: 0 bytes
print-type-size     variant `GetNestedUnion`: 0 bytes
print-type-size     variant `GetUnionDuplicate`: 0 bytes
print-type-size     variant `ParseSchemaFromValidJson`: 0 bytes
print-type-size     variant `BigDecimalSign`: 0 bytes
print-type-size     variant `BigDecimalScale`: 0 bytes
print-type-size     variant `GetLogicalTypeField`: 0 bytes
print-type-size     variant `GetComplexTypeField`: 0 bytes
print-type-size     variant `GetRecordFieldsJson`: 0 bytes
print-type-size     variant `GetEnumSymbolsField`: 0 bytes
print-type-size     variant `GetEnumSymbols`: 0 bytes
print-type-size     variant `GetArrayItemsField`: 0 bytes
print-type-size     variant `GetMapValuesField`: 0 bytes
print-type-size     variant `GetFixedSizeField`: 0 bytes
print-type-size     variant `HeaderMagic`: 0 bytes
print-type-size     variant `GetAvroSchemaFromMap`: 0 bytes
print-type-size     variant `GetHeaderMetadata`: 0 bytes
print-type-size     variant `GetBlockMarker`: 0 bytes
print-type-size     variant `IntegerOverflow`: 0 bytes
print-type-size     variant `ReadBlock`: 0 bytes
print-type-size     variant `FileHeaderAlreadyWritten`: 0 bytes
print-type-size     variant `IllegalSingleObjectWriterState`: 0 bytes
print-type-size     variant `BadCodecMetadata`: 0 bytes
```

</details>


New:
<details>
<summary>-Zprint-type-sizes output for the Error type</summary>

From `RUSTFLAGS=-Zprint-type-sizes cargo +nightly build --release > types.txt`

```
print-type-size type: `error::Error`: 72 bytes, alignment: 8 bytes
print-type-size     variant `GetDefaultRecordField`: 72 bytes
print-type-size         field `.0`: 24 bytes
print-type-size         field `.1`: 24 bytes
print-type-size         field `.2`: 24 bytes
print-type-size     variant `FindUnionVariant`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.schema`: 48 bytes, alignment: 8 bytes
print-type-size         field `.value`: 8 bytes
print-type-size     variant `GetDecimalMetadataValueFromJson`: 64 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.key`: 24 bytes, alignment: 8 bytes
print-type-size         field `.value`: 32 bytes
print-type-size     variant `GetEnumDefault`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.symbol`: 24 bytes, alignment: 8 bytes
print-type-size         field `.symbols`: 24 bytes
print-type-size     variant `SingleObjectHeaderMismatch`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size         field `.1`: 24 bytes
print-type-size     variant `SerializeValueWithSchema`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.value`: 24 bytes, alignment: 8 bytes
print-type-size         field `.value_type`: 16 bytes
print-type-size         field `.schema`: 8 bytes
print-type-size     variant `SchemaResolutionError`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 48 bytes, alignment: 8 bytes
print-type-size     variant `AmbiguousSchemaDefinition`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 48 bytes, alignment: 8 bytes
print-type-size     variant `NoEntryInLookupTable`: 56 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size         field `.1`: 24 bytes
print-type-size     variant `ConvertToUtf8`: 48 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 40 bytes, alignment: 8 bytes
print-type-size     variant `ValidationWithReason`: 48 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.reason`: 24 bytes, alignment: 8 bytes
print-type-size         field `.value`: 8 bytes
print-type-size         field `.schema`: 8 bytes
print-type-size     variant `InvalidSchemaName`: 48 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size         field `.1`: 16 bytes
print-type-size     variant `InvalidNamespace`: 48 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size         field `.1`: 16 bytes
print-type-size     variant `ConvertStrToUuid`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size     variant `ConvertSliceToUuid`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size     variant `GetRecord`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.expected`: 24 bytes, alignment: 8 bytes
print-type-size         field `.other`: 8 bytes
print-type-size     variant `GetLogicalTypeVariant`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size     variant `GetLogicalTypeFieldType`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size     variant `GetComplexType`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size     variant `EnumDefaultWrongType`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size     variant `GetFixedSizeFieldPositive`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size     variant `SerializeRecordFieldWithSchema`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.field_name`: 16 bytes, alignment: 8 bytes
print-type-size         field `.record_schema`: 8 bytes
print-type-size         field `.error`: 8 bytes
print-type-size     variant `UuidFromSlice`: 40 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 32 bytes, alignment: 8 bytes
print-type-size     variant `EncodeValueAsSchemaError`: 33 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.supported_schema`: 24 bytes, alignment: 8 bytes
print-type-size         field `.value_kind`: 1 bytes
print-type-size     variant `NameCollision`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `GetEnumSymbol`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `GetField`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `ParsePrimitive`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `EnumSymbolName`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `FieldName`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `FieldNameDuplicate`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `InvalidSchemaRecord`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `EnumSymbolDuplicate`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `SerializeValue`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `DeserializeValue`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `InvalidMetadataKey`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `CodecNotSupported`: 32 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 24 bytes, alignment: 8 bytes
print-type-size     variant `ConvertToUtf8Error`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 16 bytes, alignment: 8 bytes
print-type-size     variant `MemoryAllocation`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.desired`: 8 bytes, alignment: 8 bytes
print-type-size         field `.maximum`: 8 bytes
print-type-size     variant `SignExtend`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.requested`: 8 bytes, alignment: 8 bytes
print-type-size         field `.needed`: 8 bytes
print-type-size     variant `ReadFixed`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size         field `.1`: 8 bytes
print-type-size     variant `GetUnionVariant`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.index`: 8 bytes, alignment: 8 bytes
print-type-size         field `.num_variants`: 8 bytes
print-type-size     variant `EnumSymbolIndex`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.index`: 8 bytes, alignment: 8 bytes
print-type-size         field `.num_variants`: 8 bytes
print-type-size     variant `GetScaleAndPrecision`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.scale`: 8 bytes, alignment: 8 bytes
print-type-size         field `.precision`: 8 bytes
print-type-size     variant `GetScaleWithFixedSize`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.size`: 8 bytes, alignment: 8 bytes
print-type-size         field `.precision`: 8 bytes
print-type-size     variant `ComparePrecisionAndSize`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.precision`: 8 bytes, alignment: 8 bytes
print-type-size         field `.num_bytes`: 8 bytes
print-type-size     variant `CompareFixedSizes`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.size`: 8 bytes, alignment: 8 bytes
print-type-size         field `.n`: 8 bytes
print-type-size     variant `GetEnumValue`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.index`: 8 bytes, alignment: 8 bytes
print-type-size         field `.nsymbols`: 8 bytes
print-type-size     variant `GetDecimalMetadataFromJson`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 16 bytes, alignment: 8 bytes
print-type-size     variant `GetU64FromJson`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 16 bytes, alignment: 8 bytes
print-type-size     variant `GetI64FromJson`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 16 bytes, alignment: 8 bytes
print-type-size     variant `GetPrecisionOrScaleFromJson`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 16 bytes, alignment: 8 bytes
print-type-size     variant `DecimalPrecisionLessThanScale`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.precision`: 8 bytes, alignment: 8 bytes
print-type-size         field `.scale`: 8 bytes
print-type-size     variant `FixedDefaultLenSizeMismatch`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size         field `.1`: 8 bytes
print-type-size     variant `EncodeDecimalAsFixedError`: 24 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size         field `.1`: 8 bytes
print-type-size     variant `GetArray`: 17 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.other`: 8 bytes, alignment: 8 bytes
print-type-size         field `.expected`: 1 bytes
print-type-size     variant `GetMap`: 17 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.other`: 8 bytes, alignment: 8 bytes
print-type-size         field `.expected`: 1 bytes
print-type-size     variant `SnappyCrc32`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.expected`: 4 bytes, alignment: 4 bytes
print-type-size         field `.actual`: 4 bytes
print-type-size     variant `FixedValue`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `BytesValue`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetUuidFromStringValue`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadBoolean`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadBytes`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadString`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadDouble`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadFloat`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadDuration`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ConvertFixedToUuid`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetUuid`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetBigDecimal`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetDecimalFixedBytes`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ResolveDuration`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ResolveDecimal`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetU8`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ConvertLengthToI32`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.1`: 8 bytes, alignment: 8 bytes
print-type-size         field `.0`: 0 bytes
print-type-size     variant `GetDate`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetTimeMillis`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetTimeMicros`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetTimestampMillis`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetTimestampMicros`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetTimestampNanos`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetLocalTimestampMillis`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetLocalTimestampMicros`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetLocalTimestampNanos`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetNull`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetBoolean`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetInt`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetLong`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetDouble`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetFloat`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetBytes`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetString`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetEnum`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `GetStringForFixed`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ConvertU64ToUsize`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.1`: 8 bytes, alignment: 8 bytes
print-type-size         field `.0`: 0 bytes
print-type-size     variant `ConvertI64ToUsize`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.1`: 8 bytes, alignment: 8 bytes
print-type-size         field `.0`: 0 bytes
print-type-size     variant `ParseSchemaJson`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadSchemaFromReader`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `DecimalPrecisionMuBePositive`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.precision`: 8 bytes, alignment: 8 bytes
print-type-size     variant `BigDecimalLen`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `DeflateCompress`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `DeflateCompressFinish`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `DeflateDecompress`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ZstdCompress`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ZstdDecompress`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadHeader`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadMarker`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadBlockMarker`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadIntoBuf`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ReadVariableIntegerBytes`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ZagI32`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.1`: 8 bytes, alignment: 8 bytes
print-type-size         field `.0`: 0 bytes
print-type-size     variant `WriteBytes`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `FlushWriter`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `WriteMarker`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ConvertJsonToString`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ConvertF64ToJson`: 16 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 8 bytes, alignment: 8 bytes
print-type-size     variant `ConvertU32ToUsize`: 12 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.1`: 4 bytes, alignment: 4 bytes
print-type-size         field `.0`: 0 bytes
print-type-size     variant `ConvertI32ToUsize`: 12 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.1`: 4 bytes, alignment: 4 bytes
print-type-size         field `.0`: 0 bytes
print-type-size     variant `GetDefaultUnion`: 10 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.1`: 1 bytes, alignment: 1 bytes
print-type-size         field `.0`: 1 bytes
print-type-size     variant `BoolValue`: 9 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 1 bytes, alignment: 1 bytes
print-type-size     variant `ResolveDecimalSchema`: 9 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 1 bytes, alignment: 1 bytes
print-type-size     variant `MapKeyType`: 9 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 1 bytes, alignment: 1 bytes
print-type-size     variant `Validation`: 0 bytes
print-type-size     variant `GetEnumUnknownIndexValue`: 0 bytes
print-type-size     variant `EmptyUnion`: 0 bytes
print-type-size     variant `GetNameField`: 0 bytes
print-type-size     variant `GetNameFieldFromRecord`: 0 bytes
print-type-size     variant `GetNestedUnion`: 0 bytes
print-type-size     variant `GetUnionDuplicate`: 0 bytes
print-type-size     variant `ParseSchemaFromValidJson`: 0 bytes
print-type-size     variant `BigDecimalSign`: 0 bytes
print-type-size     variant `BigDecimalScale`: 0 bytes
print-type-size     variant `GetLogicalTypeField`: 0 bytes
print-type-size     variant `GetComplexTypeField`: 0 bytes
print-type-size     variant `GetRecordFieldsJson`: 0 bytes
print-type-size     variant `GetEnumSymbolsField`: 0 bytes
print-type-size     variant `GetEnumSymbols`: 0 bytes
print-type-size     variant `GetArrayItemsField`: 0 bytes
print-type-size     variant `GetMapValuesField`: 0 bytes
print-type-size     variant `GetFixedSizeField`: 0 bytes
print-type-size     variant `HeaderMagic`: 0 bytes
print-type-size     variant `GetAvroSchemaFromMap`: 0 bytes
print-type-size     variant `GetHeaderMetadata`: 0 bytes
print-type-size     variant `GetBlockMarker`: 0 bytes
print-type-size     variant `IntegerOverflow`: 0 bytes
print-type-size     variant `ReadBlock`: 0 bytes
print-type-size     variant `FileHeaderAlreadyWritten`: 0 bytes
print-type-size     variant `IllegalSingleObjectWriterState`: 0 bytes
print-type-size     variant `BadCodecMetadata`: 0 bytes
```

</details>