### PR TITLE
feat: Make compression_level() pub

### DIFF
--- a/avro/src/codec.rs
+++ b/avro/src/codec.rs
@@ -30,7 +30,9 @@ impl DeflateSettings {
         DeflateSettings { compression_level }
     }
 
-    fn compression_level(&self) -> u8 {
+    /// Get the compression level as a `u8`, note that this means the [`miniz_oxide::deflate::CompressionLevel::DefaultCompression`] variant
+    /// will appear as `255`, this is normalized by the [`miniz_oxide`] crate later.
+    pub fn compression_level(&self) -> u8 {
         self.compression_level as u8
     }
 }


### PR DESCRIPTION
All other compressions settings make the struct field itself pub, I'm guessing this isn't done here to streamline the flow into the miniz_oxide crate which accepts a u8 then converts it to i32.
I suggest just making this function pub at least, so we can get the current compression_level, if not modify it.