### PR TITLE
feat: Simplify `Serializer`

### DIFF
--- a/avro/src/serde/ser.rs
+++ b/avro/src/serde/ser.rs
@@ -24,16 +24,15 @@ use crate::{
 use serde::{Serialize, ser};
 use std::collections::HashMap;
 
-#[derive(Clone, Default)]
-pub struct Serializer {}
+pub struct Serializer;
 
 pub struct SeqSerializer {
     items: Vec<Value>,
 }
 
-pub struct SeqVariantSerializer<'a> {
+pub struct SeqVariantSerializer {
     index: u32,
-    variant: &'a str,
+    variant: &'static str,
     items: Vec<Value>,
 }
 
@@ -46,9 +45,9 @@ pub struct StructSerializer {
     fields: Vec<(String, Value)>,
 }
 
-pub struct StructVariantSerializer<'a> {
+pub struct StructVariantSerializer {
     index: u32,
-    variant: &'a str,
+    variant: &'static str,
     fields: Vec<(String, Value)>,
 }
 
@@ -63,8 +62,8 @@ impl SeqSerializer {
     }
 }
 
-impl<'a> SeqVariantSerializer<'a> {
-    pub fn new(index: u32, variant: &'a str, len: Option<usize>) -> SeqVariantSerializer<'a> {
+impl SeqVariantSerializer {
+    pub fn new(index: u32, variant: &'static str, len: Option<usize>) -> SeqVariantSerializer {
         let items = match len {
             Some(len) => Vec::with_capacity(len),
             None => Vec::new(),
@@ -96,8 +95,8 @@ impl StructSerializer {
     }
 }
 
-impl<'a> StructVariantSerializer<'a> {
-    pub fn new(index: u32, variant: &'a str, len: usize) -> StructVariantSerializer<'a> {
+impl StructVariantSerializer {
+    pub fn new(index: u32, variant: &'static str, len: usize) -> StructVariantSerializer {
         StructVariantSerializer {
             index,
             variant,
@@ -106,16 +105,16 @@ impl<'a> StructVariantSerializer<'a> {
     }
 }
 
-impl<'b> ser::Serializer for &'b mut Serializer {
+impl ser::Serializer for Serializer {
     type Ok = Value;
     type Error = Error;
     type SerializeSeq = SeqSerializer;
     type SerializeTuple = SeqSerializer;
     type SerializeTupleStruct = SeqSerializer;
-    type SerializeTupleVariant = SeqVariantSerializer<'b>;
+    type SerializeTupleVariant = SeqVariantSerializer;
     type SerializeMap = MapSerializer;
     type SerializeStruct = StructSerializer;
-    type SerializeStructVariant = StructVariantSerializer<'b>;
+    type SerializeStructVariant = StructVariantSerializer;
 
     fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
         Ok(Value::Boolean(v))
@@ -196,7 +195,7 @@ impl<'b> ser::Serializer for &'b mut Serializer {
     where
         T: Serialize + ?Sized,
     {
-        let v = value.serialize(&mut Serializer::default())?;
+        let v = value.serialize(Serializer)?;
         Ok(Value::from(Some(v)))
     }
 
@@ -308,8 +307,7 @@ impl ser::SerializeSeq for SeqSerializer {
     where
         T: Serialize + ?Sized,
     {
-        self.items
-            .push(value.serialize(&mut Serializer::default())?);
+        self.items.push(value.serialize(Serializer)?);
         Ok(())
     }
 
@@ -350,7 +348,7 @@ impl ser::SerializeTupleStruct for SeqSerializer {
     }
 }
 
-impl ser::SerializeSeq for SeqVariantSerializer<'_> {
+impl ser::SerializeSeq for SeqVariantSerializer {
     type Ok = Value;
     type Error = Error;
 
@@ -360,7 +358,7 @@ impl ser::SerializeSeq for SeqVariantSerializer<'_> {
     {
         self.items.push(Value::Union(
             self.index,
-            Box::new(value.serialize(&mut Serializer::default())?),
+            Box::new(value.serialize(Serializer)?),
         ));
         Ok(())
     }
@@ -376,7 +374,7 @@ impl ser::SerializeSeq for SeqVariantSerializer<'_> {
     }
 }
 
-impl ser::SerializeTupleVariant for SeqVariantSerializer<'_> {
+impl ser::SerializeTupleVariant for SeqVariantSerializer {
     type Ok = Value;
     type Error = Error;
 
@@ -400,7 +398,7 @@ impl ser::SerializeMap for MapSerializer {
     where
         T: Serialize + ?Sized,
     {
-        let key = key.serialize(&mut Serializer::default())?;
+        let key = key.serialize(Serializer)?;
 
         if let Value::String(key) = key {
             self.indices.insert(key, self.values.len());
@@ -414,8 +412,7 @@ impl ser::SerializeMap for MapSerializer {
     where
         T: Serialize + ?Sized,
     {
-        self.values
-            .push(value.serialize(&mut Serializer::default())?);
+        self.values.push(value.serialize(Serializer)?);
         Ok(())
     }
 
@@ -439,10 +436,8 @@ impl ser::SerializeStruct for StructSerializer {
     where
         T: Serialize + ?Sized,
     {
-        self.fields.push((
-            name.to_owned(),
-            value.serialize(&mut Serializer::default())?,
-        ));
+        self.fields
+            .push((name.to_owned(), value.serialize(Serializer)?));
         Ok(())
     }
 
@@ -451,7 +446,7 @@ impl ser::SerializeStruct for StructSerializer {
     }
 }
 
-impl ser::SerializeStructVariant for StructVariantSerializer<'_> {
+impl ser::SerializeStructVariant for StructVariantSerializer {
     type Ok = Value;
     type Error = Error;
 
@@ -459,10 +454,8 @@ impl ser::SerializeStructVariant for StructVariantSerializer<'_> {
     where
         T: Serialize + ?Sized,
     {
-        self.fields.push((
-            name.to_owned(),
-            value.serialize(&mut Serializer::default())?,
-        ));
+        self.fields
+            .push((name.to_owned(), value.serialize(Serializer)?));
         Ok(())
     }
 
@@ -490,8 +483,7 @@ impl ser::SerializeStructVariant for StructVariantSerializer<'_> {
 ///
 /// [`Writer::append_ser`]: crate::Writer::append_ser
 pub fn to_value<S: Serialize>(value: S) -> Result<Value, Error> {
-    let mut serializer = Serializer::default();
-    value.serialize(&mut serializer)
+    value.serialize(Serializer)
 }
 
 #[cfg(test)]

--- a/avro/src/types.rs
+++ b/avro/src/types.rs
@@ -1219,6 +1219,7 @@ mod tests {
         duration::{Days, Millis, Months},
         error::Details,
         schema::RecordFieldOrder,
+        to_value,
     };
     use apache_avro_test_helper::{
         TestResult,
@@ -2809,7 +2810,6 @@ Field with name '"b"' is not a member of the map items"#,
 
     #[test]
     fn test_avro_3460_validation_with_refs_real_struct() -> TestResult {
-        use crate::serde::ser::Serializer;
         use serde::Serialize;
 
         #[derive(Serialize, Clone)]
@@ -2874,12 +2874,9 @@ Field with name '"b"' is not a member of the map items"#,
             b: None,
         };
 
-        let mut ser = Serializer::default();
-        let test_outer1: Value = test_outer1.serialize(&mut ser)?;
-        let mut ser = Serializer::default();
-        let test_outer2: Value = test_outer2.serialize(&mut ser)?;
-        let mut ser = Serializer::default();
-        let test_outer3: Value = test_outer3.serialize(&mut ser)?;
+        let test_outer1: Value = to_value(test_outer1)?;
+        let test_outer2: Value = to_value(test_outer2)?;
+        let test_outer3: Value = to_value(test_outer3)?;
 
         assert!(
             !test_outer1.validate(&schema),
@@ -2898,7 +2895,6 @@ Field with name '"b"' is not a member of the map items"#,
     }
 
     fn avro_3674_with_or_without_namespace(with_namespace: bool) -> TestResult {
-        use crate::serde::ser::Serializer;
         use serde::Serialize;
 
         let schema_str = r#"
@@ -2969,8 +2965,7 @@ Field with name '"b"' is not a member of the map items"#,
             },
         };
 
-        let mut ser = Serializer::default();
-        let test_value: Value = msg.serialize(&mut ser)?;
+        let test_value: Value = to_value(msg)?;
         assert!(test_value.validate(&schema), "test_value should validate");
         assert!(
             test_value.resolve(&schema).is_ok(),
@@ -2991,7 +2986,6 @@ Field with name '"b"' is not a member of the map items"#,
     }
 
     fn avro_3688_schema_resolution_panic(set_field_b: bool) -> TestResult {
-        use crate::serde::ser::Serializer;
         use serde::{Deserialize, Serialize};
 
         let schema_str = r#"{
@@ -3052,8 +3046,7 @@ Field with name '"b"' is not a member of the map items"#,
             },
         };
 
-        let mut ser = Serializer::default();
-        let test_value: Value = msg.serialize(&mut ser)?;
+        let test_value: Value = to_value(msg)?;
         assert!(test_value.validate(&schema), "test_value should validate");
         assert!(
             test_value.resolve(&schema).is_ok(),


### PR DESCRIPTION
Removes unnecessary references and lifetimes.

This is not a breaking change as the type is not public.