### PR TITLE
feat!: resolve schema(ta) in the builder of `Writer`

### DIFF
--- a/avro/README.md
+++ b/avro/README.md
@@ -206,7 +206,7 @@ associated type provided by the library to specify the data we want to serialize
 use apache_avro::types::Record;
 use apache_avro::Writer;
 // a writer needs a schema and something to write to
-let mut writer = Writer::new(&schema, Vec::new());
+let mut writer = Writer::new(&schema, Vec::new()).unwrap();
 
 // the Record type models our Record schema
 let mut record = Record::new(writer.schema()).unwrap();
@@ -248,7 +248,7 @@ struct Test {
 }
 
 // a writer needs a schema and something to write to
-let mut writer = Writer::new(&schema, Vec::new());
+let mut writer = Writer::new(&schema, Vec::new()).unwrap();
 
 // the structure models our Record schema
 let test = Test {
@@ -421,7 +421,7 @@ fn main() -> Result<(), Error> {
 
     println!("{:?}", schema);
 
-    let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Deflate(DeflateSettings::default()));
+    let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Deflate(DeflateSettings::default())).unwrap();
 
     let mut record = Record::new(writer.schema()).unwrap();
     record.put("a", 27i64);
@@ -547,7 +547,7 @@ fn main() -> Result<(), Error> {
 
     println!("{:?}", schema);
 
-    let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Deflate(DeflateSettings::default()));
+    let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Deflate(DeflateSettings::default())).unwrap()   ;
 
     let mut record = Record::new(writer.schema()).unwrap();
     record.put("decimal_fixed", Decimal::from(9936.to_bigint().unwrap().to_signed_bytes_be()));
@@ -809,7 +809,7 @@ fn serde_byte_array() {
   ];
 
   // Serialize records to Avro binary format with the schema
-  let mut writer = apache_avro::Writer::new(&schema, Vec::new());
+  let mut writer = apache_avro::Writer::new(&schema, Vec::new()).unwrap();
   for record in &records {
       writer.append_ser(record).unwrap();
   }

--- a/avro/benches/serde.rs
+++ b/avro/benches/serde.rs
@@ -239,13 +239,13 @@ fn make_records_ser<T: Serialize + Clone>(record: T, count: usize) -> Vec<T> {
 }
 
 fn write(schema: &Schema, records: &[Value]) -> AvroResult<Vec<u8>> {
-    let mut writer = Writer::new(schema, Vec::new());
+    let mut writer = Writer::new(schema, Vec::new())?;
     writer.extend_from_slice(records).unwrap();
     writer.into_inner()
 }
 
 fn write_ser<T: Serialize>(schema: &Schema, records: &[T]) -> AvroResult<Vec<u8>> {
-    let mut writer = Writer::new(schema, Vec::new());
+    let mut writer = Writer::new(schema, Vec::new())?;
     writer.extend_ser(records)?;
     writer.into_inner()
 }

--- a/avro/examples/benchmark.rs
+++ b/avro/examples/benchmark.rs
@@ -59,7 +59,7 @@ fn benchmark(
         let records = records.clone();
 
         let start = Instant::now();
-        let mut writer = Writer::new(schema, BufWriter::new(Vec::new()));
+        let mut writer = Writer::new(schema, BufWriter::new(Vec::new()))?;
         writer.extend(records)?;
 
         let duration = Instant::now().duration_since(start);

--- a/avro/examples/generate_interop_data.rs
+++ b/avro/examples/generate_interop_data.rs
@@ -97,7 +97,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let file_name = format!("{}/rust{suffix}.avro", &data_folder);
         let output_file = std::fs::File::create(&file_name)?;
 
-        let mut writer = Writer::with_codec(&schema, BufWriter::new(output_file), codec);
+        let mut writer = Writer::with_codec(&schema, BufWriter::new(output_file), codec)?;
         write_user_metadata(&mut writer)?;
 
         let datum = create_datum(&schema);

--- a/avro/src/bigdecimal.rs
+++ b/avro/src/bigdecimal.rs
@@ -156,7 +156,7 @@ mod tests {
             .schema(&schema)
             .codec(codec)
             .writer(Vec::new())
-            .build();
+            .build()?;
 
         writer.append(record.clone())?;
         writer.flush()?;

--- a/avro/src/lib.rs
+++ b/avro/src/lib.rs
@@ -208,7 +208,7 @@
 //! # "#;
 //! # let schema = Schema::parse_str(raw_schema).unwrap();
 //! // a writer needs a schema and something to write to
-//! let mut writer = Writer::new(&schema, Vec::new());
+//! let mut writer = Writer::new(&schema, Vec::new()).unwrap();
 //!
 //! // the Record type models our Record schema
 //! let mut record = Record::new(writer.schema()).unwrap();
@@ -263,7 +263,7 @@
 //! # "#;
 //! # let schema = Schema::parse_str(raw_schema).unwrap();
 //! // a writer needs a schema and something to write to
-//! let mut writer = Writer::new(&schema, Vec::new());
+//! let mut writer = Writer::new(&schema, Vec::new()).unwrap();
 //!
 //! // the structure models our Record schema
 //! let test = Test {
@@ -353,7 +353,7 @@
 //! #     }
 //! # "#;
 //! # let schema = Schema::parse_str(raw_schema).unwrap();
-//! # let mut writer = Writer::new(&schema, Vec::new());
+//! # let mut writer = Writer::new(&schema, Vec::new()).unwrap();
 //! # let mut record = Record::new(writer.schema()).unwrap();
 //! # record.put("a", 27i64);
 //! # record.put("b", "foo");
@@ -382,7 +382,7 @@
 //! #     }
 //! # "#;
 //! # let writer_schema = Schema::parse_str(writer_raw_schema).unwrap();
-//! # let mut writer = Writer::new(&writer_schema, Vec::new());
+//! # let mut writer = Writer::new(&writer_schema, Vec::new()).unwrap();
 //! # let mut record = Record::new(writer.schema()).unwrap();
 //! # record.put("a", 27i64);
 //! # record.put("b", "foo");
@@ -442,7 +442,7 @@
 //! # "#;
 //! # let schema = Schema::parse_str(raw_schema).unwrap();
 //! # let schema = Schema::parse_str(raw_schema).unwrap();
-//! # let mut writer = Writer::new(&schema, Vec::new());
+//! # let mut writer = Writer::new(&schema, Vec::new()).unwrap();
 //! # let mut record = Record::new(writer.schema()).unwrap();
 //! # record.put("a", 27i64);
 //! # record.put("b", "foo");
@@ -487,7 +487,7 @@
 //! #     }
 //! # "#;
 //! # let schema = Schema::parse_str(raw_schema).unwrap();
-//! # let mut writer = Writer::new(&schema, Vec::new());
+//! # let mut writer = Writer::new(&schema, Vec::new()).unwrap();
 //! # let test = Test {
 //! #     a: 27,
 //! #     b: "foo".to_owned(),
@@ -533,7 +533,7 @@
 //!
 //!     println!("{:?}", schema);
 //!
-//!     let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Deflate(DeflateSettings::default()));
+//!     let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Deflate(DeflateSettings::default())).unwrap();
 //!
 //!     let mut record = Record::new(writer.schema()).unwrap();
 //!     record.put("a", 27i64);
@@ -659,7 +659,7 @@
 //!
 //!     println!("{:?}", schema);
 //!
-//!     let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Deflate(DeflateSettings::default()));
+//!     let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Deflate(DeflateSettings::default())).unwrap()   ;
 //!
 //!     let mut record = Record::new(writer.schema()).unwrap();
 //!     record.put("decimal_fixed", Decimal::from(9936.to_bigint().unwrap().to_signed_bytes_be()));
@@ -921,7 +921,7 @@
 //!   ];
 //!
 //!   // Serialize records to Avro binary format with the schema
-//!   let mut writer = apache_avro::Writer::new(&schema, Vec::new());
+//!   let mut writer = apache_avro::Writer::new(&schema, Vec::new()).unwrap();
 //!   for record in &records {
 //!       writer.append_ser(record).unwrap();
 //!   }
@@ -1080,7 +1080,7 @@ mod tests {
         "#;
         let writer_schema = Schema::parse_str(writer_raw_schema).unwrap();
         let reader_schema = Schema::parse_str(reader_raw_schema).unwrap();
-        let mut writer = Writer::with_codec(&writer_schema, Vec::new(), Codec::Null);
+        let mut writer = Writer::with_codec(&writer_schema, Vec::new(), Codec::Null).unwrap();
         let mut record = Record::new(writer.schema()).unwrap();
         record.put("a", 27i64);
         record.put("b", "foo");
@@ -1121,7 +1121,7 @@ mod tests {
             }
         "#;
         let schema = Schema::parse_str(raw_schema).unwrap();
-        let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Null);
+        let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Null).unwrap();
         let mut record = Record::new(writer.schema()).unwrap();
         record.put("a", 27i64);
         record.put("b", "foo");
@@ -1163,7 +1163,7 @@ mod tests {
             }
         "#;
         let writer_schema = Schema::parse_str(writer_raw_schema).unwrap();
-        let mut writer = Writer::with_codec(&writer_schema, Vec::new(), Codec::Null);
+        let mut writer = Writer::with_codec(&writer_schema, Vec::new(), Codec::Null).unwrap();
         let mut record = Record::new(writer.schema()).unwrap();
         record.put("a", 27i64);
         record.put("b", "foo");
@@ -1196,7 +1196,7 @@ mod tests {
 
         let schema = Schema::parse_str(raw_schema).unwrap();
 
-        // Would allocated 18446744073709551605 bytes
+        // Would allocate 18446744073709551605 bytes
         let illformed: &[u8] = &[0x3e, 0x15, 0xff, 0x1f, 0x15, 0xff];
 
         let value = from_avro_datum(&schema, &mut &*illformed, None);

--- a/avro/src/reader.rs
+++ b/avro/src/reader.rs
@@ -812,7 +812,7 @@ mod tests {
         use crate::writer::Writer;
 
         let schema = Schema::parse_str(SCHEMA)?;
-        let mut writer = Writer::new(&schema, Vec::new());
+        let mut writer = Writer::new(&schema, Vec::new())?;
 
         let mut user_meta_data: HashMap<String, Vec<u8>> = HashMap::new();
         user_meta_data.insert(

--- a/avro/src/schema.rs
+++ b/avro/src/schema.rs
@@ -5249,7 +5249,7 @@ mod tests {
         let avro_value = crate::to_value(foo)?;
         assert!(avro_value.validate(&schema));
 
-        let mut writer = crate::Writer::new(&schema, Vec::new());
+        let mut writer = crate::Writer::new(&schema, Vec::new())?;
 
         // schema validation happens here
         writer.append(avro_value)?;

--- a/avro/src/schema_compatibility.rs
+++ b/avro/src/schema_compatibility.rs
@@ -1451,7 +1451,7 @@ mod tests {
       "#;
         let writer_schema = Schema::parse_str(writer_raw_schema)?;
         let reader_schema = Schema::parse_str(reader_raw_schema)?;
-        let mut writer = Writer::with_codec(&writer_schema, Vec::new(), Codec::Null);
+        let mut writer = Writer::with_codec(&writer_schema, Vec::new(), Codec::Null)?;
         let mut record = Record::new(writer.schema()).unwrap();
         record.put("a", 27i64);
         record.put("b", "foo");
@@ -1515,7 +1515,7 @@ mod tests {
       "#;
         let writer_schema = Schema::parse_str(writer_raw_schema)?;
         let reader_schema = Schema::parse_str(reader_raw_schema)?;
-        let mut writer = Writer::with_codec(&writer_schema, Vec::new(), Codec::Null);
+        let mut writer = Writer::with_codec(&writer_schema, Vec::new(), Codec::Null)?;
         let mut record = Record::new(writer.schema()).unwrap();
         record.put("a", 27i64);
         record.put("b", "foo");

--- a/avro/tests/append_to_existing.rs
+++ b/avro/tests/append_to_existing.rs
@@ -37,7 +37,7 @@ fn avro_3630_append_to_an_existing_file() -> TestResult {
 
     let marker = read_marker(&bytes[..]);
 
-    let mut writer = Writer::append_to(&schema, bytes, marker);
+    let mut writer = Writer::append_to(&schema, bytes, marker)?;
 
     writer
         .append(create_datum(&schema, 2))
@@ -59,7 +59,10 @@ fn avro_3630_append_to_an_existing_file() -> TestResult {
 fn avro_4031_append_to_file_using_multiple_writers() -> TestResult {
     let schema = Schema::parse_str(SCHEMA).expect("Cannot parse the schema");
 
-    let mut first_writer = Writer::builder().schema(&schema).writer(Vec::new()).build();
+    let mut first_writer = Writer::builder()
+        .schema(&schema)
+        .writer(Vec::new())
+        .build()?;
     first_writer.append(create_datum(&schema, -42))?;
     let mut resulting_bytes = first_writer.into_inner()?;
     let first_marker = read_marker(&resulting_bytes);
@@ -69,7 +72,7 @@ fn avro_4031_append_to_file_using_multiple_writers() -> TestResult {
         .has_header(true)
         .marker(first_marker)
         .writer(Vec::new())
-        .build();
+        .build()?;
     second_writer.append(create_datum(&schema, 42))?;
     resulting_bytes.append(&mut second_writer.into_inner()?);
 
@@ -81,7 +84,7 @@ fn avro_4031_append_to_file_using_multiple_writers() -> TestResult {
 
 /// Simulates reading from a pre-existing .avro file and returns its bytes
 fn get_avro_bytes(schema: &Schema) -> Vec<u8> {
-    let mut writer = Writer::new(schema, Vec::new());
+    let mut writer = Writer::new(schema, Vec::new()).unwrap();
     writer
         .append(create_datum(schema, 1))
         .expect("An error while appending data");

--- a/avro/tests/avro-rs-226.rs
+++ b/avro/tests/avro-rs-226.rs
@@ -25,7 +25,7 @@ where
     T: Serialize + DeserializeOwned + Debug + PartialEq + Clone,
 {
     let record2 = record.clone();
-    let mut writer = Writer::new(schema, vec![]);
+    let mut writer = Writer::new(schema, vec![])?;
     writer.append_ser(record)?;
     let bytes_written = writer.into_inner()?;
 

--- a/avro/tests/avro-rs-285-bytes_deserialization.rs
+++ b/avro/tests/avro-rs-285-bytes_deserialization.rs
@@ -45,7 +45,7 @@ fn avro_rs_285_bytes_deserialization_round_trip() -> TestResult {
     ];
 
     // serialize records to Avro binary format with schema
-    let mut writer = apache_avro::Writer::new(&schema, Vec::new());
+    let mut writer = apache_avro::Writer::new(&schema, Vec::new())?;
     for record in &records {
         writer.append_ser(record)?;
     }
@@ -93,7 +93,7 @@ fn avro_rs_285_bytes_deserialization_filtered_round_trip() -> TestResult {
     ];
 
     // serialize records to Avro binary format with schema
-    let mut writer = apache_avro::Writer::new(&schema, Vec::new());
+    let mut writer = apache_avro::Writer::new(&schema, Vec::new())?;
     for record in &records {
         writer.append_ser(record)?;
     }

--- a/avro/tests/codecs.rs
+++ b/avro/tests/codecs.rs
@@ -72,7 +72,7 @@ fn avro_4032_codec_settings(codec: Codec) -> TestResult {
         }"#,
     )?;
 
-    let mut writer = Writer::with_codec(&schema, Vec::new(), codec);
+    let mut writer = Writer::with_codec(&schema, Vec::new(), codec)?;
     let mut record = Record::new(writer.schema()).unwrap();
     record.put("f1", 27_i32);
     record.put("f2", "foo");

--- a/avro/tests/schema.rs
+++ b/avro/tests/schema.rs
@@ -811,7 +811,7 @@ fn test_record_schema_with_cyclic_references() -> TestResult {
         ]),
     );
 
-    let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Null);
+    let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Null)?;
     if let Err(err) = writer.append(datum) {
         panic!("An error occurred while writing datum: {err:?}")
     }
@@ -1038,7 +1038,7 @@ fn test_avro_3847_union_field_with_default_value_of_ref() -> TestResult {
     }
     "#;
     let writer_schema = Schema::parse_str(writer_schema_str)?;
-    let mut writer = Writer::new(&writer_schema, Vec::new());
+    let mut writer = Writer::new(&writer_schema, Vec::new())?;
     let mut record = Record::new(writer.schema()).ok_or("Expected Some(Record), but got None")?;
     record.put("f1", Value::Record(vec![("f1_1".to_string(), 10.into())]));
     writer.append(record)?;
@@ -1111,7 +1111,7 @@ fn test_avro_3847_union_field_with_default_value_of_ref() -> TestResult {
     }
     "#;
     let writer_schema = Schema::parse_str(writer_schema_str)?;
-    let mut writer = Writer::new(&writer_schema, Vec::new());
+    let mut writer = Writer::new(&writer_schema, Vec::new())?;
     let mut record = Record::new(writer.schema()).ok_or("Expected Some(Record), but got None")?;
     record.put("f1", Value::Enum(1, "b".to_string()));
     writer.append(record)?;
@@ -1171,7 +1171,7 @@ fn test_avro_3847_union_field_with_default_value_of_ref() -> TestResult {
     }
     "#;
     let writer_schema = Schema::parse_str(writer_schema_str)?;
-    let mut writer = Writer::new(&writer_schema, Vec::new());
+    let mut writer = Writer::new(&writer_schema, Vec::new())?;
     let mut record = Record::new(writer.schema()).ok_or("Expected Some(Record), but got None")?;
     record.put("f1", Value::Fixed(3, vec![0, 1, 2]));
     writer.append(record)?;
@@ -1242,7 +1242,7 @@ fn test_avro_3847_union_field_with_default_value_of_ref_with_namespace() -> Test
     }
     "#;
     let writer_schema = Schema::parse_str(writer_schema_str)?;
-    let mut writer = Writer::new(&writer_schema, Vec::new());
+    let mut writer = Writer::new(&writer_schema, Vec::new())?;
     let mut record = Record::new(writer.schema()).ok_or("Expected Some(Record), but got None")?;
     record.put("f1", Value::Record(vec![("f1_1".to_string(), 10.into())]));
     writer.append(record)?;
@@ -1317,7 +1317,7 @@ fn test_avro_3847_union_field_with_default_value_of_ref_with_namespace() -> Test
     }
     "#;
     let writer_schema = Schema::parse_str(writer_schema_str)?;
-    let mut writer = Writer::new(&writer_schema, Vec::new());
+    let mut writer = Writer::new(&writer_schema, Vec::new())?;
     let mut record = Record::new(writer.schema()).ok_or("Expected Some(Record), but got None")?;
     record.put("f1", Value::Enum(1, "b".to_string()));
     writer.append(record)?;
@@ -1379,7 +1379,7 @@ fn test_avro_3847_union_field_with_default_value_of_ref_with_namespace() -> Test
     }
     "#;
     let writer_schema = Schema::parse_str(writer_schema_str)?;
-    let mut writer = Writer::new(&writer_schema, Vec::new());
+    let mut writer = Writer::new(&writer_schema, Vec::new())?;
     let mut record = Record::new(writer.schema()).ok_or("Expected Some(Record), but got None")?;
     record.put("f1", Value::Fixed(3, vec![0, 1, 2]));
     writer.append(record)?;
@@ -1451,7 +1451,7 @@ fn test_avro_3847_union_field_with_default_value_of_ref_with_enclosing_namespace
     }
     "#;
     let writer_schema = Schema::parse_str(writer_schema_str)?;
-    let mut writer = Writer::new(&writer_schema, Vec::new());
+    let mut writer = Writer::new(&writer_schema, Vec::new())?;
     let mut record = Record::new(writer.schema()).ok_or("Expected Some(Record), but got None")?;
     record.put("f1", Value::Record(vec![("f1_1".to_string(), 10.into())]));
     writer.append(record)?;
@@ -1526,7 +1526,7 @@ fn test_avro_3847_union_field_with_default_value_of_ref_with_enclosing_namespace
     }
     "#;
     let writer_schema = Schema::parse_str(writer_schema_str)?;
-    let mut writer = Writer::new(&writer_schema, Vec::new());
+    let mut writer = Writer::new(&writer_schema, Vec::new())?;
     let mut record = Record::new(writer.schema()).ok_or("Expected Some(Record), but got None")?;
     record.put("f1", Value::Enum(1, "b".to_string()));
     writer.append(record)?;
@@ -1588,7 +1588,7 @@ fn test_avro_3847_union_field_with_default_value_of_ref_with_enclosing_namespace
     }
     "#;
     let writer_schema = Schema::parse_str(writer_schema_str)?;
-    let mut writer = Writer::new(&writer_schema, Vec::new());
+    let mut writer = Writer::new(&writer_schema, Vec::new())?;
     let mut record = Record::new(writer.schema()).ok_or("Expected Some(Record), but got None")?;
     record.put("f1", Value::Fixed(3, vec![0, 1, 2]));
     writer.append(record)?;
@@ -1649,7 +1649,7 @@ fn write_schema_for_default_value_test() -> apache_avro::AvroResult<Vec<u8>> {
     }
     "#;
     let writer_schema = Schema::parse_str(writer_schema_str)?;
-    let mut writer = Writer::new(&writer_schema, Vec::new());
+    let mut writer = Writer::new(&writer_schema, Vec::new())?;
     let mut record = Record::new(writer.schema())
         .ok_or("Expected Some(Record), but got None")
         .unwrap();
@@ -1932,7 +1932,7 @@ fn test_avro_3851_read_default_value_for_ref_record_field() -> TestResult {
     }
     "#;
     let writer_schema = Schema::parse_str(writer_schema_str)?;
-    let mut writer = Writer::new(&writer_schema, Vec::new());
+    let mut writer = Writer::new(&writer_schema, Vec::new())?;
     let mut record = Record::new(writer.schema()).ok_or("Expected Some(Record), but got None")?;
     record.put("f1", Value::Record(vec![("f1_1".to_string(), 10.into())]));
     writer.append(record)?;
@@ -1997,7 +1997,7 @@ fn test_avro_3851_read_default_value_for_enum() -> TestResult {
     }
     "#;
     let writer_schema = Schema::parse_str(writer_schema_str)?;
-    let mut writer = Writer::new(&writer_schema, Vec::new());
+    let mut writer = Writer::new(&writer_schema, Vec::new())?;
     writer.append("c")?;
 
     let reader_schema_str = r#"
@@ -2364,7 +2364,7 @@ fn avro_rs_66_test_independent_canonical_form_missing_ref() -> TestResult {
 fn avro_rs_181_single_null_record() -> TestResult {
     let mut buff = Cursor::new(Vec::new());
     let schema = Schema::parse_str(r#""null""#)?;
-    let mut writer = Writer::new(&schema, &mut buff);
+    let mut writer = Writer::new(&schema, &mut buff)?;
     writer.append(serde_json::Value::Null)?;
     writer.into_inner()?;
     buff.set_position(0);

--- a/avro/tests/shared.rs
+++ b/avro/tests/shared.rs
@@ -115,7 +115,7 @@ fn test_folder(folder: &str) -> Result<(), ErrorsDesc> {
         let reader =
             Reader::with_schema(&schema, BufReader::new(&file)).expect("Can't read data.avro");
 
-        let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Null);
+        let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Null).unwrap();
 
         let mut records: Vec<Value> = vec![];
 

--- a/avro/tests/to_from_avro_datum_schemata.rs
+++ b/avro/tests/to_from_avro_datum_schemata.rs
@@ -107,7 +107,7 @@ fn test_avro_3683_multiple_schemata_writer_reader() -> TestResult {
     let schema_b = schemata[1];
     let mut output: Vec<u8> = Vec::new();
 
-    let mut writer = Writer::with_schemata(schema_b, schemata.clone(), &mut output, Codec::Null);
+    let mut writer = Writer::with_schemata(schema_b, schemata.clone(), &mut output, Codec::Null)?;
     writer.append(record.clone())?;
     writer.flush()?;
     drop(writer); //drop the writer so that `output` is no more referenced mutably

--- a/avro/tests/union_schema.rs
+++ b/avro/tests/union_schema.rs
@@ -71,7 +71,7 @@ where
 {
     let mut encoded: Vec<u8> = Vec::new();
     let mut writer =
-        Writer::with_schemata(schema, schemata.iter().collect(), &mut encoded, Codec::Null);
+        Writer::with_schemata(schema, schemata.iter().collect(), &mut encoded, Codec::Null)?;
     writer.append_ser(input)?;
     writer.flush()?;
     drop(writer); //drop the writer so that `encoded` is no more referenced mutably

--- a/avro_derive/README.md
+++ b/avro_derive/README.md
@@ -56,7 +56,7 @@ struct Test {
 // derived schema, always valid or code fails to compile with a descriptive message
 let schema = Test::get_schema();
 
-let mut writer = Writer::new(&schema, Vec::new());
+let mut writer = Writer::new(&schema, Vec::new()).unwrap();
 let test = Test {
     a: 27,
     b: "foo".to_owned(),

--- a/avro_derive/tests/derive.rs
+++ b/avro_derive/tests/derive.rs
@@ -52,7 +52,7 @@ mod test_derive {
         T: Serialize + AvroSchema,
     {
         let schema = T::get_schema();
-        let mut writer = Writer::new(&schema, Vec::new());
+        let mut writer = Writer::new(&schema, Vec::new()).unwrap();
         if let Err(e) = writer.append_ser(obj) {
             panic!("{e:?}");
         }

--- a/wasm-demo/tests/demos.rs
+++ b/wasm-demo/tests/demos.rs
@@ -68,7 +68,8 @@ fn write_read() {
         &schema,
         BufWriter::new(Vec::with_capacity(200)),
         Codec::Null,
-    );
+    )
+    .unwrap();
     writer.append(record).unwrap();
     writer.flush().unwrap();
     let bytes = writer.into_inner().unwrap().into_inner().unwrap();


### PR DESCRIPTION
This moves the resolving error to the place where it should happen and simplifies `Writer` functions.

This is a breaking change, as the builder now returns a `AvroResult`.

The actual relevant code is in the first 400 lines of `avro/src/writer.rs`. All other changes are adding `?` or `.unwrap()` to test code.