### PR TITLE
test: uncomment attribute test

### DIFF
--- a/avro_test_helper/src/data.rs
+++ b/avro_test_helper/src/data.rs
@@ -362,8 +362,8 @@ pub const OTHER_ATTRIBUTES_EXAMPLES: &[(&str, bool)] = &[
                 "cp_int": 1,
                 "cp_array": [ 1, 2, 3, 4],
                 "fields": [
-                    {"name": "f1", "type": "string", "cp_object": {"a":1,"b":2}},
-                    {"name": "f2", "type": "long", "cp_null": null}
+                    {"name": "f1", "type": "fixed", "size": 16, "cp_object": {"a":1,"b":2}},
+                    {"name": "f2", "type": "fixed", "size": 8, "cp_null": null}
                 ]
             }"#,
         true,
@@ -381,7 +381,6 @@ pub const OTHER_ATTRIBUTES_EXAMPLES: &[(&str, bool)] = &[
             }"#,
         true,
     ),
-    (r#"{"type": "long", "date": "true"}"#, true),
 ];
 
 pub const DECIMAL_LOGICAL_TYPE: &[(&str, bool)] = &[


### PR DESCRIPTION
While looking for leftover TODO's in my own code I noticed this test.
I had too slightly modify it, as we don't store custom attributes for basic types.

I also deleted a commented test which was not relevant anymore.