### PR TITLE
chore: Fix clippy errors with Rust 1.90.1

### DIFF
--- a/avro/src/de.rs
+++ b/avro/src/de.rs
@@ -1050,7 +1050,7 @@ mod tests {
             Val4(u64),
         }
 
-        let data = vec![
+        let data = [
             (
                 TestNullExternalEnum {
                     a: NullExternalEnum::Val1,

--- a/avro/src/schema.rs
+++ b/avro/src/schema.rs
@@ -2565,7 +2565,7 @@ pub mod derive {
             let inner_schema = T::get_schema_in_ctxt(named_schemas, enclosing_namespace);
             Schema::Union(UnionSchema {
                 schemas: vec![Schema::Null, inner_schema.clone()],
-                variant_index: vec![Schema::Null, inner_schema]
+                variant_index: [Schema::Null, inner_schema]
                     .iter()
                     .enumerate()
                     .map(|(idx, s)| (SchemaKind::from(s), idx))

--- a/avro/tests/io.rs
+++ b/avro/tests/io.rs
@@ -264,7 +264,7 @@ fn test_schema_promotion() -> TestResult {
     // Each schema is present in order of promotion (int -> long, long -> float, float -> double)
     // Each value represents the expected decoded value when promoting a value previously encoded with a promotable schema
     let promotable_schemas = [r#""int""#, r#""long""#, r#""float""#, r#""double""#];
-    let promotable_values = vec![
+    let promotable_values = [
         Value::Int(219),
         Value::Long(219),
         Value::Float(219.0),


### PR DESCRIPTION
Use an array instead of a Vec where possible