### PR TITLE
fix: Change TestError from uninhabited enum to an empty struct

### DIFF
--- a/avro_test_helper/src/lib.rs
+++ b/avro_test_helper/src/lib.rs
@@ -51,7 +51,7 @@ fn after_all() {
 
 /// A custom error type for tests.
 #[derive(Debug)]
-pub enum TestError {}
+pub struct TestError {}
 
 /// A converter of any error into [TestError].
 /// It is used to print better error messages in the tests.


### PR DESCRIPTION
Fixes the problem with latest nightly:
```
error: unreachable expression
    --> avro/src/schema.rs:6054:24
     |
6054 |                 return Err(format!("Expected Details::InvalidNamespace, got {other:?}").into());
     |                        ^^^^-------------------------------------------------------------------^
     |                        |   |
     |                        |   any code following this expression is unreachable
     |                        unreachable expression
     |
note: this expression has type `TestError`, which is uninhabited
```