### PR TITLE
chore: Detect MSRV builds and run derive UI tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
  "proc-macro2",
  "proptest",
  "quote",
- "rustversion",
+ "rustc_version",
  "serde",
  "serde_json",
  "syn",

--- a/avro_derive/Cargo.toml
+++ b/avro_derive/Cargo.toml
@@ -43,12 +43,11 @@ uuid = { workspace = true }
 apache-avro = { default-features = false, path = "../avro", features = ["derive"] }
 pretty_assertions = { workspace = true }
 proptest = { default-features = false, version = "1.10.0", features = ["std"] }
-rustversion = "1.0.22"
 serde = { workspace = true }
 trybuild = "1.0.116"
 
 [build-dependencies]
-rustversion = "1.0.22"
+rustc_version = "0.4"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/avro_derive/build.rs
+++ b/avro_derive/build.rs
@@ -20,10 +20,14 @@
 //! We would prefer to just do `#![rustversion::attr(nightly, feature(proc_macro_diagnostic)]`
 //! but that's currently not possible, see <https://github.com/dtolnay/rustversion/issues/8>
 
-#[rustversion::nightly]
-fn main() {
-    println!("cargo:rustc-cfg=nightly");
-}
+use rustc_version::version;
 
-#[rustversion::not(nightly)]
-fn main() {}
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(msrv)");
+    let msrv = std::env::var("CARGO_PKG_RUST_VERSION").unwrap();
+    let current = version().unwrap().to_string();
+
+    if current == msrv {
+        println!(r#"cargo:rustc-cfg=msrv"#);
+    }
+}

--- a/avro_derive/tests/ui.rs
+++ b/avro_derive/tests/ui.rs
@@ -18,7 +18,7 @@
 /// These tests only run on nightly as the output can change per compiler version.
 ///
 /// See <https://github.com/dtolnay/trybuild/issues/84>
-#[rustversion::attr(not(nightly), ignore)]
+#[cfg_attr(not(msrv), ignore)]
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();

--- a/avro_derive/tests/ui/avro_rs_226_skip_serializing.stderr
+++ b/avro_derive/tests/ui/avro_rs_226_skip_serializing.stderr
@@ -1,7 +1,5 @@
 error: `#[serde(skip_serializing)]` and `#[serde(skip_serializing_if)]` are incompatible with `#[avro(default = false)]`
   --> tests/ui/avro_rs_226_skip_serializing.rs:24:5
    |
-24 | /     #[serde(skip_serializing)]
-25 | |     #[avro(default = false)]
-26 | |     z: Option<i8>,
-   | |_________________^
+24 |     #[serde(skip_serializing)]
+   |     ^

--- a/avro_derive/tests/ui/avro_rs_226_skip_serializing_if.stderr
+++ b/avro_derive/tests/ui/avro_rs_226_skip_serializing_if.stderr
@@ -1,7 +1,5 @@
 error: `#[serde(skip_serializing)]` and `#[serde(skip_serializing_if)]` are incompatible with `#[avro(default = false)]`
   --> tests/ui/avro_rs_226_skip_serializing_if.rs:23:5
    |
-23 | /     #[serde(skip_serializing_if = "Option::is_none")]
-24 | |     #[avro(default = false)]
-25 | |     y: Option<String>,
-   | |_____________________^
+23 |     #[serde(skip_serializing_if = "Option::is_none")]
+   |     ^

--- a/avro_derive/tests/ui/avro_rs_373_alias.stderr
+++ b/avro_derive/tests/ui/avro_rs_373_alias.stderr
@@ -1,15 +1,5 @@
-warning: `#[avro(alias = "..")]` is deprecated
-  --> tests/ui/avro_rs_373_alias.rs:22:5
-   |
-22 | /     #[avro(alias = "c")]
-23 | |     a: String,
-   | |_____________^
-   |
-   = help: Use `#[serde(alias = "..")]` instead
-
 error: `#[avro(alias = "..")]` must match `#[serde(alias = "..")]`, it's also deprecated. Please use only `#[serde(alias = "..")]`
   --> tests/ui/avro_rs_373_alias.rs:22:5
    |
-22 | /     #[avro(alias = "c")]
-23 | |     a: String,
-   | |_____________^
+22 |     #[avro(alias = "c")]
+   |     ^

--- a/avro_derive/tests/ui/avro_rs_373_field_rename.stderr
+++ b/avro_derive/tests/ui/avro_rs_373_field_rename.stderr
@@ -1,15 +1,5 @@
-warning: `#[avro(rename = "..")]` is deprecated
-  --> tests/ui/avro_rs_373_field_rename.rs:22:5
-   |
-22 | /     #[avro(rename = "c")]
-23 | |     a: String,
-   | |_____________^
-   |
-   = help: Use `#[serde(rename = "..")]` instead
-
 error: `#[avro(rename = "..")]` must match `#[serde(rename = "..")]`, it's also deprecated. Please use only `#[serde(rename = "..")]`
   --> tests/ui/avro_rs_373_field_rename.rs:22:5
    |
-22 | /     #[avro(rename = "c")]
-23 | |     a: String,
-   | |_____________^
+22 |     #[avro(rename = "c")]
+   |     ^

--- a/avro_derive/tests/ui/avro_rs_373_flatten.stderr
+++ b/avro_derive/tests/ui/avro_rs_373_flatten.stderr
@@ -1,15 +1,5 @@
-warning: `#[avro(flatten)]` is deprecated
-  --> tests/ui/avro_rs_373_flatten.rs:22:5
-   |
-22 | /     #[avro(flatten)]
-23 | |     a: Bar,
-   | |__________^
-   |
-   = help: Use `#[serde(flatten)]` instead
-
 error: `#[avro(flatten)]` requires `#[serde(flatten)]`, it's also deprecated. Please use only `#[serde(flatten)]`
   --> tests/ui/avro_rs_373_flatten.rs:22:5
    |
-22 | /     #[avro(flatten)]
-23 | |     a: Bar,
-   | |__________^
+22 |     #[avro(flatten)]
+   |     ^

--- a/avro_derive/tests/ui/avro_rs_373_name.stderr
+++ b/avro_derive/tests/ui/avro_rs_373_name.stderr
@@ -1,21 +1,5 @@
-warning: `#[avro(name = "...")]` is deprecated.
-  --> tests/ui/avro_rs_373_name.rs:21:1
-   |
-21 | / #[avro(name = "Something")]
-22 | | struct Foo {
-23 | |     a: String,
-24 | |     b: i32,
-25 | | }
-   | |_^
-   |
-   = help: Use `#[serde(rename = "...")]` instead.
-
 error: #[avro(name = "..")] must match #[serde(rename = "..")], it's also deprecated. Please use only `#[serde(rename = "..")]`
   --> tests/ui/avro_rs_373_name.rs:21:1
    |
-21 | / #[avro(name = "Something")]
-22 | | struct Foo {
-23 | |     a: String,
-24 | |     b: i32,
-25 | | }
-   | |_^
+21 | #[avro(name = "Something")]
+   | ^

--- a/avro_derive/tests/ui/avro_rs_373_remote.stderr
+++ b/avro_derive/tests/ui/avro_rs_373_remote.stderr
@@ -1,9 +1,5 @@
 error: AvroSchema derive does not support the Serde `remote` attribute
   --> tests/ui/avro_rs_373_remote.rs:27:1
    |
-27 | / #[serde(remote = "Foo")]
-28 | | struct FooRemote {
-29 | |     a: String,
-30 | |     b: i32,
-31 | | }
-   | |_^
+27 | #[serde(remote = "Foo")]
+   | ^

--- a/avro_derive/tests/ui/avro_rs_373_rename_all.stderr
+++ b/avro_derive/tests/ui/avro_rs_373_rename_all.stderr
@@ -1,21 +1,5 @@
-warning: `#[avro(rename_all = "..")]` is deprecated
-  --> tests/ui/avro_rs_373_rename_all.rs:21:1
-   |
-21 | / #[avro(rename_all = "snake_case")]
-22 | | struct Foo {
-23 | |     a: String,
-24 | |     b: i32,
-25 | | }
-   | |_^
-   |
-   = help: Use `#[serde(rename_all = "..")]` instead
-
 error: #[avro(rename_all = "..")] must match #[serde(rename_all = "..")], it's also deprecated. Please use only `#[serde(rename_all = "..")]`
   --> tests/ui/avro_rs_373_rename_all.rs:21:1
    |
-21 | / #[avro(rename_all = "snake_case")]
-22 | | struct Foo {
-23 | |     a: String,
-24 | |     b: i32,
-25 | | }
-   | |_^
+21 | #[avro(rename_all = "snake_case")]
+   | ^

--- a/avro_derive/tests/ui/avro_rs_373_skip.stderr
+++ b/avro_derive/tests/ui/avro_rs_373_skip.stderr
@@ -1,15 +1,5 @@
-warning: `#[avro(skip)]` is deprecated
-  --> tests/ui/avro_rs_373_skip.rs:22:5
-   |
-22 | /     #[avro(skip)]
-23 | |     a: String,
-   | |_____________^
-   |
-   = help: Use `#[serde(skip)]` instead
-
 error: `#[avro(skip)]` requires `#[serde(skip)]`, it's also deprecated. Please use only `#[serde(skip)]`
   --> tests/ui/avro_rs_373_skip.rs:22:5
    |
-22 | /     #[avro(skip)]
-23 | |     a: String,
-   | |_____________^
+22 |     #[avro(skip)]
+   |     ^

--- a/avro_derive/tests/ui/avro_rs_373_tag_content_enum.stderr
+++ b/avro_derive/tests/ui/avro_rs_373_tag_content_enum.stderr
@@ -1,9 +1,5 @@
 error: AvroSchema derive does not support changing the tagging Serde generates (`tag`, `content`, `untagged`, `variant_identifier`, `field_identifier`)
   --> tests/ui/avro_rs_373_tag_content_enum.rs:21:1
    |
-21 | / #[serde(tag = "bar", content = "spam")]
-22 | | enum Foo {
-23 | |     One,
-24 | |     Two,
-25 | | }
-   | |_^
+21 | #[serde(tag = "bar", content = "spam")]
+   | ^

--- a/avro_derive/tests/ui/avro_rs_373_tag_enum.stderr
+++ b/avro_derive/tests/ui/avro_rs_373_tag_enum.stderr
@@ -1,9 +1,5 @@
 error: AvroSchema derive does not support changing the tagging Serde generates (`tag`, `content`, `untagged`, `variant_identifier`, `field_identifier`)
   --> tests/ui/avro_rs_373_tag_enum.rs:21:1
    |
-21 | / #[serde(tag = "bar")]
-22 | | enum Foo {
-23 | |     One,
-24 | |     Two,
-25 | | }
-   | |_^
+21 | #[serde(tag = "bar")]
+   | ^

--- a/avro_derive/tests/ui/avro_rs_373_tag_struct.stderr
+++ b/avro_derive/tests/ui/avro_rs_373_tag_struct.stderr
@@ -1,9 +1,5 @@
 error: AvroSchema derive does not support changing the tagging Serde generates (`tag`, `content`, `untagged`, `variant_identifier`, `field_identifier`)
   --> tests/ui/avro_rs_373_tag_struct.rs:21:1
    |
-21 | / #[serde(tag = "bar")]
-22 | | struct Foo {
-23 | |     a: String,
-24 | |     b: i32,
-25 | | }
-   | |_^
+21 | #[serde(tag = "bar")]
+   | ^

--- a/avro_derive/tests/ui/avro_rs_373_untagged_enum.stderr
+++ b/avro_derive/tests/ui/avro_rs_373_untagged_enum.stderr
@@ -1,9 +1,5 @@
 error: AvroSchema derive does not support changing the tagging Serde generates (`tag`, `content`, `untagged`, `variant_identifier`, `field_identifier`)
   --> tests/ui/avro_rs_373_untagged_enum.rs:21:1
    |
-21 | / #[serde(untagged)]
-22 | | enum Foo {
-23 | |     One,
-24 | |     Two,
-25 | | }
-   | |_^
+21 | #[serde(untagged)]
+   | ^

--- a/avro_derive/tests/ui/avro_rs_373_variant_rename.stderr
+++ b/avro_derive/tests/ui/avro_rs_373_variant_rename.stderr
@@ -1,15 +1,5 @@
-warning: `#[avro(rename = "..")]` is deprecated
-  --> tests/ui/avro_rs_373_variant_rename.rs:23:5
-   |
-23 | /     #[avro(rename = "Scam")]
-24 | |     Spam,
-   | |________^
-   |
-   = help: Use `#[serde(rename = "..")]` instead
-
 error: `#[avro(rename = "..")]` must match `#[serde(rename = "..")]`, it's also deprecated. Please use only `#[serde(rename = "..")]`
   --> tests/ui/avro_rs_373_variant_rename.rs:23:5
    |
-23 | /     #[avro(rename = "Scam")]
-24 | |     Spam,
-   | |________^
+23 |     #[avro(rename = "Scam")]
+   |     ^

--- a/avro_derive/tests/ui/avro_rs_397_with_closure_parameters.stderr
+++ b/avro_derive/tests/ui/avro_rs_397_with_closure_parameters.stderr
@@ -1,9 +1,8 @@
 error: Expected closure with 0 parameters
   --> tests/ui/avro_rs_397_with_closure_parameters.rs:22:5
    |
-22 | /     #[avro(with = |_named_schemas, _enclosing_namespace| Schema::Bytes)]
-23 | |     a: String,
-   | |_____________^
+22 |     #[avro(with = |_named_schemas, _enclosing_namespace| Schema::Bytes)]
+   |     ^
 
 warning: unused import: `Schema`
   --> tests/ui/avro_rs_397_with_closure_parameters.rs:18:31
@@ -11,4 +10,4 @@ warning: unused import: `Schema`
 18 | use apache_avro::{AvroSchema, Schema};
    |                               ^^^^^^
    |
-   = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+   = note: `#[warn(unused_imports)]` on by default

--- a/avro_derive/tests/ui/avro_rs_397_with_expr_string.stderr
+++ b/avro_derive/tests/ui/avro_rs_397_with_expr_string.stderr
@@ -1,6 +1,5 @@
 error: Invalid expression, expected function or closure
   --> tests/ui/avro_rs_397_with_expr_string.rs:22:5
    |
-22 | /     #[avro(with = "Schema::Bytes")]
-23 | |     a: String,
-   | |_____________^
+22 |     #[avro(with = "Schema::Bytes")]
+   |     ^

--- a/avro_derive/tests/ui/avro_rs_397_with_word_without_serde.stderr
+++ b/avro_derive/tests/ui/avro_rs_397_with_word_without_serde.stderr
@@ -1,6 +1,5 @@
 error: `#[avro(with)]` requires `#[serde(with = "some_module")]` or provide a function to call `#[avro(with = some_fn)]`
   --> tests/ui/avro_rs_397_with_word_without_serde.rs:22:5
    |
-22 | /     #[avro(with)]
-23 | |     a: String,
-   | |_____________^
+22 |     #[avro(with)]
+   |     ^

--- a/avro_derive/tests/ui/avro_rs_398_transparent.stderr
+++ b/avro_derive/tests/ui/avro_rs_398_transparent.stderr
@@ -1,18 +1,11 @@
 error: AvroSchema: #[serde(transparent)] is only allowed on structs with one unskipped field
   --> tests/ui/avro_rs_398_transparent.rs:21:1
    |
-21 | / #[serde(transparent)]
-22 | | struct Foo {
-23 | |     a: String,
-24 | |     b: i32,
-25 | | }
-   | |_^
+21 | #[serde(transparent)]
+   | ^
 
 error: AvroSchema: `#[serde(transparent)]` is only supported on structs
   --> tests/ui/avro_rs_398_transparent.rs:28:1
    |
-28 | / #[serde(transparent)]
-29 | | enum Bar {
-30 | |     A
-31 | | }
-   | |_^
+28 | #[serde(transparent)]
+   | ^

--- a/avro_derive/tests/ui/avro_rs_398_transparent_skips.stderr
+++ b/avro_derive/tests/ui/avro_rs_398_transparent_skips.stderr
@@ -1,11 +1,5 @@
 error: AvroSchema: #[serde(transparent)] is only allowed on structs with one unskipped field
   --> tests/ui/avro_rs_398_transparent_skips.rs:21:1
    |
-21 | / #[serde(transparent)]
-22 | | struct Foo {
-23 | |     #[serde(skip)]
-24 | |     a: String,
-...  |
-28 | |     c: Vec<u8>
-29 | | }
-   | |_^
+21 | #[serde(transparent)]
+   | ^


### PR DESCRIPTION
Idea to detect MSRV builds:
- use `std::env::var("CARGO_PKG_RUST_VERSION")` to read the MSRV
- use `rust_version::version().unwrap().to_string();`to read the rustc version
- export `msrv` cfg if both match
- use `cfg!(msrv)` to build conditionally

The UI tests are re-generated with `TRYBUILD=overwrite`. Their output is less informative than `nightly` though.