### PR TITLE
fix: documentation linked to private items

### DIFF
--- a/avro/src/lib.rs
+++ b/avro/src/lib.rs
@@ -953,7 +953,6 @@ mod encode;
 mod reader;
 mod ser;
 mod ser_schema;
-mod util;
 mod writer;
 
 pub mod error;
@@ -963,6 +962,7 @@ pub mod schema;
 pub mod schema_compatibility;
 pub mod schema_equality;
 pub mod types;
+pub mod util;
 pub mod validator;
 
 pub use crate::{
@@ -989,7 +989,6 @@ pub use reader::{
 };
 pub use schema::{AvroSchema, Schema};
 pub use ser::to_value;
-pub use util::{max_allocation_bytes, set_serde_human_readable};
 pub use uuid::Uuid;
 pub use writer::{
     GenericSingleObjectWriter, SpecificSingleObjectWriter, Writer, WriterBuilder, to_avro_datum,
@@ -1001,6 +1000,43 @@ pub use apache_avro_derive::*;
 
 /// A convenience type alias for `Result`s with `Error`s.
 pub type AvroResult<T> = Result<T, Error>;
+
+/// Set the maximum number of bytes that can be allocated when decoding data.
+///
+/// This function only changes the setting once. On subsequent calls the value will stay the same
+/// as the first time it is called. It is automatically called on first allocation and defaults to
+/// [`util::DEFAULT_MAX_ALLOCATION_BYTES`].
+///
+/// # Returns
+/// The configured maximum, which might be different from what the function was called with if the
+/// value was already set before.
+#[deprecated(
+    since = "0.21.0",
+    note = "Please use apache_avro::util::max_allocation_bytes"
+)]
+pub fn max_allocation_bytes(num_bytes: usize) -> usize {
+    util::max_allocation_bytes(num_bytes)
+}
+
+/// Set whether the serializer and deserializer should indicate to types that the format is human-readable.
+///
+/// This function only changes the setting once. On subsequent calls the value will stay the same
+/// as the first time it is called. It is automatically called on first allocation and defaults to
+/// [`util::DEFAULT_SERDE_HUMAN_READABLE`].
+///
+/// *NOTE*: Changing this setting can change the output of [`from_value`] and the
+/// accepted input of [`to_value`].
+///
+/// # Returns
+/// The configured human-readable value, which might be different from what the function was called
+/// with if the value was already set before.
+#[deprecated(
+    since = "0.21.0",
+    note = "Please use apache_avro::util::set_serde_human_readable"
+)]
+pub fn set_serde_human_readable(human_readable: bool) -> bool {
+    util::set_serde_human_readable(human_readable)
+}
 
 #[cfg(test)]
 mod tests {

--- a/avro/tests/serde_human_readable_false.rs
+++ b/avro/tests/serde_human_readable_false.rs
@@ -36,7 +36,7 @@ fn avro_rs_53_uuid_with_fixed() -> TestResult {
     let mut buffer = Vec::new();
 
     // serialize the Uuid as Bytes
-    assert!(!apache_avro::set_serde_human_readable(false));
+    assert!(!apache_avro::util::set_serde_human_readable(false));
     let bytes = SpecificSingleObjectWriter::<Comment>::with_capacity(64)?
         .write_ref(&payload, &mut buffer)?;
     assert_eq!(bytes, 27);

--- a/avro/tests/serde_human_readable_true.rs
+++ b/avro/tests/serde_human_readable_true.rs
@@ -36,7 +36,7 @@ fn avro_rs_53_uuid_with_fixed_true() -> TestResult {
     let mut buffer = Vec::new();
 
     // serialize the Uuid as String
-    assert!(apache_avro::set_serde_human_readable(true));
+    assert!(apache_avro::util::set_serde_human_readable(true));
     let bytes = SpecificSingleObjectWriter::<Comment>::with_capacity(64)?
         .write_ref(&payload, &mut buffer)?;
     assert_eq!(bytes, 47);


### PR DESCRIPTION
I've made the items public, by making the `util` module public. Any items in there that should not be public have been marked `pub(crate)`.

As `set_serde_human_readable` and `max_allocation_bytes` are now also available through the `util` path, I've deprecated them in the root of the crate. As you can't deprecate a re-export, I've done this by wrapping them in a function and deprecating that function.

I've also updated the documentation of `set_serde_human_readable` and `max_allocation_bytes` to explain the return value and that it can be different than the user expects.