### PR TITLE
fix duplicate serialization of logicalType key for logical type schemas based on fixed type

### DIFF
--- a/avro/src/schema.rs
+++ b/avro/src/schema.rs
@@ -7564,10 +7564,9 @@ mod tests {
         )?;
 
         let schema_json_str = serde_json::to_string(&schema)?;
-        let logical_type_keys: Vec<&str> = schema_json_str.matches("logicalType").collect();
 
         assert_eq!(
-            logical_type_keys.len(),
+            schema_json_str.matches("logicalType").count(),
             1,
             "Expected serialized schema to contain only one logicalType key: {schema_json_str}"
         );
@@ -7587,10 +7586,9 @@ mod tests {
         )?;
 
         let schema_json_str = serde_json::to_string(&schema)?;
-        let logical_type_keys: Vec<&str> = schema_json_str.matches("logicalType").collect();
 
         assert_eq!(
-            logical_type_keys.len(),
+            schema_json_str.matches("logicalType").count(),
             1,
             "Expected serialized schema to contain only one logicalType key: {schema_json_str}"
         );
@@ -7612,10 +7610,9 @@ mod tests {
         )?;
 
         let schema_json_str = serde_json::to_string(&schema)?;
-        let logical_type_keys: Vec<&str> = schema_json_str.matches("logicalType").collect();
 
         assert_eq!(
-            logical_type_keys.len(),
+            schema_json_str.matches("logicalType").count(),
             1,
             "Expected serialized schema to contain only one logicalType key: {schema_json_str}"
         );


### PR DESCRIPTION
I was playing around a bit with the latest avro-rs (thanks for taking my last PR!) and I noticed that in some cases, the output of `serde_json::to_string(&schema)` would result in the `logicalType` field being written twice.  It's not noticeable if you're reading the serialized json back using serde_json, since it just ignores the duplicate key, (which is why all the existing tests comparing schemas as structured json values still pass,) but it's possible that some json parsers would fail to parse such a schema.

I eventually found that the duplicate was coming from the fact that in some cases, `logicalType` shows up in the inner fixed schema's extra attributes, so it could be written once when we call `fixed_schema.serialize_to_map::<S>(map)`, and then a second time when we call `map.serialize_entry("logicalType", "decimal')`.

I'm not sure if the `Serialize` implementation for `Schema` is the place to fix it, or if we should be preventing `logicalType` from showing up in the inner fixed schema's attributes in the first place, but here's a PR that fixes it on the serialization side that you can merge if it looks good to you.

I added a few unit tests that fail with the latest from main, and pass with the changes in this PR.