### PR TITLE
feat!: Change default of `is_human_readable` to `false`

### DIFF
--- a/avro/src/de.rs
+++ b/avro/src/de.rs
@@ -1538,14 +1538,14 @@ mod tests {
     }
 
     #[test]
-    fn avro_3747_human_readable_true() -> TestResult {
+    fn avro_3747_human_readable_false() -> TestResult {
         use serde::de::Deserializer as SerdeDeserializer;
 
-        assert!(crate::util::is_human_readable());
+        assert!(!crate::util::is_human_readable());
 
         let deser = &Deserializer::new(&Value::Null);
 
-        assert!(deser.is_human_readable());
+        assert!(!deser.is_human_readable());
 
         Ok(())
     }

--- a/avro/src/ser.rs
+++ b/avro/src/ser.rs
@@ -1019,13 +1019,13 @@ mod tests {
     }
 
     #[test]
-    fn avro_3747_human_readable_true() {
+    fn avro_3747_human_readable_false() {
         use serde::ser::Serializer as SerdeSerializer;
 
-        assert!(crate::util::is_human_readable());
+        assert!(!crate::util::is_human_readable());
 
         let ser = &mut Serializer {};
 
-        assert!(ser.is_human_readable());
+        assert!(!ser.is_human_readable());
     }
 }

--- a/avro/src/ser_schema.rs
+++ b/avro/src/ser_schema.rs
@@ -2424,7 +2424,6 @@ mod tests {
         }"#,
         )?;
 
-        assert!(crate::util::is_human_readable());
         let mut buffer: Vec<u8> = Vec::new();
         let names = HashMap::new();
         let mut serializer = SchemaAwareWriteSerializer::new(&mut buffer, &schema, &names, None);
@@ -2446,7 +2445,7 @@ mod tests {
         }"#,
         )?;
 
-        assert!(crate::util::is_human_readable());
+        assert!(!crate::util::is_human_readable());
         let mut buffer: Vec<u8> = Vec::new();
         let names = HashMap::new();
         let mut serializer = SchemaAwareWriteSerializer::new(&mut buffer, &schema, &names, None);
@@ -2471,9 +2470,7 @@ mod tests {
         assert_eq!(
             buffer.as_slice(),
             &[
-                72, b'8', b'c', b'2', b'8', b'd', b'a', b'8', b'1', b'-', b'2', b'3', b'8', b'c',
-                b'-', b'4', b'3', b'2', b'6', b'-', b'b', b'd', b'd', b'd', b'-', b'4', b'e', b'3',
-                b'd', b'0', b'0', b'c', b'c', b'5', b'0', b'9', b'9'
+                32, 140, 40, 218, 129, 35, 140, 67, 38, 189, 221, 78, 61, 0, 204, 80, 153
             ]
         );
 
@@ -2740,7 +2737,7 @@ mod tests {
             inner_record: Option<Box<TestRecord>>,
         }
 
-        assert!(crate::util::is_human_readable());
+        assert!(!crate::util::is_human_readable());
         let mut buffer: Vec<u8> = Vec::new();
         let rs = ResolvedSchema::try_from(&schema)?;
         let mut serializer =
@@ -2764,12 +2761,10 @@ mod tests {
         assert_eq!(
             buffer.as_slice(),
             &[
-                8, 116, 101, 115, 116, 20, 10, 6, 0, 195, 104, 4, 72, 56, 99, 50, 56, 100, 97, 56,
-                49, 45, 50, 51, 56, 99, 45, 52, 51, 50, 54, 45, 98, 100, 100, 100, 45, 52, 101, 51,
-                100, 48, 48, 99, 99, 53, 48, 57, 56, 2, 20, 105, 110, 110, 101, 114, 95, 116, 101,
-                115, 116, 200, 1, 8, 4, 78, 70, 4, 72, 56, 99, 50, 56, 100, 97, 56, 49, 45, 50, 51,
-                56, 99, 45, 52, 51, 50, 54, 45, 98, 100, 100, 100, 45, 52, 101, 51, 100, 48, 48,
-                99, 99, 53, 48, 57, 57, 0
+                8, 116, 101, 115, 116, 20, 10, 6, 0, 195, 104, 4, 32, 140, 40, 218, 129, 35, 140,
+                67, 38, 189, 221, 78, 61, 0, 204, 80, 152, 2, 20, 105, 110, 110, 101, 114, 95, 116,
+                101, 115, 116, 200, 1, 8, 4, 78, 70, 4, 32, 140, 40, 218, 129, 35, 140, 67, 38,
+                189, 221, 78, 61, 0, 204, 80, 153, 0
             ]
         );
 

--- a/avro/src/util.rs
+++ b/avro/src/util.rs
@@ -35,7 +35,7 @@ static MAX_ALLOCATION_BYTES: OnceLock<usize> = OnceLock::new();
 // crate-visible for testing
 pub(crate) static SERDE_HUMAN_READABLE: OnceLock<bool> = OnceLock::new();
 /// Whether the serializer and deserializer should indicate to types that the format is human-readable.
-pub const DEFAULT_SERDE_HUMAN_READABLE: bool = true;
+pub const DEFAULT_SERDE_HUMAN_READABLE: bool = false;
 
 pub trait MapHelper {
     fn string(&self, key: &str) -> Option<String>;


### PR DESCRIPTION
According to the Serde documentation this is the correct value as Avro is not a human readable format. This will make files more compact and have the serializer do less work depending on the type.

This is a breaking change, but it is easy for a user to go back to the previous default by calling `set_human_readable(true)` which we can add to the changelog.