### PR TITLE
feat: Custom `Debug` implementation for `*Schema` types

### DIFF
--- a/avro/src/schema/record/field.rs
+++ b/avro/src/schema/record/field.rs
@@ -26,11 +26,12 @@ use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
 use serde_json::{Map, Value};
 use std::collections::BTreeMap;
+use std::fmt::{Debug, Formatter};
 use std::str::FromStr;
 use strum::EnumString;
 
 /// Represents a `field` in a `record` Avro schema.
-#[derive(bon::Builder, Clone, Debug, PartialEq)]
+#[derive(bon::Builder, Clone, PartialEq)]
 pub struct RecordField {
     /// Name of the field.
     #[builder(into)]
@@ -57,6 +58,31 @@ pub struct RecordField {
     /// A collection of all unknown fields in the record field.
     #[builder(default = BTreeMap::new())]
     pub custom_attributes: BTreeMap<String, Value>,
+}
+
+impl Debug for RecordField {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut debug = f.debug_struct("RecordField");
+        debug.field("name", &self.name);
+        if let Some(doc) = &self.doc {
+            debug.field("doc", &doc);
+        }
+        if let Some(aliases) = &self.aliases {
+            debug.field("aliases", &aliases);
+        }
+        if let Some(default) = &self.default {
+            debug.field("default", &default);
+        }
+        debug.field("schema", &self.schema);
+        // This field is ignored as it currently has no effect
+        // debug.field("order", &self.order);
+        debug.field("position", &self.position);
+        if !self.custom_attributes.is_empty() {
+            debug.field("custom_attributes", &self.custom_attributes);
+        }
+        // As we are always skipping self.order, always show the ..
+        debug.finish_non_exhaustive()
+    }
 }
 
 /// Represents any valid order for a `field` in a `record` Avro schema.

--- a/avro/src/schema/record/schema.rs
+++ b/avro/src/schema/record/schema.rs
@@ -18,9 +18,10 @@
 use crate::schema::{Aliases, Documentation, Name, RecordField};
 use serde_json::Value;
 use std::collections::BTreeMap;
+use std::fmt::{Debug, Formatter};
 
 /// A description of a Record schema.
-#[derive(bon::Builder, Debug, Clone)]
+#[derive(bon::Builder, Clone)]
 pub struct RecordSchema {
     /// The name of the schema
     pub name: Name,
@@ -40,6 +41,28 @@ pub struct RecordSchema {
     /// The custom attributes of the schema
     #[builder(default)]
     pub attributes: BTreeMap<String, Value>,
+}
+
+impl Debug for RecordSchema {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut debug = f.debug_struct("RecordSchema");
+        debug.field("name", &self.name);
+        if let Some(aliases) = &self.aliases {
+            debug.field("default", aliases);
+        }
+        if let Some(doc) = &self.doc {
+            debug.field("doc", doc);
+        }
+        debug.field("fields", &self.fields);
+        if !self.attributes.is_empty() {
+            debug.field("attributes", &self.attributes);
+        }
+        if self.aliases.is_none() || self.doc.is_none() || self.attributes.is_empty() {
+            debug.finish_non_exhaustive()
+        } else {
+            debug.finish()
+        }
+    }
 }
 
 impl<S: record_schema_builder::State> RecordSchemaBuilder<S> {

--- a/avro/src/schema/union.rs
+++ b/avro/src/schema/union.rs
@@ -21,10 +21,10 @@ use crate::schema::{Name, Namespace, ResolvedSchema, Schema, SchemaKind};
 use crate::types;
 use std::borrow::Borrow;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::fmt::Debug;
+use std::fmt::{Debug, Formatter};
 
 /// A description of a Union schema
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct UnionSchema {
     /// The schemas that make up this union
     pub(crate) schemas: Vec<Schema>,
@@ -33,6 +33,15 @@ pub struct UnionSchema {
     // **NOTE** that this approach does not work for named types, and will have to be modified
     // to support that. A simple solution is to also keep a mapping of the names used.
     variant_index: BTreeMap<SchemaKind, usize>,
+}
+
+impl Debug for UnionSchema {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // Doesn't include `variant_index` as it's a derivative of `schemas`
+        f.debug_struct("UnionSchema")
+            .field("schemas", &self.schemas)
+            .finish()
+    }
 }
 
 impl UnionSchema {

--- a/avro/src/writer.rs
+++ b/avro/src/writer.rs
@@ -1785,7 +1785,7 @@ mod tests {
             Err(e) => {
                 assert_eq!(
                     e.to_string(),
-                    r#"Failed to serialize field 'time' for record Record(RecordSchema { name: Name { name: "Conference", namespace: None }, aliases: None, doc: None, fields: [RecordField { name: "name", doc: None, aliases: None, default: None, schema: String, order: Ascending, position: 0, custom_attributes: {} }, RecordField { name: "date", doc: None, aliases: Some(["time2", "time"]), default: None, schema: Union(UnionSchema { schemas: [Null, Long], variant_index: {Null: 0, Long: 1} }), order: Ascending, position: 1, custom_attributes: {} }], lookup: {"date": 1, "name": 0, "time": 1, "time2": 1}, attributes: {} }): Failed to serialize value of type f64 using schema Union(UnionSchema { schemas: [Null, Long], variant_index: {Null: 0, Long: 1} }): 12345678.9. Cause: Cannot find a Double schema in [Null, Long]"#
+                    r#"Failed to serialize field 'time' for record Record(RecordSchema { name: Name { name: "Conference", namespace: None }, fields: [RecordField { name: "name", schema: String, position: 0, .. }, RecordField { name: "date", aliases: ["time2", "time"], schema: Union(UnionSchema { schemas: [Null, Long] }), position: 1, .. }], .. }): Failed to serialize value of type f64 using schema Union(UnionSchema { schemas: [Null, Long] }): 12345678.9. Cause: Cannot find a Double schema in [Null, Long]"#
                 );
             }
         }

--- a/avro/tests/serde_human_readable_true.rs
+++ b/avro/tests/serde_human_readable_true.rs
@@ -103,7 +103,7 @@ fn avro_rs_440_uuid_bytes() -> TestResult {
     let writer = SpecificSingleObjectWriter::new()?;
     assert_eq!(
         writer.write(uuid, &mut buffer).unwrap_err().to_string(),
-        "Failed to serialize value of type string using schema Uuid(Bytes): 550e8400-e29b-41d4-a716-446655440000. Cause: Expected bytes but got a string. Did you mean to use `Schema::Uuid(UuidSchema::String)` or `utils::serde_set_human_readable(false)`?"
+        r#"Failed to serialize value of type string using schema Uuid(Bytes): 550e8400-e29b-41d4-a716-446655440000. Cause: Expected bytes but got a string. Did you mean to use `Schema::Uuid(UuidSchema::String)` or `utils::serde_set_human_readable(false)`?"#
     );
 
     Ok(())
@@ -129,7 +129,7 @@ fn avro_rs_440_uuid_fixed() -> TestResult {
     let writer = SpecificSingleObjectWriter::new()?;
     assert_eq!(
         writer.write(uuid, &mut buffer).unwrap_err().to_string(),
-        r#"Failed to serialize value of type string using schema Uuid(Fixed(FixedSchema { name: Name { name: "uuid", namespace: None }, aliases: None, doc: None, size: 16, attributes: {} })): 550e8400-e29b-41d4-a716-446655440000. Cause: Expected bytes but got a string. Did you mean to use `Schema::Uuid(UuidSchema::String)` or `utils::serde_set_human_readable(false)`?"#
+        r#"Failed to serialize value of type string using schema Uuid(Fixed(FixedSchema { name: Name { name: "uuid", namespace: None }, size: 16, .. })): 550e8400-e29b-41d4-a716-446655440000. Cause: Expected bytes but got a string. Did you mean to use `Schema::Uuid(UuidSchema::String)` or `utils::serde_set_human_readable(false)`?"#
     );
 
     Ok(())


### PR DESCRIPTION
This makes error messages significantly more readable, by not displaying values that are `None` or custom attributes that are empty.