### PR TITLE
refactor: Replace `Once` with now stable `OnceLock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "serial_test",
  "sha2",
  "snap",
  "strum",
@@ -497,83 +496,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,15 +643,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,45 +734,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -980,15 +858,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,27 +961,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
-
-[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,31 +1020,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serial_test"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
-dependencies = [
- "futures",
- "log",
- "once_cell",
- "parking_lot",
- "scc",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,18 +1035,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "slab"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snap"

--- a/avro/Cargo.toml
+++ b/avro/Cargo.toml
@@ -88,7 +88,6 @@ criterion = { default-features = false, version = "0.7.0" }
 hex-literal = { default-features = false, version = "1.0.0" }
 md-5 = { default-features = false, version = "0.10.6" }
 pretty_assertions = { workspace = true }
-serial_test = "3.2.0"
 sha2 = { default-features = false, version = "0.10.9" }
 paste = { default-features = false, version = "1.0.15" }
 rstest = { default-features = false, version = "0.26.1" }

--- a/avro/src/de.rs
+++ b/avro/src/de.rs
@@ -766,15 +766,12 @@ mod tests {
     use num_bigint::BigInt;
     use pretty_assertions::assert_eq;
     use serde::{Deserialize, Serialize};
-    use serial_test::serial;
-    use std::sync::atomic::Ordering;
     use uuid::Uuid;
 
     use apache_avro_test_helper::TestResult;
 
-    use crate::Decimal;
-
     use super::*;
+    use crate::Decimal;
 
     #[derive(PartialEq, Eq, Serialize, Deserialize, Debug)]
     pub struct StringEnum {
@@ -1541,26 +1538,10 @@ mod tests {
     }
 
     #[test]
-    #[serial(serde_is_human_readable)]
-    fn avro_3747_human_readable_false() -> TestResult {
-        use serde::de::Deserializer as SerdeDeserializer;
-
-        let is_human_readable = false;
-        crate::util::SERDE_HUMAN_READABLE.store(is_human_readable, Ordering::Release);
-
-        let deser = &Deserializer::new(&Value::Null);
-
-        assert_eq!(deser.is_human_readable(), is_human_readable);
-
-        Ok(())
-    }
-
-    #[test]
-    #[serial(serde_is_human_readable)]
     fn avro_3747_human_readable_true() -> TestResult {
         use serde::de::Deserializer as SerdeDeserializer;
 
-        crate::util::SERDE_HUMAN_READABLE.store(true, Ordering::Release);
+        assert!(crate::util::is_human_readable());
 
         let deser = &Deserializer::new(&Value::Null);
 

--- a/avro/src/ser.rs
+++ b/avro/src/ser.rs
@@ -492,8 +492,6 @@ mod tests {
     use apache_avro_test_helper::TestResult;
     use pretty_assertions::assert_eq;
     use serde::{Deserialize, Serialize};
-    use serial_test::serial;
-    use std::sync::atomic::Ordering;
 
     #[derive(Debug, Deserialize, Serialize, Clone)]
     struct Test {
@@ -1021,23 +1019,10 @@ mod tests {
     }
 
     #[test]
-    #[serial(serde_is_human_readable)]
-    fn avro_3747_human_readable_false() {
-        use serde::ser::Serializer as SerdeSerializer;
-
-        crate::util::SERDE_HUMAN_READABLE.store(false, Ordering::Release);
-
-        let ser = &mut Serializer {};
-
-        assert_eq!(ser.is_human_readable(), false);
-    }
-
-    #[test]
-    #[serial(serde_is_human_readable)]
     fn avro_3747_human_readable_true() {
         use serde::ser::Serializer as SerdeSerializer;
 
-        crate::util::SERDE_HUMAN_READABLE.store(true, Ordering::Release);
+        assert!(crate::util::is_human_readable());
 
         let ser = &mut Serializer {};
 

--- a/avro/src/ser_schema.rs
+++ b/avro/src/ser_schema.rs
@@ -1773,11 +1773,9 @@ mod tests {
     use num_bigint::{BigInt, Sign};
     use serde::Serialize;
     use serde_bytes::{ByteArray, Bytes};
-    use serial_test::serial;
     use std::{
         collections::{BTreeMap, HashMap},
         marker::PhantomData,
-        sync::atomic::Ordering,
     };
     use uuid::Uuid;
 
@@ -2418,7 +2416,6 @@ mod tests {
     }
 
     #[test]
-    #[serial(serde_is_human_readable)]
     fn test_serialize_bigdecimal() -> TestResult {
         let schema = Schema::parse_str(
             r#"{
@@ -2427,7 +2424,7 @@ mod tests {
         }"#,
         )?;
 
-        crate::util::SERDE_HUMAN_READABLE.store(true, Ordering::Release);
+        assert!(crate::util::is_human_readable());
         let mut buffer: Vec<u8> = Vec::new();
         let names = HashMap::new();
         let mut serializer = SchemaAwareWriteSerializer::new(&mut buffer, &schema, &names, None);
@@ -2441,7 +2438,6 @@ mod tests {
     }
 
     #[test]
-    #[serial(serde_is_human_readable)]
     fn test_serialize_uuid() -> TestResult {
         let schema = Schema::parse_str(
             r#"{
@@ -2450,7 +2446,7 @@ mod tests {
         }"#,
         )?;
 
-        crate::util::SERDE_HUMAN_READABLE.store(true, Ordering::Release);
+        assert!(crate::util::is_human_readable());
         let mut buffer: Vec<u8> = Vec::new();
         let names = HashMap::new();
         let mut serializer = SchemaAwareWriteSerializer::new(&mut buffer, &schema, &names, None);
@@ -2718,7 +2714,6 @@ mod tests {
     }
 
     #[test]
-    #[serial(serde_is_human_readable)] // for BigDecimal and Uuid
     fn test_serialize_recursive_record() -> TestResult {
         let schema = Schema::parse_str(
             r#"{
@@ -2745,7 +2740,7 @@ mod tests {
             inner_record: Option<Box<TestRecord>>,
         }
 
-        crate::util::SERDE_HUMAN_READABLE.store(true, Ordering::Release);
+        assert!(crate::util::is_human_readable());
         let mut buffer: Vec<u8> = Vec::new();
         let rs = ResolvedSchema::try_from(&schema)?;
         let mut serializer =

--- a/avro/src/util.rs
+++ b/avro/src/util.rs
@@ -19,10 +19,7 @@ use crate::{AvroResult, error::Details, schema::Documentation};
 use serde_json::{Map, Value};
 use std::{
     io::{Read, Write},
-    sync::{
-        Once,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
-    },
+    sync::OnceLock,
 };
 
 /// Maximum number of bytes that can be allocated when decoding
@@ -30,15 +27,15 @@ use std::{
 /// data, whose length field might be interpreted as enormous.
 /// See max_allocation_bytes to change this limit.
 pub const DEFAULT_MAX_ALLOCATION_BYTES: usize = 512 * 1024 * 1024;
-static MAX_ALLOCATION_BYTES: AtomicUsize = AtomicUsize::new(DEFAULT_MAX_ALLOCATION_BYTES);
-static MAX_ALLOCATION_BYTES_ONCE: Once = Once::new();
+static MAX_ALLOCATION_BYTES: OnceLock<usize> = OnceLock::new();
 
 /// Whether to set serialization & deserialization traits
 /// as `human_readable` or not.
 /// See [set_serde_human_readable] to change this value.
 // crate-visible for testing
-pub(crate) static SERDE_HUMAN_READABLE: AtomicBool = AtomicBool::new(true);
-static SERDE_HUMAN_READABLE_ONCE: Once = Once::new();
+pub(crate) static SERDE_HUMAN_READABLE: OnceLock<bool> = OnceLock::new();
+/// Whether the serializer and deserializer should indicate to types that the format is human-readable.
+pub const DEFAULT_SERDE_HUMAN_READABLE: bool = true;
 
 pub trait MapHelper {
     fn string(&self, key: &str) -> Option<String>;
@@ -144,18 +141,13 @@ fn decode_variable<R: Read>(reader: &mut R) -> AvroResult<u64> {
     Ok(i)
 }
 
-/// Set a new maximum number of bytes that can be allocated when decoding data.
-/// Once called, the limit cannot be changed.
+/// Set the maximum number of bytes that can be allocated when decoding data.
 ///
-/// **NOTE** This function must be called before decoding **any** data. The
-/// library leverages [`std::sync::Once`](https://doc.rust-lang.org/std/sync/struct.Once.html)
-/// to set the limit either when calling this method, or when decoding for
-/// the first time.
+/// This function only changes the setting once. On subsequent calls the value will stay the same
+/// as the first time it is called. It is automatically called on first allocation and defaults to
+/// [`DEFAULT_MAX_ALLOCATION_BYTES`].
 pub fn max_allocation_bytes(num_bytes: usize) -> usize {
-    MAX_ALLOCATION_BYTES_ONCE.call_once(|| {
-        MAX_ALLOCATION_BYTES.store(num_bytes, Ordering::Release);
-    });
-    MAX_ALLOCATION_BYTES.load(Ordering::Acquire)
+    *MAX_ALLOCATION_BYTES.get_or_init(|| num_bytes)
 }
 
 pub fn safe_len(len: usize) -> AvroResult<usize> {
@@ -172,22 +164,20 @@ pub fn safe_len(len: usize) -> AvroResult<usize> {
     }
 }
 
-/// Set whether serializing/deserializing is marked as human readable in serde traits.
-/// This will adjust the return value of `is_human_readable()` for both.
-/// Once called, the value cannot be changed.
+/// Set whether the serializer and deserializer should indicate to types that the format is human-readable.
 ///
-/// **NOTE** This function must be called before serializing/deserializing **any** data. The
-/// library leverages [`std::sync::Once`](https://doc.rust-lang.org/std/sync/struct.Once.html)
-/// to set the limit either when calling this method, or when decoding for
-/// the first time.
-pub fn set_serde_human_readable(human_readable: bool) {
-    SERDE_HUMAN_READABLE_ONCE.call_once(|| {
-        SERDE_HUMAN_READABLE.store(human_readable, Ordering::Release);
-    });
+/// This function only changes the setting once. On subsequent calls the value will stay the same
+/// as the first time it is called. It is automatically called on first allocation and defaults to
+/// [`DEFAULT_SERDE_HUMAN_READABLE`].
+///
+/// *NOTE*: Changing this setting can change the output of [`from_value`](crate::from_value) and the
+/// accepted input of [`to_value`].
+pub fn set_serde_human_readable(human_readable: bool) -> bool {
+    *SERDE_HUMAN_READABLE.get_or_init(|| human_readable)
 }
 
 pub(crate) fn is_human_readable() -> bool {
-    SERDE_HUMAN_READABLE.load(Ordering::Acquire)
+    *SERDE_HUMAN_READABLE.get_or_init(|| DEFAULT_SERDE_HUMAN_READABLE)
 }
 
 #[cfg(test)]

--- a/avro/tests/serde_human_readable_false.rs
+++ b/avro/tests/serde_human_readable_false.rs
@@ -1,0 +1,45 @@
+use apache_avro::{AvroSchema, Schema, SpecificSingleObjectWriter};
+use apache_avro_test_helper::TestResult;
+use serde::{Deserialize, Serialize};
+
+#[test]
+fn avro_rs_53_uuid_with_fixed() -> TestResult {
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Comment {
+        id: apache_avro::Uuid,
+    }
+
+    impl AvroSchema for Comment {
+        fn get_schema() -> Schema {
+            Schema::parse_str(
+                r#"{
+                        "type" : "record",
+                        "name" : "Comment",
+                        "fields" : [ {
+                          "name" : "id",
+                          "type" : {
+                            "type" : "fixed",
+                            "size" : 16,
+                            "logicalType" : "uuid",
+                            "name": "FixedUUID"
+                          }
+                        } ]
+                     }"#,
+            )
+            .expect("Invalid Comment Avro schema")
+        }
+    }
+
+    let payload = Comment {
+        id: "de2df598-9948-4988-b00a-a41c0e287398".parse()?,
+    };
+    let mut buffer = Vec::new();
+
+    // serialize the Uuid as Bytes
+    assert!(!apache_avro::set_serde_human_readable(false));
+    let bytes = SpecificSingleObjectWriter::<Comment>::with_capacity(64)?
+        .write_ref(&payload, &mut buffer)?;
+    assert_eq!(bytes, 27);
+
+    Ok(())
+}

--- a/avro/tests/serde_human_readable_true.rs
+++ b/avro/tests/serde_human_readable_true.rs
@@ -1,0 +1,45 @@
+use apache_avro::{AvroSchema, Schema, SpecificSingleObjectWriter};
+use apache_avro_test_helper::TestResult;
+use serde::{Deserialize, Serialize};
+
+#[test]
+fn avro_rs_53_uuid_with_fixed_true() -> TestResult {
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Comment {
+        id: apache_avro::Uuid,
+    }
+
+    impl AvroSchema for Comment {
+        fn get_schema() -> Schema {
+            Schema::parse_str(
+                r#"{
+                        "type" : "record",
+                        "name" : "Comment",
+                        "fields" : [ {
+                          "name" : "id",
+                          "type" : {
+                            "type" : "fixed",
+                            "size" : 16,
+                            "logicalType" : "uuid",
+                            "name": "FixedUUID"
+                          }
+                        } ]
+                     }"#,
+            )
+            .expect("Invalid Comment Avro schema")
+        }
+    }
+
+    let payload = Comment {
+        id: "de2df598-9948-4988-b00a-a41c0e287398".parse()?,
+    };
+    let mut buffer = Vec::new();
+
+    // serialize the Uuid as String
+    assert!(apache_avro::set_serde_human_readable(true));
+    let bytes = SpecificSingleObjectWriter::<Comment>::with_capacity(64)?
+        .write_ref(&payload, &mut buffer)?;
+    assert_eq!(bytes, 47);
+
+    Ok(())
+}


### PR DESCRIPTION
This refactor splits a unit test into two integration tests as it's no longer possible to overwrite `SERDE_HUMAN_READABLE` after it has been set. By splitting it into two integration tests, they don't share global state and can thus modify it for the test.

I've also removed the unit tests that test that the `Serializer`/ `Deserializer` correctly use `SERDE_HUMAN_READABLE` for their `is_human_readable` implementation as these structs are not accessible from a integration test. I've kept the half of the tests that test for `SERDE_HUMAN_READABLE == true`. If this implementation is ever changed it will also affect the integration tests so it's still being tested.

Closes #253 