### PR TITLE
feat!: Support `default` field for array and map

### DIFF
--- a/avro/src/error.rs
+++ b/avro/src/error.rs
@@ -312,6 +312,9 @@ pub enum Details {
     #[error("`default`'s value type of field {0:?} in {1:?} must be {2:?}")]
     GetDefaultRecordField(String, String, String),
 
+    #[error("JSON number {0} could not be converted into an Avro value as it's too large")]
+    JsonNumberTooLarge(serde_json::Number),
+
     #[error("JSON value {0} claims to be u64 but cannot be converted")]
     GetU64FromJson(serde_json::Number),
 
@@ -342,6 +345,9 @@ pub enum Details {
 
     #[error("Cannot convert i32 to u128: {1}")]
     ConvertI32ToU128(#[source] std::num::TryFromIntError, i32),
+
+    #[error("Cannot convert usize to i64: {1}")]
+    ConvertUsizeToI64(#[source] std::num::TryFromIntError, usize),
 
     #[error("Invalid JSON value for decimal precision/scale integer: {0}")]
     GetPrecisionOrScaleFromJson(serde_json::Number),

--- a/avro/src/schema/mod.rs
+++ b/avro/src/schema/mod.rs
@@ -4729,7 +4729,7 @@ mod tests {
                 assert_eq!(field.name, "birthday");
                 assert_eq!(field.schema, Schema::Date);
                 assert_eq!(
-                    types::Value::from(field.default.clone().unwrap()),
+                    types::Value::try_from(field.default.clone().unwrap())?,
                     types::Value::Int(1681601653)
                 );
             }

--- a/avro/src/schema/parser.rs
+++ b/avro/src/schema/parser.rs
@@ -710,7 +710,8 @@ impl Parser {
             .and_then(|items| self.parse(items, enclosing_namespace))?;
         let default = if let Some(default) = complex.get("default").cloned() {
             if let Value::Array(_) = default {
-                let crate::types::Value::Array(array) = crate::types::Value::from(default) else {
+                let crate::types::Value::Array(array) = crate::types::Value::try_from(default)?
+                else {
                     unreachable!("JsonValue::Array can only become a Value::Array")
                 };
                 // Check that the default type matches the schema type
@@ -747,7 +748,7 @@ impl Parser {
 
         let default = if let Some(default) = complex.get("default").cloned() {
             if let Value::Object(_) = default {
-                let crate::types::Value::Map(map) = crate::types::Value::from(default) else {
+                let crate::types::Value::Map(map) = crate::types::Value::try_from(default)? else {
                     unreachable!("JsonValue::Object can only become a Value::Map")
                 };
                 // Check that the default type matches the schema type

--- a/avro/src/schema/record/field.rs
+++ b/avro/src/schema/record/field.rs
@@ -133,7 +133,7 @@ impl RecordField {
         default: &Option<Value>,
     ) -> AvroResult<()> {
         if let Some(value) = default {
-            let avro_value = types::Value::from(value.clone());
+            let avro_value = types::Value::try_from(value.clone())?;
             match field_schema {
                 Schema::Union(union_schema) => {
                     let schemas = &union_schema.schemas;

--- a/avro/src/types.rs
+++ b/avro/src/types.rs
@@ -156,11 +156,13 @@ impl From<()> for Value {
     }
 }
 
-impl From<usize> for Value {
-    fn from(value: usize) -> Self {
-        i64::try_from(value)
-            .expect("cannot convert usize to i64")
-            .into()
+impl TryFrom<usize> for Value {
+    type Error = Error;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        Ok(i64::try_from(value)
+            .map_err(|e| Details::ConvertUsizeToI64(e, value))?
+            .into())
     }
 }
 
@@ -269,29 +271,38 @@ impl<'a> From<Record<'a>> for Value {
     }
 }
 
-impl From<JsonValue> for Value {
-    fn from(value: JsonValue) -> Self {
+impl TryFrom<JsonValue> for Value {
+    type Error = Error;
+
+    fn try_from(value: JsonValue) -> Result<Self, Self::Error> {
         match value {
-            JsonValue::Null => Self::Null,
-            JsonValue::Bool(b) => b.into(),
+            JsonValue::Null => Ok(Self::Null),
+            JsonValue::Bool(b) => Ok(b.into()),
             JsonValue::Number(ref n) if n.is_i64() => {
                 let n = n.as_i64().unwrap();
                 if n >= i32::MIN as i64 && n <= i32::MAX as i64 {
-                    Value::Int(n as i32)
+                    Ok(Value::Int(n as i32))
                 } else {
-                    Value::Long(n)
+                    Ok(Value::Long(n))
                 }
             }
-            JsonValue::Number(ref n) if n.is_f64() => Value::Double(n.as_f64().unwrap()),
-            JsonValue::Number(n) => panic!("{n:?} does not fit into an Avro long"),
-            JsonValue::String(s) => s.into(),
-            JsonValue::Array(items) => Value::Array(items.into_iter().map(Value::from).collect()),
-            JsonValue::Object(items) => Value::Map(
-                items
+            JsonValue::Number(ref n) if n.is_f64() => Ok(Value::Double(n.as_f64().unwrap())),
+            JsonValue::Number(n) => Err(Details::JsonNumberTooLarge(n).into()),
+            JsonValue::String(s) => Ok(s.into()),
+            JsonValue::Array(items) => {
+                let items = items
                     .into_iter()
-                    .map(|(key, value)| (key, value.into()))
-                    .collect(),
-            ),
+                    .map(Value::try_from)
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Value::Array(items))
+            }
+            JsonValue::Object(items) => {
+                let items = items
+                    .into_iter()
+                    .map(|(key, value)| Value::try_from(value).map(|v| (key, v)))
+                    .collect::<Result<HashMap<_, _>, _>>()?;
+                Ok(Value::Map(items))
+            }
         }
     }
 }
@@ -1161,7 +1172,7 @@ impl Value {
                                 ref symbols,
                                 ref default,
                                 ..
-                            }) => Value::from(value.clone()).resolve_enum(
+                            }) => Value::try_from(value.clone())?.resolve_enum(
                                 symbols,
                                 default,
                                 &field.default.clone(),
@@ -1174,16 +1185,18 @@ impl Value {
                                     Schema::Null => Value::Union(0, Box::new(Value::Null)),
                                     _ => Value::Union(
                                         0,
-                                        Box::new(Value::from(value.clone()).resolve_internal(
-                                            first,
-                                            names,
-                                            enclosing_namespace,
-                                            &field.default,
-                                        )?),
+                                        Box::new(
+                                            Value::try_from(value.clone())?.resolve_internal(
+                                                first,
+                                                names,
+                                                enclosing_namespace,
+                                                &field.default,
+                                            )?,
+                                        ),
                                     ),
                                 }
                             }
-                            _ => Value::from(value.clone()),
+                            _ => Value::try_from(value.clone())?,
                         },
                         None => {
                             return Err(Details::GetField(field.name.clone()).into());
@@ -3073,7 +3086,7 @@ Field with name '"b"' is not a member of the map items"#,
         "#,
         )?;
 
-        let avro_value = Value::from(value);
+        let avro_value = Value::try_from(value)?;
 
         let schemas = Schema::parse_list([main_schema, referenced_schema])?;
 
@@ -3113,7 +3126,7 @@ Field with name '"b"' is not a member of the map items"#,
         "#,
         )?;
 
-        let avro_value = Value::from(value);
+        let avro_value = Value::try_from(value)?;
 
         let schemata = Schema::parse_list([referenced_enum, referenced_record, main_schema])?;
 
@@ -3212,30 +3225,33 @@ Field with name '"b"' is not a member of the map items"#,
     }
 
     #[test]
-    fn avro_3928_from_serde_value_to_types_value() {
-        assert_eq!(Value::from(serde_json::Value::Null), Value::Null);
-        assert_eq!(Value::from(json!(true)), Value::Boolean(true));
-        assert_eq!(Value::from(json!(false)), Value::Boolean(false));
-        assert_eq!(Value::from(json!(0)), Value::Int(0));
-        assert_eq!(Value::from(json!(i32::MIN)), Value::Int(i32::MIN));
-        assert_eq!(Value::from(json!(i32::MAX)), Value::Int(i32::MAX));
+    fn avro_3928_from_serde_value_to_types_value() -> TestResult {
+        assert_eq!(Value::try_from(serde_json::Value::Null)?, Value::Null);
+        assert_eq!(Value::try_from(json!(true))?, Value::Boolean(true));
+        assert_eq!(Value::try_from(json!(false))?, Value::Boolean(false));
+        assert_eq!(Value::try_from(json!(0))?, Value::Int(0));
+        assert_eq!(Value::try_from(json!(i32::MIN))?, Value::Int(i32::MIN));
+        assert_eq!(Value::try_from(json!(i32::MAX))?, Value::Int(i32::MAX));
         assert_eq!(
-            Value::from(json!(i32::MIN as i64 - 1)),
+            Value::try_from(json!(i32::MIN as i64 - 1))?,
             Value::Long(i32::MIN as i64 - 1)
         );
         assert_eq!(
-            Value::from(json!(i32::MAX as i64 + 1)),
+            Value::try_from(json!(i32::MAX as i64 + 1))?,
             Value::Long(i32::MAX as i64 + 1)
         );
-        assert_eq!(Value::from(json!(1.23)), Value::Double(1.23));
-        assert_eq!(Value::from(json!(-1.23)), Value::Double(-1.23));
-        assert_eq!(Value::from(json!(u64::MIN)), Value::Int(u64::MIN as i32));
+        assert_eq!(Value::try_from(json!(1.23))?, Value::Double(1.23));
+        assert_eq!(Value::try_from(json!(-1.23))?, Value::Double(-1.23));
         assert_eq!(
-            Value::from(json!("some text")),
+            Value::try_from(json!(u64::MIN))?,
+            Value::Int(u64::MIN as i32)
+        );
+        assert_eq!(
+            Value::try_from(json!("some text"))?,
             Value::String("some text".into())
         );
         assert_eq!(
-            Value::from(json!(["text1", "text2", "text3"])),
+            Value::try_from(json!(["text1", "text2", "text3"]))?,
             Value::Array(vec![
                 Value::String("text1".into()),
                 Value::String("text2".into()),
@@ -3243,7 +3259,7 @@ Field with name '"b"' is not a member of the map items"#,
             ])
         );
         assert_eq!(
-            Value::from(json!({"key1": "value1", "key2": "value2"})),
+            Value::try_from(json!({"key1": "value1", "key2": "value2"}))?,
             Value::Map(
                 vec![
                     ("key1".into(), Value::String("value1".into())),
@@ -3253,6 +3269,7 @@ Field with name '"b"' is not a member of the map items"#,
                 .collect()
             )
         );
+        Ok(())
     }
 
     #[test]
@@ -3491,8 +3508,13 @@ Field with name '"b"' is not a member of the map items"#,
     }
 
     #[test]
-    #[should_panic(expected = "Number(18446744073709551615) does not fit into an Avro long")]
     fn avro_rs_450_serde_json_number_u64_max() {
-        let _ = Value::from(json!(u64::MAX));
+        assert_eq!(
+            Value::try_from(json!(u64::MAX))
+                .unwrap_err()
+                .into_details()
+                .to_string(),
+            "JSON number 18446744073709551615 could not be converted into an Avro value as it's too large"
+        );
     }
 }

--- a/avro/src/writer.rs
+++ b/avro/src/writer.rs
@@ -390,8 +390,8 @@ impl<'a, W: Write> Writer<'a, W> {
         let num_values = self.num_values;
         let stream_len = self.buffer.len();
 
-        num_bytes += self.append_raw(&num_values.into(), &Schema::Long)?
-            + self.append_raw(&stream_len.into(), &Schema::Long)?
+        num_bytes += self.append_raw(&num_values.try_into()?, &Schema::Long)?
+            + self.append_raw(&stream_len.try_into()?, &Schema::Long)?
             + self
                 .writer
                 .write(self.buffer.as_ref())

--- a/avro/tests/schema.rs
+++ b/avro/tests/schema.rs
@@ -2351,7 +2351,7 @@ fn avro_rs_181_single_null_record() -> TestResult {
     let mut buff = Cursor::new(Vec::new());
     let schema = Schema::parse_str(r#""null""#)?;
     let mut writer = Writer::new(&schema, &mut buff)?;
-    writer.append_value(serde_json::Value::Null)?;
+    writer.append_value(Value::Null)?;
     writer.into_inner()?;
     buff.set_position(0);
 


### PR DESCRIPTION
One thing I did notice in the spec is that the text says `support a single attribute` while the example does show a `default` field, so the text of the spec should be updated as well.