### PR TITLE
fix: `test_overflow` doesn't test for overflow

### DIFF
--- a/avro/src/util.rs
+++ b/avro/src/util.rs
@@ -296,8 +296,13 @@ mod tests {
 
     #[test]
     fn test_overflow() {
-        let causes_left_shift_overflow: &[u8] = &[0xe1, 0xe1, 0xe1, 0xe1, 0xe1];
-        assert!(decode_variable(&mut &*causes_left_shift_overflow).is_err());
+        let causes_left_shift_overflow: &[u8] = &[0xe1; 10];
+        assert!(matches!(
+            decode_variable(&mut &*causes_left_shift_overflow)
+                .unwrap_err()
+                .details(),
+            Details::IntegerOverflow
+        ));
     }
 
     #[test]


### PR DESCRIPTION
The test still "worked" because an error was still returned, but the error was the `ReadVariableIntegerBytes`.