### PR TITLE
chore: Disable the build of TestLogger for WASM32

### DIFF
--- a/avro_test_helper/src/logger.rs
+++ b/avro_test_helper/src/logger.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#![cfg(not(target_arch = "wasm32"))]
+
 use crate::LOG_MESSAGES;
 use log::{LevelFilter, Log, Metadata};
 use std::sync::OnceLock;
@@ -85,7 +87,6 @@ pub fn assert_logged(expected_message: &str) {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn install() {
     log::set_logger(test_logger())
         .map(|_| log::set_max_level(LevelFilter::Trace))


### PR DESCRIPTION
Until now only the install() function was not compiled for WASM32 and this led to the following warning at build time:

```
warning: struct `TestLogger` is never constructed
  --> avro_test_helper/src/logger.rs:22:8
   |
22 | struct TestLogger {
   |        ^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

warning: function `test_logger` is never used
  --> avro_test_helper/src/logger.rs:43:4
   |
43 | fn test_logger() -> &'static TestLogger {
   |    ^^^^^^^^^^^

warning: `apache-avro-test-helper` (lib) generated 2 warnings
```