### PR TITLE
feat: Make `Schema::denormalize` public

### DIFF
--- a/avro/src/schema/mod.rs
+++ b/avro/src/schema/mod.rs
@@ -398,7 +398,7 @@ impl Schema {
     /// Returns the [Parsing Canonical Form] of `self` that is self contained (not dependent on
     /// any definitions in `schemata`)
     ///
-    /// If your require a self contained schema including `default` and `doc` attributes, see [`denormalize`][Schema::denormalize].
+    /// If you require a self contained schema including `default` and `doc` attributes, see [`denormalize`][Schema::denormalize].
     ///
     /// [Parsing Canonical Form]:
     /// https://avro.apache.org/docs/++version++/specification/#parsing-canonical-form-for-schemas


### PR DESCRIPTION
This should help fix https://github.com/lerouxrgd/rsgen-avro/issues/92

I've not applied the `with_capacity(schemata.len())` optimisation that `independant_canonical_form` had, as that capacity will be wrong in 99% of usecases. This should allow the capacity to grow in more predictable ways.