### PR TITLE
fix: Set -o pipefail in CI

### DIFF
--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -250,6 +250,7 @@ jobs:
           key: ${{ runner.os }}-target-cache1-stable-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install wasm-pack
+        shell: /usr/bin/bash -o pipefail -e {0}
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Build the Web Assembly demo app


### PR DESCRIPTION
By default `curl | sh` will have `sh`'s exit code, with this option `curl`'s exit code is propagated.