### PR TITLE
fix: Union serialization

### DIFF
--- a/avro/src/error.rs
+++ b/avro/src/error.rs
@@ -274,6 +274,14 @@ pub enum Details {
     #[error("Could not find matching type in {schema:?} for {value:?}")]
     FindUnionVariant { schema: UnionSchema, value: Value },
 
+    #[error("Union index {index} out of bounds: {num_variants} in {schema:?} for {value:?}")]
+    UnionIndexOutOfBounds {
+        schema: UnionSchema,
+        value: Value,
+        index: usize,
+        num_variants: usize,
+    },
+
     #[error("Union type should not be empty")]
     EmptyUnion,
 

--- a/avro/src/types.rs
+++ b/avro/src/types.rs
@@ -1024,18 +1024,34 @@ impl Value {
         enclosing_namespace: &Namespace,
         field_default: &Option<JsonValue>,
     ) -> Result<Self, Error> {
-        let v = match self {
-            // Both are unions case.
-            Value::Union(_i, v) => *v,
-            // Reader is a union, but writer is not.
-            v => v,
-        };
-        let (i, inner) = schema
-            .find_schema_with_known_schemata(&v, Some(names), enclosing_namespace)
-            .ok_or_else(|| Details::FindUnionVariant {
-                schema: schema.clone(),
-                value: v.clone(),
-            })?;
+        let (i, inner, v) =
+            match self {
+                // Both are unions case.
+                Value::Union(i, v) => {
+                    let index = i as usize;
+                    let inner = schema.schemas.get(index).ok_or_else(|| {
+                        Details::UnionIndexOutOfBounds {
+                            schema: schema.clone(),
+                            value: *v.clone(),
+                            index,
+                            num_variants: schema.schemas.len(),
+                        }
+                    })?;
+
+                    (index, inner, *v)
+                }
+                // Reader is a union, but writer is not.
+                v => {
+                    let (i, inner) = schema
+                        .find_schema_with_known_schemata(&v, Some(names), enclosing_namespace)
+                        .ok_or_else(|| Details::FindUnionVariant {
+                            schema: schema.clone(),
+                            value: v.clone(),
+                        })?;
+
+                    (i, inner, v)
+                }
+            };
 
         Ok(Value::Union(
             i as u32,

--- a/avro/tests/union_serialization.rs
+++ b/avro/tests/union_serialization.rs
@@ -1,0 +1,202 @@
+use apache_avro::{AvroResult, Schema};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+struct Root {
+    field_union: Enum,
+    field_f: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+enum Enum {
+    A {},
+    B {},
+    C {
+        field_a: i64,
+        field_b: Option<String>,
+    },
+    D {
+        field_a: f32,
+        field_b: i32,
+    },
+}
+
+const SCHEMA_STR: &str = r#"{
+    "name": "Root",
+    "type": "record",
+    "fields": [
+        {"name": "field_union", "type": [
+            {
+                "name": "A",
+                "type": "record",
+                "fields": []
+            },
+            {
+                "name": "B",
+                "type": "record",
+                "fields": []
+            },
+            {
+                "name": "C",
+                "type": "record",
+                "fields": [
+                    {"name": "field_a", "type": "long"},
+                    {"name": "field_b", "type": ["null", "string"]}
+                ]
+            },
+            {
+                "name": "D",
+                "type": "record",
+                "fields": [
+                    {"name": "field_a", "type": "float"},
+                    {"name": "field_b", "type": "int"}
+                ]
+            }
+        ]},
+        {"name": "field_f", "type": "string"}
+    ]
+}"#;
+
+#[test]
+fn test_union_variants_serialization() -> AvroResult<()> {
+    let schema = Schema::parse_str(SCHEMA_STR)?;
+
+    // Test variant 0
+    {
+        let input = Root {
+            field_union: Enum::A {},
+            field_f: "test1".to_owned(),
+        };
+
+        #[rustfmt::skip]
+        let expected_bytes: [u8; 7] = [
+            // Root {
+                // field_union:
+                    0x00, // variant 0 (Enum::A) {
+                    // }
+                // field_f:
+                    0x0A, // string length = 5
+                    0x74, 0x65, 0x73, 0x74, 0x31, // UTF-8 string "test1"
+            // }
+        ];
+
+        let value = apache_avro::to_value(&input)?.resolve(&schema)?;
+        let encoded = apache_avro::to_avro_datum(&schema, value)?;
+
+        assert_eq!(encoded, expected_bytes);
+
+        let value = apache_avro::from_avro_datum(&schema, &mut encoded.as_slice(), None)?;
+        let output: Root = apache_avro::from_value(&value)?;
+
+        assert_eq!(input, output);
+    }
+
+    // Test variant 1
+    {
+        let input = Root {
+            field_union: Enum::B {},
+            field_f: "test2".to_owned(),
+        };
+
+        #[rustfmt::skip]
+        let expected_bytes: [u8; 7] = [
+            // Root {
+                // field_union:
+                    0x02, // variant 1 (Enum::B) {
+                    // }
+                // field_f:
+                    0x0A, // string length = 5
+                    0x74, 0x65, 0x73, 0x74, 0x32, // UTF-8 string "test2"
+            // }
+        ];
+
+        let value = apache_avro::to_value(&input)?.resolve(&schema)?;
+        let encoded = apache_avro::to_avro_datum(&schema, value)?;
+
+        assert_eq!(encoded, expected_bytes);
+
+        let value = apache_avro::from_avro_datum(&schema, &mut encoded.as_slice(), None)?;
+        let output: Root = apache_avro::from_value(&value)?;
+
+        assert_eq!(input, output);
+    }
+
+    // Test variant 2
+    {
+        let input = Root {
+            field_union: Enum::C {
+                field_a: 3,
+                field_b: Some("test3".to_owned()),
+            },
+            field_f: "test4".to_owned(),
+        };
+
+        #[rustfmt::skip]
+        let expected_bytes: [u8; 15] = [
+            // Root {
+                // field_union:
+                    0x04, // variant 2 (Enum::C) {
+                        // field_a:
+                            0x06, // 3
+                        // field_b:
+                            0x02, // variant 1 (Some) {
+                                0x0A, // string length = 5
+                                0x74, 0x65, 0x73, 0x74, 0x33, // UTF-8 string "test3"
+                            // }
+                    // }
+                // field_f:
+                    0x0A, // string length = 5
+                    0x74, 0x65, 0x73, 0x74, 0x34, // UTF-8 string "test4"
+            // }
+        ];
+
+        let value = apache_avro::to_value(&input)?.resolve(&schema)?;
+        let encoded = apache_avro::to_avro_datum(&schema, value)?;
+
+        assert_eq!(encoded, expected_bytes);
+
+        let value = apache_avro::from_avro_datum(&schema, &mut encoded.as_slice(), None)?;
+        let output: Root = apache_avro::from_value(&value)?;
+
+        assert_eq!(input, output);
+    }
+
+    // Test variant 3
+    {
+        let input = Root {
+            field_union: Enum::D {
+                field_a: 0.0,
+                field_b: 4,
+            },
+            field_f: "test5".to_owned(),
+        };
+
+        #[rustfmt::skip]
+        let expected_bytes: [u8; 12] = [
+            // Root {
+                // field_union:
+                    0x06, // variant 3 (Enum::D) {
+                        // field_a:
+                            0x00, 0x00, 0x00, 0x00, // 0.0
+                        // field_b:
+                            0x08, // 4
+                    // }
+                // field_f:
+                    0x0A, // string length = 5
+                    0x74, 0x65, 0x73, 0x74, 0x35, // UTF-8 string "test5"
+            // }
+        ];
+
+        let value = apache_avro::to_value(&input)?.resolve(&schema)?;
+        let encoded = apache_avro::to_avro_datum(&schema, value)?;
+
+        assert_eq!(encoded, expected_bytes);
+
+        let value = apache_avro::from_avro_datum(&schema, &mut encoded.as_slice(), None)?;
+        let output: Root = apache_avro::from_value(&value)?;
+
+        assert_eq!(input, output);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Description
Fix for the issue described here: https://github.com/apache/avro-rs/issues/365

> 1. For some reason enum variants get serialized as records with two fields:
> - "type" with an Avro enum for the discriminator,
> - "value" with a union variant containing the fields.
> instead of just serializing union variant directly. Because of this bytecode ends up being different from what's expected (there's an additional enum byte for "type"), but also schema resolution fails because it expects to find actual fields at the top level, while they are under "value".
> 2. Separately from the first issue, even if you try to use `resolve()` on a `Value` built manually, schema resolution ignores the variant number coming from `Value::Union` and tries to find a schema by simply matching the fields, which causes serialization to lose field data in some cases, depending on the order in which these variants are listed in the schema.


## Changes
- changed `SeqVariantSerializer` and `StructVariantSerializer` to serialize Enum variants as `Union(...)` directly
 instead of `Record([("type", Enum(...)) ("value, Union(...))])`;
- since they don't need to store the `variant` anymore, I removed the field and removed the lifetime annotation
 that was only needed because this field was a `&str`;
- `SeqVariantSerializer` had two implementations: `ser::SerializeTupleVariant` and `ser::SerializeStructVariant`,
 where the first one delegated everything to the second one, but the second one was never used by itself,
 so I removed it;
- changed the logic of the `resolve_union` function so that it uses the index from `Value::Union`
 to get the correct schema;
- added a new Error variant `UnionIndexOutOfBounds` for cases where this index gets out of bounds;
- wrote a test that fails before the fix and succeeds after.