### PR TITLE
chore: Replace `strum-macros` with `features = ["derive"` on `strum` and update to `0.28.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,6 @@ dependencies = [
  "sha2",
  "snap",
  "strum",
- "strum_macros",
  "thiserror",
  "uuid",
  "zstd",
@@ -1306,15 +1305,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/avro/Cargo.toml
+++ b/avro/Cargo.toml
@@ -64,8 +64,7 @@ serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
 snap = { default-features = false, version = "1.1.0", optional = true }
-strum = { default-features = false, version = "0.27.2" }
-strum_macros = { default-features = false, version = "0.27.2" }
+strum = { default-features = false, version = "0.28.0", features = ["derive"] }
 thiserror = { default-features = false, version = "2.0.18" }
 uuid = { workspace = true }
 liblzma = { default-features = false, version = "0.4.6", optional = true }

--- a/avro/src/codec.rs
+++ b/avro/src/codec.rs
@@ -17,7 +17,7 @@
 
 //! Logic for all supported compression codecs in Avro.
 use crate::{AvroResult, Error, error::Details, types::Value};
-use strum_macros::{EnumIter, EnumString, IntoStaticStr};
+use strum::{EnumIter, EnumString, IntoStaticStr};
 
 /// Settings for the `Deflate` codec.
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]

--- a/avro/src/schema/mod.rs
+++ b/avro/src/schema/mod.rs
@@ -24,6 +24,17 @@ mod record;
 mod resolve;
 mod union;
 
+pub(crate) use crate::schema::resolve::{
+    ResolvedOwnedSchema, resolve_names, resolve_names_with_schemata,
+};
+pub use crate::schema::{
+    name::{Alias, Aliases, Name, Names, NamesRef, Namespace},
+    record::{
+        RecordField, RecordFieldBuilder, RecordFieldOrder, RecordSchema, RecordSchemaBuilder,
+    },
+    resolve::ResolvedSchema,
+    union::UnionSchema,
+};
 use crate::{
     AvroResult,
     error::{Details, Error},
@@ -44,19 +55,7 @@ use std::{
     hash::Hash,
     io::Read,
 };
-use strum_macros::{Display, EnumDiscriminants};
-
-pub(crate) use crate::schema::resolve::{
-    ResolvedOwnedSchema, resolve_names, resolve_names_with_schemata,
-};
-pub use crate::schema::{
-    name::{Alias, Aliases, Name, Names, NamesRef, Namespace},
-    record::{
-        RecordField, RecordFieldBuilder, RecordFieldOrder, RecordSchema, RecordSchemaBuilder,
-    },
-    resolve::ResolvedSchema,
-    union::UnionSchema,
-};
+use strum::{Display, EnumDiscriminants};
 
 /// Represents documentation for complex Avro schemas.
 pub type Documentation = Option<String>;

--- a/avro/src/schema/record/field.rs
+++ b/avro/src/schema/record/field.rs
@@ -28,7 +28,7 @@ use serde::{Serialize, Serializer};
 use serde_json::{Map, Value};
 use std::collections::BTreeMap;
 use std::str::FromStr;
-use strum_macros::EnumString;
+use strum::EnumString;
 
 /// Represents a `field` in a `record` Avro schema.
 #[derive(bon::Builder, Clone, Debug, PartialEq)]

--- a/avro/src/types.rs
+++ b/avro/src/types.rs
@@ -50,7 +50,7 @@ fn max_prec_for_len(len: usize) -> Result<usize, Error> {
 ///
 /// More information about Avro values can be found in the [Avro
 /// Specification](https://avro.apache.org/docs/++version++/specification/#schema-declaration)
-#[derive(Clone, Debug, PartialEq, strum_macros::EnumDiscriminants)]
+#[derive(Clone, Debug, PartialEq, strum::EnumDiscriminants)]
 #[strum_discriminants(name(ValueKind))]
 pub enum Value {
     /// A `null` Avro value.


### PR DESCRIPTION
Closes #480 #482