### PR TITLE
RFC - Split serialization logic from writing logic to make concurrent writes faster

### DIFF
--- a/avro/src/lib.rs
+++ b/avro/src/lib.rs
@@ -868,6 +868,7 @@ mod decode;
 mod duration;
 mod encode;
 mod reader;
+mod ser;
 mod ser_schema;
 mod util;
 mod writer;
@@ -878,7 +879,6 @@ pub mod rabin;
 pub mod schema;
 pub mod schema_compatibility;
 pub mod schema_equality;
-pub mod ser;
 pub mod types;
 pub mod validator;
 

--- a/avro/src/lib.rs
+++ b/avro/src/lib.rs
@@ -868,7 +868,6 @@ mod decode;
 mod duration;
 mod encode;
 mod reader;
-mod ser;
 mod ser_schema;
 mod util;
 mod writer;
@@ -879,6 +878,7 @@ pub mod rabin;
 pub mod schema;
 pub mod schema_compatibility;
 pub mod schema_equality;
+pub mod ser;
 pub mod types;
 pub mod validator;
 

--- a/avro/src/writer.rs
+++ b/avro/src/writer.rs
@@ -498,15 +498,6 @@ impl<'a, W: Write> Writer<'a, W> {
         }
     }
 
-    /// Disables writing the header into the writer.
-    /// This is useful for contexts when you just want to serialize blocks of Avro data
-    /// without creating a well formed Avro file.
-    /// 
-    /// Please use at your own risk
-    pub fn disable_header_write(&mut self) {
-        self.has_header = true;
-    }
-
     /// Create an Avro header based on schema, codec and sync marker.
     fn header(&self) -> Result<Vec<u8>, Error> {
         let schema_bytes = serde_json::to_string(self.schema)

--- a/avro/src/writer.rs
+++ b/avro/src/writer.rs
@@ -63,7 +63,7 @@ pub struct Writer<'a, W: Write> {
     user_metadata: HashMap<String, Value>,
 }
 
-struct AvroSerializedBuffer {
+pub struct AvroSerializedBuffer {
     buffer: Vec<u8>,
     num_values: usize,
 }

--- a/avro/src/writer.rs
+++ b/avro/src/writer.rs
@@ -63,6 +63,11 @@ pub struct Writer<'a, W: Write> {
     user_metadata: HashMap<String, Value>,
 }
 
+pub struct AvroSerializedBuffer {
+    buffer: Vec<u8>,
+    num_values: usize,
+}
+
 impl<'a, W: Write> Writer<'a, W> {
     /// Creates a `Writer` given a `Schema` and something implementing the `io::Write` trait to write
     /// to.
@@ -302,6 +307,69 @@ impl<'a, W: Write> Writer<'a, W> {
         num_bytes += self.flush()?;
 
         Ok(num_bytes)
+    }
+
+    /**
+     * Writes a previously serialized bundle of rows directly to the writer (see self::serialize_ser).
+     * This will not flush any intermediate buffers - only write the provided buffer
+     * directly to the underlying writer.
+     */
+    pub fn extend_avro_serialized_buffer(
+        &mut self,
+        avro_serialized_buffer: AvroSerializedBuffer,
+    ) -> AvroResult<usize> {
+        let mut num_bytes = self.maybe_write_header()?;
+        let buffer = avro_serialized_buffer.buffer;
+        let stream_len = buffer.len();
+        let num_values = avro_serialized_buffer.num_values;
+
+        num_bytes += self.append_raw(&num_values.into(), &Schema::Long)?
+            + self.append_raw(&stream_len.into(), &Schema::Long)?
+            + self
+                .writer
+                .write(buffer.as_ref())
+                .map_err(Details::WriteBytes)?
+            + self.append_marker()?;
+
+        self.writer.flush().map_err(Details::FlushWriter)?;
+
+        Ok(num_bytes)
+    }
+
+    /**
+     * Serialize an iterator of serde::Serialize objects into an AvroSerializedBuffer. This call
+     * does not need a `mut` self - so it is safe to call from multiple threads to prepare data
+     * for writing.
+     */
+    pub fn serialize_ser<I, T: Serialize>(&self, values: I) -> AvroResult<AvroSerializedBuffer>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let rs = match self.resolved_schema {
+            Some(ref rs) => rs,
+            None => &ResolvedSchema::try_from(self.schema)?,
+        };
+
+        let mut buffer = Vec::new();
+        let mut count = 0;
+        let mut serializer = SchemaAwareWriteSerializer::new(
+            &mut buffer,
+            self.schema,
+            rs.get_names(),
+            None,
+        );
+
+        for value in values {
+            value.serialize(&mut serializer)?;
+            count += 1;
+        }
+
+        self.codec.compress(&mut buffer)?;
+
+        Ok(AvroSerializedBuffer {
+            buffer,
+            num_values: count,
+        })
     }
 
     /// Extend a `Writer` by appending each `Value` from a slice, while also performing schema

--- a/avro/src/writer.rs
+++ b/avro/src/writer.rs
@@ -63,6 +63,8 @@ pub struct Writer<'a, W: Write> {
     user_metadata: HashMap<String, Value>,
 }
 
+/// A buffer containing Avro serialized data ready to be written to a Writer
+/// See [Writer::serialize_ser] and [Writer::extend_avro_serialized_buffer]
 pub struct AvroSerializedBuffer {
     buffer: Vec<u8>,
     num_values: usize,
@@ -309,7 +311,7 @@ impl<'a, W: Write> Writer<'a, W> {
         Ok(num_bytes)
     }
 
-    /// Writes a previously serialized bundle of rows directly to the writer (see self::serialize_ser).
+    /// Writes a previously serialized bundle of rows directly to the writer (see [serialize_ser](Self::serialize_ser)).
     /// This will not flush any intermediate buffers - only write the provided buffer
     /// directly to the underlying writer.
     pub fn extend_avro_serialized_buffer(
@@ -334,11 +336,9 @@ impl<'a, W: Write> Writer<'a, W> {
         Ok(num_bytes)
     }
 
-    /**
-     * Serialize an iterator of serde::Serialize objects into an AvroSerializedBuffer. This call
-     * does not need a `mut` self - so it is safe to call from multiple threads to prepare data
-     * for writing.
-     */
+    /// Serialize an iterator of serde::Serialize objects into an AvroSerializedBuffer. This call
+    /// does not need a `mut` self - so it is safe to call from multiple threads to prepare data
+    /// for writing.
     pub fn serialize_ser<I, T: Serialize>(&self, values: I) -> AvroResult<AvroSerializedBuffer>
     where
         I: IntoIterator<Item = T>,
@@ -350,12 +350,8 @@ impl<'a, W: Write> Writer<'a, W> {
 
         let mut buffer = Vec::new();
         let mut count = 0;
-        let mut serializer = SchemaAwareWriteSerializer::new(
-            &mut buffer,
-            self.schema,
-            rs.get_names(),
-            None,
-        );
+        let mut serializer =
+            SchemaAwareWriteSerializer::new(&mut buffer, self.schema, rs.get_names(), None);
 
         for value in values {
             value.serialize(&mut serializer)?;

--- a/avro/src/writer.rs
+++ b/avro/src/writer.rs
@@ -63,7 +63,7 @@ pub struct Writer<'a, W: Write> {
     user_metadata: HashMap<String, Value>,
 }
 
-pub struct AvroSerializedBuffer {
+struct AvroSerializedBuffer {
     buffer: Vec<u8>,
     num_values: usize,
 }

--- a/avro/src/writer.rs
+++ b/avro/src/writer.rs
@@ -309,11 +309,9 @@ impl<'a, W: Write> Writer<'a, W> {
         Ok(num_bytes)
     }
 
-    /**
-     * Writes a previously serialized bundle of rows directly to the writer (see self::serialize_ser).
-     * This will not flush any intermediate buffers - only write the provided buffer
-     * directly to the underlying writer.
-     */
+    /// Writes a previously serialized bundle of rows directly to the writer (see self::serialize_ser).
+    /// This will not flush any intermediate buffers - only write the provided buffer
+    /// directly to the underlying writer.
     pub fn extend_avro_serialized_buffer(
         &mut self,
         avro_serialized_buffer: AvroSerializedBuffer,

--- a/avro/src/writer.rs
+++ b/avro/src/writer.rs
@@ -430,6 +430,15 @@ impl<'a, W: Write> Writer<'a, W> {
         }
     }
 
+    /// Disables writing the header into the writer.
+    /// This is useful for contexts when you just want to serialize blocks of Avro data
+    /// without creating a well formed Avro file.
+    /// 
+    /// Please use at your own risk
+    pub fn disable_header_write(&mut self) {
+        self.has_header = true;
+    }
+
     /// Create an Avro header based on schema, codec and sync marker.
     fn header(&self) -> Result<Vec<u8>, Error> {
         let schema_bytes = serde_json::to_string(self.schema)


### PR DESCRIPTION
Working on adding better ability to concurrently process avro - this moves the heavy work of serializing + compressing to not require a `mut` anymore. This allows users to wrap the serialization logic in whatever async/processing runtime they want easily, without introducing any opinions or bloat.

- `serialize_ser` does the heavy lifting, returning a private struct
- `extend_avro_serialized_buffer` accepts this struct, writing it directly to the writer and performing all avro bookkeeping.

Let me know what you think :)  its a lil messy factoring wise, but I think the abstraction is fairly reasonable, effective, and safe.