### PR TITLE
Schema parsing and resolved schema rework

### DIFF
--- a/avro/src/decode.rs
+++ b/avro/src/decode.rs
@@ -15,19 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::schema::{InnerDecimalSchema, NamespaceRef, UuidSchema};
+use crate::schema::{InnerDecimalSchema, UuidSchema};
 use crate::{
     AvroResult, Error,
     bigdecimal::deserialize_big_decimal,
     decimal::Decimal,
     duration::Duration,
     error::Details,
-    schema::{DecimalSchema, EnumSchema, FixedSchema, Name, RecordSchema, ResolvedSchema, Schema},
+    schema::{DecimalSchema, EnumSchema, FixedSchema, ResolvedSchema, Schema, ResolvedNode, ResolvedRecord},
     types::Value,
     util::{safe_len, zag_i32, zag_i64},
 };
 use std::{
-    borrow::Borrow,
     collections::HashMap,
     io::{ErrorKind, Read},
 };
@@ -69,20 +68,26 @@ fn decode_seq_len<R: Read>(reader: &mut R) -> AvroResult<usize> {
 }
 
 /// Decode a `Value` from avro format given its `Schema`.
+/// This function will always convert the supplied schema into a ResolvedSchema which
+/// may cuase performance concerns. Consider using decode_complete.
 pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> AvroResult<Value> {
-    let rs = ResolvedSchema::try_from(schema)?;
-    decode_internal(schema, rs.get_names(), None, reader)
+    let resolved : ResolvedSchema = schema.clone().try_into()?;
+    decode_complete(&resolved, reader)
 }
 
-pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
-    schema: &Schema,
-    names: &HashMap<Name, S>,
-    enclosing_namespace: NamespaceRef,
-    reader: &mut R,
+
+/// Decode a `Value` from avro format given its `Schema`.
+pub fn decode_complete<R: Read>(resolved_schema: &ResolvedSchema, reader: &mut R) -> AvroResult<Value> {
+    decode_internal(ResolvedNode::new(&resolved_schema), reader)
+}
+
+pub(crate) fn decode_internal<R: Read>(
+    node: ResolvedNode,
+    reader: &mut R
 ) -> AvroResult<Value> {
-    match schema {
-        Schema::Null => Ok(Value::Null),
-        Schema::Boolean => {
+    match node {
+        ResolvedNode::Null => Ok(Value::Null),
+        ResolvedNode::Boolean => {
             let mut buf = [0u8; 1];
             match reader.read_exact(&mut buf[..]) {
                 Ok(_) => match buf[0] {
@@ -99,34 +104,32 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
                 }
             }
         }
-        Schema::Decimal(DecimalSchema { inner, .. }) => match inner {
+        ResolvedNode::Decimal(DecimalSchema { inner, .. }) => match inner {
             InnerDecimalSchema::Fixed(fixed) => {
                 match decode_internal(
-                    &Schema::Fixed(fixed.copy_only_size()),
-                    names,
-                    enclosing_namespace,
-                    reader,
+                    ResolvedNode::Fixed(&fixed.copy_only_size()),
+                    reader
                 )? {
                     Value::Fixed(_, bytes) => Ok(Value::Decimal(Decimal::from(bytes))),
                     value => Err(Details::FixedValue(value).into()),
                 }
             }
             InnerDecimalSchema::Bytes => {
-                match decode_internal(&Schema::Bytes, names, enclosing_namespace, reader)? {
+                match decode_internal(ResolvedNode::Bytes, reader)? {
                     Value::Bytes(bytes) => Ok(Value::Decimal(Decimal::from(bytes))),
                     value => Err(Details::BytesValue(value).into()),
                 }
             }
         },
-        Schema::BigDecimal => {
-            match decode_internal(&Schema::Bytes, names, enclosing_namespace, reader)? {
+        ResolvedNode::BigDecimal => {
+            match decode_internal(ResolvedNode::Bytes, reader)? {
                 Value::Bytes(bytes) => deserialize_big_decimal(&bytes).map(Value::BigDecimal),
                 value => Err(Details::BytesValue(value).into()),
             }
         }
-        Schema::Uuid(UuidSchema::String) => {
+        ResolvedNode::Uuid(UuidSchema::String) => {
             let Value::String(string) =
-                decode_internal(&Schema::String, names, enclosing_namespace, reader)?
+                decode_internal(ResolvedNode::String, reader)?
             else {
                 // decoding a String can also return a Null, indicating EOF
                 return Err(Error::new(Details::ReadBytes(std::io::Error::from(
@@ -136,9 +139,9 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
             let uuid = Uuid::parse_str(&string).map_err(Details::ConvertStrToUuid)?;
             Ok(Value::Uuid(uuid))
         }
-        Schema::Uuid(UuidSchema::Bytes) => {
+        ResolvedNode::Uuid(UuidSchema::Bytes) => {
             let Value::Bytes(bytes) =
-                decode_internal(&Schema::Bytes, names, enclosing_namespace, reader)?
+                decode_internal(ResolvedNode::Bytes, reader)?
             else {
                 unreachable!(
                     "decode_internal(Schema::Bytes) can only return a Value::Bytes or an error"
@@ -147,12 +150,10 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
             let uuid = Uuid::from_slice(&bytes).map_err(Details::ConvertSliceToUuid)?;
             Ok(Value::Uuid(uuid))
         }
-        Schema::Uuid(UuidSchema::Fixed(fixed)) => {
+        ResolvedNode::Uuid(UuidSchema::Fixed(fixed)) => {
             let Value::Fixed(n, bytes) = decode_internal(
-                &Schema::Fixed(fixed.copy_only_size()),
-                names,
-                enclosing_namespace,
-                reader,
+                ResolvedNode::Fixed(&fixed.copy_only_size()),
+                reader
             )?
             else {
                 unreachable!(
@@ -165,18 +166,18 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
             let uuid = Uuid::from_slice(&bytes).map_err(Details::ConvertSliceToUuid)?;
             Ok(Value::Uuid(uuid))
         }
-        Schema::Int => decode_int(reader),
-        Schema::Date => zag_i32(reader).map(Value::Date),
-        Schema::TimeMillis => zag_i32(reader).map(Value::TimeMillis),
-        Schema::Long => decode_long(reader),
-        Schema::TimeMicros => zag_i64(reader).map(Value::TimeMicros),
-        Schema::TimestampMillis => zag_i64(reader).map(Value::TimestampMillis),
-        Schema::TimestampMicros => zag_i64(reader).map(Value::TimestampMicros),
-        Schema::TimestampNanos => zag_i64(reader).map(Value::TimestampNanos),
-        Schema::LocalTimestampMillis => zag_i64(reader).map(Value::LocalTimestampMillis),
-        Schema::LocalTimestampMicros => zag_i64(reader).map(Value::LocalTimestampMicros),
-        Schema::LocalTimestampNanos => zag_i64(reader).map(Value::LocalTimestampNanos),
-        Schema::Duration(fixed_schema) => {
+        ResolvedNode::Int => decode_int(reader),
+        ResolvedNode::Date => zag_i32(reader).map(Value::Date),
+        ResolvedNode::TimeMillis => zag_i32(reader).map(Value::TimeMillis),
+        ResolvedNode::Long => decode_long(reader),
+        ResolvedNode::TimeMicros => zag_i64(reader).map(Value::TimeMicros),
+        ResolvedNode::TimestampMillis => zag_i64(reader).map(Value::TimestampMillis),
+        ResolvedNode::TimestampMicros => zag_i64(reader).map(Value::TimestampMicros),
+        ResolvedNode::TimestampNanos => zag_i64(reader).map(Value::TimestampNanos),
+        ResolvedNode::LocalTimestampMillis => zag_i64(reader).map(Value::LocalTimestampMillis),
+        ResolvedNode::LocalTimestampMicros => zag_i64(reader).map(Value::LocalTimestampMicros),
+        ResolvedNode::LocalTimestampNanos => zag_i64(reader).map(Value::LocalTimestampNanos),
+        ResolvedNode::Duration(fixed_schema) => {
             if fixed_schema.size == 12 {
                 let mut buf = [0u8; 12];
                 reader.read_exact(&mut buf).map_err(Details::ReadDuration)?;
@@ -189,27 +190,27 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
                 .into())
             }
         }
-        Schema::Float => {
+        ResolvedNode::Float => {
             let mut buf = [0u8; std::mem::size_of::<f32>()];
             reader
                 .read_exact(&mut buf[..])
                 .map_err(Details::ReadFloat)?;
             Ok(Value::Float(f32::from_le_bytes(buf)))
         }
-        Schema::Double => {
+        ResolvedNode::Double => {
             let mut buf = [0u8; std::mem::size_of::<f64>()];
             reader
                 .read_exact(&mut buf[..])
                 .map_err(Details::ReadDouble)?;
             Ok(Value::Double(f64::from_le_bytes(buf)))
         }
-        Schema::Bytes => {
+        ResolvedNode::Bytes => {
             let len = decode_len(reader)?;
             let mut buf = vec![0u8; len];
             reader.read_exact(&mut buf).map_err(Details::ReadBytes)?;
             Ok(Value::Bytes(buf))
         }
-        Schema::String => {
+        ResolvedNode::String => {
             let len = decode_len(reader)?;
             let mut buf = vec![0u8; len];
             match reader.read_exact(&mut buf) {
@@ -225,14 +226,14 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
                 }
             }
         }
-        Schema::Fixed(FixedSchema { size, .. }) => {
+        ResolvedNode::Fixed(FixedSchema { size, .. }) => {
             let mut buf = vec![0u8; *size];
             reader
                 .read_exact(&mut buf)
                 .map_err(|e| Details::ReadFixed(e, *size))?;
             Ok(Value::Fixed(*size, buf))
         }
-        Schema::Array(inner) => {
+        ResolvedNode::Array(inner) => {
             let mut items = Vec::new();
 
             loop {
@@ -244,17 +245,15 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
                 items.reserve(len);
                 for _ in 0..len {
                     items.push(decode_internal(
-                        &inner.items,
-                        names,
-                        enclosing_namespace,
-                        reader,
+                        inner.resolve_items(),
+                        reader
                     )?);
                 }
             }
 
             Ok(Value::Array(items))
         }
-        Schema::Map(inner) => {
+        ResolvedNode::Map(inner) => {
             let mut items = HashMap::new();
 
             loop {
@@ -265,10 +264,10 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
 
                 items.reserve(len);
                 for _ in 0..len {
-                    match decode_internal(&Schema::String, names, enclosing_namespace, reader)? {
+                    match decode_internal(ResolvedNode::String, reader)? {
                         Value::String(key) => {
                             let value =
-                                decode_internal(&inner.types, names, enclosing_namespace, reader)?;
+                                decode_internal(inner.resolve_types(), reader)?;
                             items.insert(key, value);
                         }
                         value => return Err(Details::MapKeyType(value.into()).into()),
@@ -278,16 +277,16 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
 
             Ok(Value::Map(items))
         }
-        Schema::Union(inner) => match zag_i64(reader).map_err(Error::into_details) {
+        ResolvedNode::Union(inner) => match zag_i64(reader).map_err(Error::into_details) {
             Ok(index) => {
-                let variants = inner.variants();
+                let variants = inner.resolve_schemas();
                 let variant = variants
                     .get(usize::try_from(index).map_err(|e| Details::ConvertI64ToUsize(e, index))?)
                     .ok_or(Details::GetUnionVariant {
                         index,
                         num_variants: variants.len(),
                     })?;
-                let value = decode_internal(variant, names, enclosing_namespace, reader)?;
+                let value = decode_internal(variant.clone(), reader)?;
                 Ok(Value::Union(index as u32, Box::new(value)))
             }
             Err(Details::ReadVariableIntegerBytes(io_err)) => {
@@ -299,8 +298,7 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
             }
             Err(io_err) => Err(Error::new(io_err)),
         },
-        Schema::Record(RecordSchema { name, fields, .. }) => {
-            let fully_qualified_name = name.fully_qualified_name(enclosing_namespace);
+        ResolvedNode::Record(ResolvedRecord {fields, .. }) => {
             // Benchmarks indicate ~10% improvement using this method.
             let mut items = Vec::with_capacity(fields.len());
             for field in fields {
@@ -308,16 +306,14 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
                 items.push((
                     field.name.clone(),
                     decode_internal(
-                        &field.schema,
-                        names,
-                        fully_qualified_name.namespace(),
+                        field.resolve_field(),
                         reader,
                     )?,
                 ));
             }
             Ok(Value::Record(items))
         }
-        Schema::Enum(EnumSchema { symbols, .. }) => {
+        ResolvedNode::Enum(EnumSchema { symbols, .. }) => {
             Ok(if let Value::Int(raw_index) = decode_int(reader)? {
                 let index = usize::try_from(raw_index)
                     .map_err(|e| Details::ConvertI32ToUsize(e, raw_index))?;
@@ -334,19 +330,6 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
             } else {
                 return Err(Details::GetEnumUnknownIndexValue.into());
             })
-        }
-        Schema::Ref { name } => {
-            let fully_qualified_name = name.fully_qualified_name(enclosing_namespace);
-            if let Some(resolved) = names.get(&fully_qualified_name) {
-                decode_internal(
-                    resolved.borrow(),
-                    names,
-                    fully_qualified_name.namespace(),
-                    reader,
-                )
-            } else {
-                Err(Details::SchemaResolutionError(fully_qualified_name.into_owned()).into())
-            }
         }
     }
 }
@@ -368,6 +351,7 @@ mod tests {
     use apache_avro_test_helper::TestResult;
     use pretty_assertions::assert_eq;
     use std::collections::HashMap;
+    use std::sync::Arc;
     use uuid::Uuid;
 
     #[test]
@@ -417,7 +401,7 @@ mod tests {
         let schema = Schema::Decimal(DecimalSchema {
             inner: InnerDecimalSchema::Fixed(
                 FixedSchema::builder()
-                    .name(Name::new("decimal")?)
+                    .name(Name::new("decimal")?.into())
                     .size(2)
                     .build(),
             ),
@@ -444,7 +428,7 @@ mod tests {
         let schema = Schema::Decimal(DecimalSchema {
             inner: InnerDecimalSchema::Fixed(FixedSchema {
                 size: 13,
-                name: Name::new("decimal")?,
+                name: Name::new("decimal")?.into(),
                 aliases: None,
                 doc: None,
                 attributes: Default::default(),
@@ -887,7 +871,7 @@ mod tests {
 
         let fixed = FixedSchema {
             size: 16,
-            name: "uuid".try_into()?,
+            name: Arc::new("uuid".try_into()?),
             aliases: None,
             doc: None,
             attributes: Default::default(),

--- a/avro/src/decode.rs
+++ b/avro/src/decode.rs
@@ -68,8 +68,8 @@ fn decode_seq_len<R: Read>(reader: &mut R) -> AvroResult<usize> {
 }
 
 /// Decode a `Value` from avro format given its `Schema`.
-/// This function will always convert the supplied schema into a ResolvedSchema which
-/// may cuase performance concerns. Consider using decode_complete.
+/// This function will always convert the supplied schema into a [`ResolvedSchema`] which
+/// may cuase performance concerns. Consider using [`decode_complete`].
 pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> AvroResult<Value> {
     let resolved : ResolvedSchema = schema.clone().try_into()?;
     decode_complete(&resolved, reader)
@@ -78,7 +78,7 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> AvroResult<Value> {
 
 /// Decode a `Value` from avro format given its `Schema`.
 pub fn decode_complete<R: Read>(resolved_schema: &ResolvedSchema, reader: &mut R) -> AvroResult<Value> {
-    decode_internal(ResolvedNode::new(&resolved_schema), reader)
+    decode_internal(ResolvedNode::new(resolved_schema), reader)
 }
 
 pub(crate) fn decode_internal<R: Read>(

--- a/avro/src/encode.rs
+++ b/avro/src/encode.rs
@@ -15,29 +15,36 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::schema::{InnerDecimalSchema, NamespaceRef, UuidSchema};
+use crate::schema::{InnerDecimalSchema, UuidSchema, ResolvedNode, ResolvedRecord};
 use crate::{
     AvroResult,
     bigdecimal::serialize_big_decimal,
     error::Details,
     schema::{
-        DecimalSchema, EnumSchema, FixedSchema, Name, RecordSchema, ResolvedSchema, Schema,
-        SchemaKind, UnionSchema,
+        DecimalSchema, EnumSchema, FixedSchema, ResolvedSchema, Schema,
+        SchemaKind,
     },
     types::{Value, ValueKind},
     util::{zig_i32, zig_i64},
 };
 use log::error;
-use std::{borrow::Borrow, collections::HashMap, io::Write};
+use std::{collections::HashMap, io::Write, sync::Arc};
 
+///KTODO: documentation
 /// Encode a `Value` into avro format.
 ///
 /// **NOTE** This will not perform schema validation. The value is assumed to
 /// be valid with regards to the schema. Schema are needed only to guide the
 /// encoding for complex type values.
 pub fn encode<W: Write>(value: &Value, schema: &Schema, writer: &mut W) -> AvroResult<usize> {
-    let rs = ResolvedSchema::try_from(schema)?;
-    encode_internal(value, schema, rs.get_names(), None, writer)
+    let rs = ResolvedSchema::try_from(schema.clone())?;
+    encode_complete(value, rs, writer)
+}
+
+/// Encode a 'Value' into avro format given the provided ResolvedSchema.
+/// This is the preffered method over `encode`.
+pub fn encode_complete<W: Write>(value: &Value, resolved_schema: ResolvedSchema, writer: &mut W) -> AvroResult<usize> {
+    encode_internal(value, ResolvedNode::new(&resolved_schema), writer)
 }
 
 /// Encode `s` as the _bytes_ primitive type.
@@ -62,27 +69,15 @@ pub(crate) fn encode_int<W: Write>(i: i32, writer: W) -> AvroResult<usize> {
     zig_i32(i, writer)
 }
 
-pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
+pub(crate) fn encode_internal<W: Write>(
     value: &Value,
-    schema: &Schema,
-    names: &HashMap<Name, S>,
-    enclosing_namespace: NamespaceRef,
+    node: ResolvedNode,
     writer: &mut W,
 ) -> AvroResult<usize> {
-    if let Schema::Ref { name } = schema {
-        let fully_qualified_name = name.fully_qualified_name(enclosing_namespace);
-        let resolved = names
-            .get(&fully_qualified_name)
-            .ok_or(Details::SchemaResolutionError(
-                fully_qualified_name.into_owned(),
-            ))?;
-        return encode_internal(value, resolved.borrow(), names, enclosing_namespace, writer);
-    }
-
     match value {
         Value::Null => {
-            if let Schema::Union(union) = schema {
-                match union.schemas.iter().position(|sch| *sch == Schema::Null) {
+            if let ResolvedNode::Union(union) = node {
+                match union.resolve_schemas().iter().position(|sch| SchemaKind::from(sch) == SchemaKind::Null) {
                     None => Err(Details::EncodeValueAsSchemaError {
                         value_kind: ValueKind::Null,
                         supported_schema: vec![SchemaKind::Null, SchemaKind::Union],
@@ -113,8 +108,8 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
         Value::Double(x) => writer
             .write(&x.to_le_bytes())
             .map_err(|e| Details::WriteBytes(e).into()),
-        Value::Decimal(decimal) => match schema {
-            Schema::Decimal(DecimalSchema { inner, .. }) => match inner {
+        Value::Decimal(decimal) => match node {
+            ResolvedNode::Decimal(DecimalSchema { inner, .. }) => match inner {
                 InnerDecimalSchema::Fixed(fixed) => {
                     let bytes = decimal.to_sign_extended_bytes_with_len(fixed.size)?;
                     let num_bytes = bytes.len();
@@ -145,21 +140,21 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
                 .write(&slice)
                 .map_err(|e| Details::WriteBytes(e).into())
         }
-        Value::Uuid(uuid) => match *schema {
-            Schema::Uuid(UuidSchema::String) | Schema::String => encode_bytes(
+        Value::Uuid(uuid) => match node {
+            ResolvedNode::Uuid(UuidSchema::String) | ResolvedNode::String => encode_bytes(
                 // we need the call .to_string() to properly convert ASCII to UTF-8
                 #[allow(clippy::unnecessary_to_owned)]
                 &uuid.to_string(),
                 writer,
             ),
-            Schema::Uuid(UuidSchema::Bytes) | Schema::Bytes => {
+            ResolvedNode::Uuid(UuidSchema::Bytes) | ResolvedNode::Bytes => {
                 let bytes = uuid.as_bytes();
                 encode_bytes(bytes, writer)
             }
-            Schema::Uuid(UuidSchema::Fixed(FixedSchema { size, .. }))
-            | Schema::Fixed(FixedSchema { size, .. }) => {
-                if size != 16 {
-                    return Err(Details::ConvertFixedToUuid(size).into());
+            ResolvedNode::Uuid(UuidSchema::Fixed(FixedSchema { size, .. }))
+            | ResolvedNode::Fixed(FixedSchema { size, .. }) => {
+                if *size != 16 {
+                    return Err(Details::ConvertFixedToUuid(*size).into());
                 }
 
                 let bytes = uuid.as_bytes();
@@ -184,9 +179,9 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
                 .write(buf.as_slice())
                 .map_err(|e| Details::WriteBytes(e).into())
         }
-        Value::Bytes(bytes) => match *schema {
-            Schema::Bytes | Schema::Uuid(UuidSchema::Bytes) => encode_bytes(bytes, writer),
-            Schema::Fixed { .. } => writer
+        Value::Bytes(bytes) => match node {
+            ResolvedNode::Bytes | ResolvedNode::Uuid(UuidSchema::Bytes) => encode_bytes(bytes, writer),
+            ResolvedNode::Fixed { .. } => writer
                 .write(bytes.as_slice())
                 .map_err(|e| Details::WriteBytes(e).into()),
             _ => Err(Details::EncodeValueAsSchemaError {
@@ -195,9 +190,9 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
             }
             .into()),
         },
-        Value::String(s) => match *schema {
-            Schema::String | Schema::Uuid(UuidSchema::String) => encode_bytes(s, writer),
-            Schema::Enum(EnumSchema { ref symbols, .. }) => {
+        Value::String(s) => match node {
+            ResolvedNode::String | ResolvedNode::Uuid(UuidSchema::String) => encode_bytes(s, writer),
+            ResolvedNode::Enum(EnumSchema {symbols, .. }) => {
                 if let Some(index) = symbols.iter().position(|item| item == s) {
                     encode_int(index as i32, writer)
                 } else {
@@ -216,15 +211,15 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
             .map_err(|e| Details::WriteBytes(e).into()),
         Value::Enum(i, _) => encode_int(*i as i32, writer),
         Value::Union(idx, item) => {
-            if let Schema::Union(ref inner) = *schema {
-                let inner_schema = inner
-                    .schemas
+            if let ResolvedNode::Union(inner) = node {
+                let resolved = inner.resolve_schemas();
+                let inner_schema = resolved
                     .get(*idx as usize)
                     .expect("Invalid Union validation occurred");
                 encode_long(*idx as i64, &mut *writer)?;
-                encode_internal(item, inner_schema, names, enclosing_namespace, &mut *writer)
+                encode_internal(item, inner_schema.clone(), &mut *writer)
             } else {
-                error!("invalid schema type for Union: {schema:?}");
+                error!("invalid schema type for Union: {:?}", SchemaKind::from(&node));
                 Err(Details::EncodeValueAsSchemaError {
                     value_kind: ValueKind::Union,
                     supported_schema: vec![SchemaKind::Union],
@@ -233,16 +228,14 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
             }
         }
         Value::Array(items) => {
-            if let Schema::Array(ref inner) = *schema {
+            if let ResolvedNode::Array(inner) = node {
                 if !items.is_empty() {
                     encode_long(items.len() as i64, &mut *writer)?;
                     for item in items.iter() {
                         encode_internal(
                             item,
-                            &inner.items,
-                            names,
-                            enclosing_namespace,
-                            &mut *writer,
+                            inner.resolve_items(),
+                            &mut *writer
                         )?;
                     }
                 }
@@ -250,7 +243,7 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
                     .write(&[0u8])
                     .map_err(|e| Details::WriteBytes(e).into())
             } else {
-                error!("invalid schema type for Array: {schema:?}");
+                error!("invalid schema type for Array: {:?}", SchemaKind::from(&node));
                 Err(Details::EncodeValueAsSchemaError {
                     value_kind: ValueKind::Array,
                     supported_schema: vec![SchemaKind::Array],
@@ -259,16 +252,14 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
             }
         }
         Value::Map(items) => {
-            if let Schema::Map(ref inner) = *schema {
+            if let ResolvedNode::Map(inner) = node {
                 if !items.is_empty() {
                     encode_long(items.len() as i64, &mut *writer)?;
                     for (key, value) in items {
                         encode_bytes(key, &mut *writer)?;
                         encode_internal(
                             value,
-                            &inner.types,
-                            names,
-                            enclosing_namespace,
+                            inner.resolve_types(),
                             &mut *writer,
                         )?;
                     }
@@ -277,7 +268,7 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
                     .write(&[0u8])
                     .map_err(|e| Details::WriteBytes(e).into())
             } else {
-                error!("invalid schema type for Map: {schema:?}");
+                error!("invalid schema type for Map: {:?}", SchemaKind::from(&node));
                 Err(Details::EncodeValueAsSchemaError {
                     value_kind: ValueKind::Map,
                     supported_schema: vec![SchemaKind::Map],
@@ -286,14 +277,11 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
             }
         }
         Value::Record(value_fields) => {
-            if let Schema::Record(RecordSchema {
-                ref name,
-                fields: ref schema_fields,
+            if let ResolvedNode::Record(ResolvedRecord {
+                fields: schema_fields,
                 ..
-            }) = *schema
+            }) = node
             {
-                let record_namespace = name.namespace().or(enclosing_namespace);
-
                 let mut lookup = HashMap::new();
                 value_fields.iter().for_each(|(name, field)| {
                     lookup.insert(name, field);
@@ -301,7 +289,7 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
 
                 let mut written_bytes = 0;
                 for schema_field in schema_fields.iter() {
-                    let name = &schema_field.name;
+                    let name = schema_field.name;
                     let value_opt = lookup.get(name).or_else(|| {
                         schema_field
                             .aliases
@@ -312,9 +300,7 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
                     if let Some(value) = value_opt {
                         written_bytes += encode_internal(
                             value,
-                            &schema_field.schema,
-                            names,
-                            record_namespace,
+                            schema_field.resolve_field(),
                             writer,
                         )?;
                     } else {
@@ -326,15 +312,13 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
                     }
                 }
                 Ok(written_bytes)
-            } else if let Schema::Union(UnionSchema { schemas, .. }) = schema {
+            } else if let ResolvedNode::Union(resolved_union) = node {
                 let mut union_buffer: Vec<u8> = Vec::new();
-                for (index, schema) in schemas.iter().enumerate() {
+                for (index, schema) in resolved_union.resolve_schemas().iter().enumerate() {
                     encode_long(index as i64, &mut union_buffer)?;
                     let encode_res = encode_internal(
                         value,
-                        schema,
-                        names,
-                        enclosing_namespace,
+                        schema.clone(),
                         &mut union_buffer,
                     );
                     match encode_res {
@@ -354,7 +338,7 @@ pub(crate) fn encode_internal<W: Write, S: Borrow<Schema>>(
                 }
                 .into())
             } else {
-                error!("invalid schema type for Record: {schema:?}");
+                error!("invalid schema type for Record: {:?}", SchemaKind::from(&node));
                 Err(Details::EncodeValueAsSchemaError {
                     value_kind: ValueKind::Record,
                     supported_schema: vec![SchemaKind::Record, SchemaKind::Union],
@@ -975,7 +959,7 @@ pub(crate) mod tests {
     fn avro_3926_encode_decode_uuid_to_fixed_wrong_schema_size() -> TestResult {
         let schema = Schema::Fixed(FixedSchema {
             size: 15,
-            name: "uuid".try_into()?,
+            name: Arc::new("uuid".try_into()?),
             aliases: None,
             doc: None,
             attributes: Default::default(),

--- a/avro/src/encode.rs
+++ b/avro/src/encode.rs
@@ -28,21 +28,27 @@ use crate::{
     util::{zig_i32, zig_i64},
 };
 use log::error;
-use std::{collections::HashMap, io::Write, sync::Arc};
+use std::{collections::HashMap, io::Write};
 
-///KTODO: documentation
-/// Encode a `Value` into avro format.
+/// Encode a `Value` into avro format. This function will first attempt to convert the provided [`Schema`] into a [`ResolvedSchema`]
+/// and will produce an error if this conversion is not successful. If a [`ResolvedSchema`] is
+/// already on hand, it is more performant to use [`encode_complete`].
 ///
 /// **NOTE** This will not perform schema validation. The value is assumed to
 /// be valid with regards to the schema. Schema are needed only to guide the
 /// encoding for complex type values.
+///
 pub fn encode<W: Write>(value: &Value, schema: &Schema, writer: &mut W) -> AvroResult<usize> {
     let rs = ResolvedSchema::try_from(schema.clone())?;
     encode_complete(value, rs, writer)
 }
 
-/// Encode a 'Value' into avro format given the provided ResolvedSchema.
-/// This is the preffered method over `encode`.
+/// Encode a 'Value' into avro format given the provided [`ResolvedSchema`].
+///
+/// **NOTE** This will not perform schema validation. The value is assumed to
+/// be valid with regards to the schema. Schema are needed only to guide the
+/// encoding for complex type values.
+///
 pub fn encode_complete<W: Write>(value: &Value, resolved_schema: ResolvedSchema, writer: &mut W) -> AvroResult<usize> {
     encode_internal(value, ResolvedNode::new(&resolved_schema), writer)
 }
@@ -359,6 +365,7 @@ pub fn encode_to_vec(value: &Value, schema: &Schema) -> AvroResult<Vec<u8>> {
 #[allow(clippy::expect_fun_call)]
 pub(crate) mod tests {
     use super::*;
+    use std::sync::Arc;
     use crate::error::{Details, Error};
     use apache_avro_test_helper::TestResult;
     use pretty_assertions::assert_eq;

--- a/avro/src/error.rs
+++ b/avro/src/error.rs
@@ -88,6 +88,11 @@ pub enum Details {
     #[error("Two schemas with the same fullname were given: {0:?}")]
     NameCollision(String),
 
+    /// Error for when we are redefining schemata that already exists in
+    /// a resolving context
+    #[error("Schamata with fullnames: {0:?}, already have definitions in this context.")]
+    MultipleNameCollision(Vec<String>),
+
     #[error("Not a fixed or bytes type, required for decimal schema, got: {0:?}")]
     ResolveDecimalSchema(SchemaKind),
 
@@ -598,6 +603,21 @@ pub enum Details {
     /// Error while resolving [`Schema::Ref`]
     #[error("Unresolved schema reference: {0}")]
     SchemaResolutionError(Name),
+
+    /// Error while resolving Schema::Ref with message
+    /// from resolver
+    #[error("Unresolved schema reference: {0}. Error message: {1}")]
+    SchemaResolutionErrorWithMsg(Name, String),
+
+    /// Error thrown when no schema with provided name
+    /// is found in a ResolvedContext
+    #[error("Could not find schema with name: {0} in this context")]
+    SchemaLookupError(Name),
+
+    /// Resolver did not return schemata with expected name
+    #[error("Custom resolver did not return schema definition for expected name. Expected name: {0:?}, Names
+        received from resolver: {1:?}")]
+    CustomSchemaResolverMismatch(Name, Vec<Name>),
 
     #[error("The file metadata is already flushed.")]
     FileHeaderAlreadyWritten,

--- a/avro/src/error.rs
+++ b/avro/src/error.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::{
-    AvroResult, schema::{Name, Schema, SchemaKind, UnionSchema}, types::{Value, ValueKind}
+    schema::{Name, Schema, SchemaKind, UnionSchema}, types::{Value, ValueKind}
 };
 use std::{error::Error as _, fmt};
 
@@ -429,7 +429,7 @@ pub enum Details {
     #[error("No `type` in complex type")]
     GetComplexTypeField,
 
-    #[error("Given json value {value:?} is not allowed to be the value of \"type\" when interpreting a JSON object as a schema. Only builtin type names as strings are allowed")]
+    #[error("Json value {value:?} is not allowed to be the value of \"type\" inside a schema JSON object. Only built-in type names as strings are allowed")]
     JsonSchemaTypeNotAllowed{
         value: serde_json::Value,
     },
@@ -618,13 +618,13 @@ pub enum Details {
     #[error("Unresolved schema reference: {0}")]
     SchemaResolutionError(Name),
 
-    /// Error while resolving Schema::Ref with message
+    /// Error while resolving `Schema::Ref` with message
     /// from resolver
     #[error("Unresolved schema reference: {0}. Error message: {1}")]
     SchemaResolutionErrorWithMsg(Name, String),
 
     /// Error thrown when no schema with provided name
-    /// is found in a ResolvedContext
+    /// is found in a `ResolvedContext`
     #[error("Could not find schema with name: {0} in this context")]
     SchemaLookupError(Name),
 
@@ -633,9 +633,8 @@ pub enum Details {
         received from resolver: {1:?}")]
     CustomSchemaResolverMismatch(Name, Vec<Name>),
 
-    /// Wrapper error for a collection of errors when attempting to resolve several schema
-    /// KTODO: check on this!
-    #[error("Error when resolving: error messages: {0:?}")]
+    /// One or more errors encountered while resolving schema references.
+    #[error("{}", display_resolution_errors(.0))]
     ResolvedSchemaCreationError(Vec<Error>),
 
     #[error("The file metadata is already flushed.")]
@@ -752,6 +751,20 @@ impl serde::ser::Error for Details {
 impl serde::de::Error for Details {
     fn custom<T: fmt::Display>(msg: T) -> Self {
         Details::DeserializeValue(msg.to_string())
+    }
+}
+
+fn display_resolution_errors(errors: &[Error]) -> String {
+    match errors.len() {
+        0 => "Schema resolution failed (no details available)".to_string(),
+        1 => format!("Schema resolution failed: {}", errors[0]),
+        n => {
+            let mut msg = format!("Schema resolution failed with {n} errors:");
+            for (i, err) in errors.iter().enumerate() {
+                msg.push_str(&format!("\n  {}: {err}", i + 1));
+            }
+            msg
+        }
     }
 }
 

--- a/avro/src/error.rs
+++ b/avro/src/error.rs
@@ -16,8 +16,7 @@
 // under the License.
 
 use crate::{
-    schema::{Name, Schema, SchemaKind, UnionSchema},
-    types::{Value, ValueKind},
+    AvroResult, schema::{Name, Schema, SchemaKind, UnionSchema}, types::{Value, ValueKind}
 };
 use std::{error::Error as _, fmt};
 
@@ -112,6 +111,16 @@ pub enum Details {
         value: Value,
         schema: Schema,
         reason: String,
+    },
+
+    /// Describes error when performing defualt validation:
+    #[error("Provided defualt for field {field_name:?} in record {record_name:?} with schema {schema:?} does not validate with the provided defualt value {value:?}. Reason: {reason}")]
+    DefaultValidationWithReason {
+        record_name: String,
+        field_name: String,
+        value: serde_json::Value,
+        schema: Schema,
+        reason: String
     },
 
     #[error(
@@ -420,6 +429,11 @@ pub enum Details {
     #[error("No `type` in complex type")]
     GetComplexTypeField,
 
+    #[error("Given json value {value:?} is not allowed to be the value of \"type\" when interpreting a JSON object as a schema. Only builtin type names as strings are allowed")]
+    JsonSchemaTypeNotAllowed{
+        value: serde_json::Value,
+    },
+
     #[error("No `type` in record field")]
     GetRecordFieldTypeField,
 
@@ -618,6 +632,11 @@ pub enum Details {
     #[error("Custom resolver did not return schema definition for expected name. Expected name: {0:?}, Names
         received from resolver: {1:?}")]
     CustomSchemaResolverMismatch(Name, Vec<Name>),
+
+    /// Wrapper error for a collection of errors when attempting to resolve several schema
+    /// KTODO: check on this!
+    #[error("Error when resolving: error messages: {0:?}")]
+    ResolvedSchemaCreationError(Vec<Error>),
 
     #[error("The file metadata is already flushed.")]
     FileHeaderAlreadyWritten,

--- a/avro/src/reader/block.rs
+++ b/avro/src/reader/block.rs
@@ -203,9 +203,7 @@ impl<'r, R: Read> Block<'r, R> {
         Ok(Some(item))
     }
 
-    fn read_writer_schema(&mut self, metadata: &HashMap<String, Value>) -> AvroResult<()> { // KTODO,
-                                                                                            // Include
-                                                                                            // atest here, mine expands this
+    fn read_writer_schema(&mut self, metadata: &HashMap<String, Value>) -> AvroResult<()> {
         let json: serde_json::Value = metadata
             .get("avro.schema")
             .and_then(|bytes| {
@@ -219,7 +217,7 @@ impl<'r, R: Read> Block<'r, R> {
         let writer_from_stream = Schema::parse(&json)?;
         let writer_from_stream_with_symbols : SchemaWithSymbols = writer_from_stream.clone().into();
         let schemata_with_symbols : Vec<SchemaWithSymbols> = self.schemata.iter().map(|schema|{SchemaWithSymbols::from((*schema).clone())}).collect();
-        let [writer_from_stream_resolved] = ResolvedSchema::resolve().additional(schemata_with_symbols)?.build_array([writer_from_stream_with_symbols])?;
+        let [writer_from_stream_resolved] = ResolvedSchema::builder().additional(schemata_with_symbols)?.build_array([writer_from_stream_with_symbols])?;
         self.writer_schema = writer_from_stream;
         self.resolved_writer = writer_from_stream_resolved;
         Ok(())

--- a/avro/src/reader/block.rs
+++ b/avro/src/reader/block.rs
@@ -19,7 +19,7 @@ use crate::{
     AvroResult, Codec, Error,
     decode::{decode, decode_internal},
     error::Details,
-    schema::{Names, Schema, resolve_names, resolve_names_with_schemata},
+    schema::{ResolvedNode, ResolvedSchema, Schema, SchemaWithSymbols},
     types::Value,
     util,
 };
@@ -45,7 +45,7 @@ pub(super) struct Block<'r, R> {
     pub(super) writer_schema: Schema,
     schemata: Vec<&'r Schema>,
     pub(super) user_metadata: HashMap<String, Vec<u8>>,
-    names_refs: Names,
+    resolved_writer: ResolvedSchema
 }
 
 impl<'r, R: Read> Block<'r, R> {
@@ -60,7 +60,7 @@ impl<'r, R: Read> Block<'r, R> {
             message_count: 0,
             marker: [0; 16],
             user_metadata: Default::default(),
-            names_refs: Default::default(),
+            resolved_writer: ResolvedSchema::new_empty(),
         };
 
         block.read_header()?;
@@ -186,9 +186,7 @@ impl<'r, R: Read> Block<'r, R> {
         let b_original = block_bytes.len();
 
         let item = decode_internal(
-            &self.writer_schema,
-            &self.names_refs,
-            None,
+            ResolvedNode::new(&self.resolved_writer),
             &mut block_bytes,
         )?;
         let item = match read_schema {
@@ -205,7 +203,9 @@ impl<'r, R: Read> Block<'r, R> {
         Ok(Some(item))
     }
 
-    fn read_writer_schema(&mut self, metadata: &HashMap<String, Value>) -> AvroResult<()> {
+    fn read_writer_schema(&mut self, metadata: &HashMap<String, Value>) -> AvroResult<()> { // KTODO,
+                                                                                            // Include
+                                                                                            // atest here, mine expands this
         let json: serde_json::Value = metadata
             .get("avro.schema")
             .and_then(|bytes| {
@@ -216,22 +216,12 @@ impl<'r, R: Read> Block<'r, R> {
                 }
             })
             .ok_or(Details::GetAvroSchemaFromMap)?;
-        if !self.schemata.is_empty() {
-            let mut names = HashMap::new();
-            resolve_names_with_schemata(
-                self.schemata.iter().copied(),
-                &mut names,
-                None,
-                &HashMap::new(),
-            )?;
-            self.names_refs = names.into_iter().map(|(n, s)| (n, s.clone())).collect();
-            self.writer_schema = Schema::parse_with_names(&json, self.names_refs.clone())?;
-        } else {
-            self.writer_schema = Schema::parse(&json)?;
-            let mut names = HashMap::new();
-            resolve_names(&self.writer_schema, &mut names, None, &HashMap::new())?;
-            self.names_refs = names.into_iter().map(|(n, s)| (n, s.clone())).collect();
-        }
+        let writer_from_stream = Schema::parse(&json)?;
+        let writer_from_stream_with_symbols : SchemaWithSymbols = writer_from_stream.clone().into();
+        let schemata_with_symbols : Vec<SchemaWithSymbols> = self.schemata.iter().map(|schema|{SchemaWithSymbols::from((*schema).clone())}).collect();
+        let [writer_from_stream_resolved] = ResolvedSchema::from_with_symbols_array([writer_from_stream_with_symbols], schemata_with_symbols)?;
+        self.writer_schema = writer_from_stream;
+        self.resolved_writer = writer_from_stream_resolved;
         Ok(())
     }
 

--- a/avro/src/reader/block.rs
+++ b/avro/src/reader/block.rs
@@ -219,7 +219,7 @@ impl<'r, R: Read> Block<'r, R> {
         let writer_from_stream = Schema::parse(&json)?;
         let writer_from_stream_with_symbols : SchemaWithSymbols = writer_from_stream.clone().into();
         let schemata_with_symbols : Vec<SchemaWithSymbols> = self.schemata.iter().map(|schema|{SchemaWithSymbols::from((*schema).clone())}).collect();
-        let [writer_from_stream_resolved] = ResolvedSchema::from_with_symbols_array([writer_from_stream_with_symbols], schemata_with_symbols)?;
+        let [writer_from_stream_resolved] = ResolvedSchema::resolve().additional(schemata_with_symbols)?.build_array([writer_from_stream_with_symbols])?;
         self.writer_schema = writer_from_stream;
         self.resolved_writer = writer_from_stream_resolved;
         Ok(())

--- a/avro/src/reader/datum.rs
+++ b/avro/src/reader/datum.rs
@@ -89,7 +89,7 @@ impl<'s, S: generic_datum_reader_builder::State> GenericDatumReaderBuilder<'s, S
     where
         S::ResolvedWriterSchemata: generic_datum_reader_builder::IsUnset,
     {
-        let [resolved] = ResolvedSchema::resolve().additional(schemata)?.build_array([self.writer_schema])?;
+        let [resolved] = ResolvedSchema::builder().additional(schemata)?.build_array([self.writer_schema])?;
         Ok(self.resolved_writer_schemata(resolved))
     }
 
@@ -110,7 +110,7 @@ impl<'s, S: generic_datum_reader_builder::State> GenericDatumReaderBuilder<'s, S
         S::ResolvedReaderSchemata: generic_datum_reader_builder::IsUnset,
         S::ReaderSchema: generic_datum_reader_builder::IsUnset,
     {
-        let [resolved] = ResolvedSchema::resolve().additional(schemata)?.build_array([schema])?;
+        let [resolved] = ResolvedSchema::builder().additional(schemata)?.build_array([schema])?;
         Ok(self.reader_schema(schema).resolved_reader_schemata(resolved))
     }
     pub fn maybe_reader_schema_with_schemata(
@@ -125,7 +125,7 @@ impl<'s, S: generic_datum_reader_builder::State> GenericDatumReaderBuilder<'s, S
         S::ReaderSchema: generic_datum_reader_builder::IsUnset,
     {
         if let Some(schema) = schema {
-            let [resolved] = ResolvedSchema::resolve().additional(schemata)?.build_array([schema])?;
+            let [resolved] = ResolvedSchema::builder().additional(schemata)?.build_array([schema])?;
             Ok(self.reader_schema(schema).resolved_reader_schemata(resolved))
         } else {
             Ok(self

--- a/avro/src/reader/datum.rs
+++ b/avro/src/reader/datum.rs
@@ -89,7 +89,7 @@ impl<'s, S: generic_datum_reader_builder::State> GenericDatumReaderBuilder<'s, S
     where
         S::ResolvedWriterSchemata: generic_datum_reader_builder::IsUnset,
     {
-        let [resolved] = ResolvedSchema::from_schema_array([self.writer_schema], schemata)?;
+        let [resolved] = ResolvedSchema::resolve().additional(schemata)?.build_array([self.writer_schema])?;
         Ok(self.resolved_writer_schemata(resolved))
     }
 
@@ -110,7 +110,7 @@ impl<'s, S: generic_datum_reader_builder::State> GenericDatumReaderBuilder<'s, S
         S::ResolvedReaderSchemata: generic_datum_reader_builder::IsUnset,
         S::ReaderSchema: generic_datum_reader_builder::IsUnset,
     {
-        let [resolved] = ResolvedSchema::from_schema_array([schema],schemata)?;
+        let [resolved] = ResolvedSchema::resolve().additional(schemata)?.build_array([schema])?;
         Ok(self.reader_schema(schema).resolved_reader_schemata(resolved))
     }
     pub fn maybe_reader_schema_with_schemata(
@@ -125,7 +125,7 @@ impl<'s, S: generic_datum_reader_builder::State> GenericDatumReaderBuilder<'s, S
         S::ReaderSchema: generic_datum_reader_builder::IsUnset,
     {
         if let Some(schema) = schema {
-            let [resolved] = ResolvedSchema::from_schema_array([schema], schemata)?;
+            let [resolved] = ResolvedSchema::resolve().additional(schemata)?.build_array([schema])?;
             Ok(self.reader_schema(schema).resolved_reader_schemata(resolved))
         } else {
             Ok(self

--- a/avro/src/reader/datum.rs
+++ b/avro/src/reader/datum.rs
@@ -19,7 +19,7 @@ use std::io::Read;
 
 use bon::bon;
 
-use crate::{AvroResult, Schema, decode::decode_internal, schema::ResolvedSchema, types::Value};
+use crate::{AvroResult, Schema, decode::decode_internal, schema::{ResolvedNode, ResolvedSchema}, types::Value};
 
 /// Reader for reading raw Avro data.
 ///
@@ -28,8 +28,8 @@ use crate::{AvroResult, Schema, decode::decode_internal, schema::ResolvedSchema,
 /// [`SpecificSingleObjectReader`][crate::SpecificSingleObjectReader] instead.
 pub struct GenericDatumReader<'s> {
     writer: &'s Schema,
-    resolved: ResolvedSchema<'s>,
-    reader: Option<(&'s Schema, ResolvedSchema<'s>)>,
+    resolved: ResolvedSchema,
+    reader: Option<(&'s Schema, ResolvedSchema)>,
 }
 
 #[bon]
@@ -45,11 +45,11 @@ impl<'s> GenericDatumReader<'s> {
         #[builder(start_fn)]
         writer_schema: &'s Schema,
         /// Already resolved schemata that will be used to resolve references in the writer's schema.
-        resolved_writer_schemata: Option<ResolvedSchema<'s>>,
+        resolved_writer_schemata: Option<ResolvedSchema>,
         /// The schema that will be used to resolve the value to conform the the new schema.
         reader_schema: Option<&'s Schema>,
         /// Already resolved schemata that will be used to resolve references in the reader's schema.
-        resolved_reader_schemata: Option<ResolvedSchema<'s>>,
+        resolved_reader_schemata: Option<ResolvedSchema>,
     ) -> AvroResult<Self> {
         let resolved_writer_schemata = if let Some(resolved) = resolved_writer_schemata {
             resolved
@@ -89,7 +89,7 @@ impl<'s, S: generic_datum_reader_builder::State> GenericDatumReaderBuilder<'s, S
     where
         S::ResolvedWriterSchemata: generic_datum_reader_builder::IsUnset,
     {
-        let resolved = ResolvedSchema::new_with_schemata(schemata)?;
+        let [resolved] = ResolvedSchema::from_schema_array([self.writer_schema], schemata)?;
         Ok(self.resolved_writer_schemata(resolved))
     }
 
@@ -99,27 +99,49 @@ impl<'s, S: generic_datum_reader_builder::State> GenericDatumReaderBuilder<'s, S
     /// If you already have a [`ResolvedSchema`], use that function instead.
     ///
     /// This function can only be called after the reader schema is set.
-    pub fn reader_schemata(
+    pub fn reader_schema_with_schemata(
         self,
+        schema: &'s Schema,
         schemata: Vec<&'s Schema>,
     ) -> AvroResult<
-        GenericDatumReaderBuilder<'s, generic_datum_reader_builder::SetResolvedReaderSchemata<S>>,
+        GenericDatumReaderBuilder<'s, generic_datum_reader_builder::SetResolvedReaderSchemata<generic_datum_reader_builder::SetReaderSchema<S>>>,
     >
     where
         S::ResolvedReaderSchemata: generic_datum_reader_builder::IsUnset,
-        S::ReaderSchema: generic_datum_reader_builder::IsSet,
+        S::ReaderSchema: generic_datum_reader_builder::IsUnset,
     {
-        let resolved = ResolvedSchema::new_with_schemata(schemata)?;
-        Ok(self.resolved_reader_schemata(resolved))
+        let [resolved] = ResolvedSchema::from_schema_array([schema],schemata)?;
+        Ok(self.reader_schema(schema).resolved_reader_schemata(resolved))
     }
+    pub fn maybe_reader_schema_with_schemata(
+    self,
+    schema: Option<&'s Schema>,
+    schemata: Vec<&'s Schema>,
+) -> AvroResult<
+        GenericDatumReaderBuilder<'s, generic_datum_reader_builder::SetResolvedReaderSchemata<generic_datum_reader_builder::SetReaderSchema<S>>>,
+    >
+    where
+        S::ResolvedReaderSchemata: generic_datum_reader_builder::IsUnset,
+        S::ReaderSchema: generic_datum_reader_builder::IsUnset,
+    {
+        if let Some(schema) = schema {
+            let [resolved] = ResolvedSchema::from_schema_array([schema], schemata)?;
+            Ok(self.reader_schema(schema).resolved_reader_schemata(resolved))
+        } else {
+            Ok(self
+                .maybe_reader_schema(None)
+                .maybe_resolved_reader_schemata(None))
+        }
+    }
+
 }
 
 impl<'s> GenericDatumReader<'s> {
     /// Read a Avro datum from the reader.
     pub fn read_value<R: Read>(&self, reader: &mut R) -> AvroResult<Value> {
-        let value = decode_internal(self.writer, self.resolved.get_names(), None, reader)?;
-        if let Some((reader, resolved)) = &self.reader {
-            value.resolve_internal(reader, resolved.get_names(), None, &None)
+        let value = decode_internal(ResolvedNode::new(&self.resolved), reader)?;
+        if let Some((_reader, resolved)) = &self.reader {
+            value.resolve_internal(ResolvedNode::new(resolved))
         } else {
             Ok(value)
         }
@@ -215,8 +237,7 @@ pub fn from_avro_datum_reader_schemata<R: Read>(
 ) -> AvroResult<Value> {
     GenericDatumReader::builder(writer_schema)
         .writer_schemata(writer_schemata)?
-        .maybe_reader_schema(reader_schema)
-        .reader_schemata(reader_schemata)?
+        .maybe_reader_schema_with_schemata(reader_schema, reader_schemata)?
         .build()?
         .read_value(reader)
 }

--- a/avro/src/reader/mod.rs
+++ b/avro/src/reader/mod.rs
@@ -69,7 +69,7 @@ impl<'a, R: Read> Reader<'a, R> {
         reader_schema: Option<&'a Schema>,
         schemata: Option<Vec<&'a Schema>>,
     ) -> AvroResult<Reader<'a, R>> {
-        let schemata = schemata.unwrap_or_else(|| vec![]);
+        let schemata = schemata.unwrap_or_default();
         let block = Block::new(reader, schemata)?;
         let mut reader = Reader {
             block,

--- a/avro/src/reader/mod.rs
+++ b/avro/src/reader/mod.rs
@@ -69,9 +69,7 @@ impl<'a, R: Read> Reader<'a, R> {
         reader_schema: Option<&'a Schema>,
         schemata: Option<Vec<&'a Schema>>,
     ) -> AvroResult<Reader<'a, R>> {
-        let schemata =
-            schemata.unwrap_or_else(|| reader_schema.map(|rs| vec![rs]).unwrap_or_default());
-
+        let schemata = schemata.unwrap_or_else(|| vec![]);
         let block = Block::new(reader, schemata)?;
         let mut reader = Reader {
             block,

--- a/avro/src/reader/single_object.rs
+++ b/avro/src/reader/single_object.rs
@@ -18,7 +18,7 @@
 use crate::decode::decode_internal;
 use crate::error::Details;
 use crate::headers::{HeaderBuilder, RabinFingerprintHeader};
-use crate::schema::ResolvedOwnedSchema;
+use crate::schema::{ResolvedNode, ResolvedSchema};
 use crate::types::Value;
 use crate::{AvroResult, AvroSchema, Schema, from_value};
 use serde::de::DeserializeOwned;
@@ -26,7 +26,7 @@ use std::io::Read;
 use std::marker::PhantomData;
 
 pub struct GenericSingleObjectReader {
-    write_schema: ResolvedOwnedSchema,
+    write_schema: ResolvedSchema,
     expected_header: Vec<u8>,
 }
 
@@ -42,7 +42,7 @@ impl GenericSingleObjectReader {
     ) -> AvroResult<GenericSingleObjectReader> {
         let expected_header = header_builder.build_header();
         Ok(GenericSingleObjectReader {
-            write_schema: ResolvedOwnedSchema::try_from(schema)?,
+            write_schema: ResolvedSchema::try_from(schema)?,
             expected_header,
         })
     }
@@ -53,9 +53,7 @@ impl GenericSingleObjectReader {
             Ok(_) => {
                 if self.expected_header == header {
                     decode_internal(
-                        self.write_schema.get_root_schema(),
-                        self.write_schema.get_names(),
-                        None,
+                        ResolvedNode::new(&self.write_schema),
                         reader,
                     )
                 } else {

--- a/avro/src/schema/builders.rs
+++ b/avro/src/schema/builders.rs
@@ -32,13 +32,11 @@ impl Schema {
     #[builder(finish_fn = build)]
     pub fn map(
         #[builder(start_fn)] types: Schema,
-        default: Option<HashMap<String, Value>>,
         attributes: Option<BTreeMap<String, JsonValue>>,
     ) -> Self {
         let attributes = attributes.unwrap_or_default();
         Schema::Map(MapSchema {
             types: Box::new(types),
-            default,
             attributes,
         })
     }
@@ -48,13 +46,11 @@ impl Schema {
     #[builder(finish_fn = build)]
     pub fn array(
         #[builder(start_fn)] items: Schema,
-        default: Option<Vec<Value>>,
         attributes: Option<BTreeMap<String, JsonValue>>,
     ) -> Self {
         let attributes = attributes.unwrap_or_default();
         Schema::Array(ArraySchema {
             items: Box::new(items),
-            default,
             attributes,
         })
     }
@@ -73,7 +69,7 @@ impl Schema {
         let attributes = attributes.unwrap_or_default();
         let symbols = symbols.into_iter().map(Into::into).collect();
         Schema::Enum(EnumSchema {
-            name,
+            name: name.into(),
             symbols,
             aliases,
             doc,
@@ -94,7 +90,7 @@ impl Schema {
     ) -> Self {
         let attributes = attributes.unwrap_or_default();
         Schema::Fixed(FixedSchema {
-            name,
+            name: name.into(),
             size,
             aliases,
             doc,
@@ -115,7 +111,7 @@ impl Schema {
         let fields = fields.unwrap_or_default();
         let attributes = attributes.unwrap_or_default();
         let record_schema = RecordSchema::builder()
-            .name(name)
+            .name(name.into())
             .fields(fields)
             .aliases(aliases)
             .doc(doc)
@@ -147,7 +143,7 @@ mod tests {
         let schema = Schema::r#enum(name.clone(), symbols.clone()).build();
 
         if let Schema::Enum(enum_schema) = schema {
-            assert_eq!(enum_schema.name, name);
+            assert_eq!(enum_schema.name, name.into());
             assert_eq!(enum_schema.symbols, symbols);
             assert_eq!(enum_schema.aliases, None);
             assert_eq!(enum_schema.doc, None);
@@ -178,7 +174,7 @@ mod tests {
             .build();
 
         if let Schema::Enum(enum_schema) = schema {
-            assert_eq!(enum_schema.name, name);
+            assert_eq!(enum_schema.name, name.into());
             assert_eq!(enum_schema.symbols, symbols);
             assert_eq!(enum_schema.aliases, Some(aliases));
             assert_eq!(enum_schema.doc, Some(doc.into()));
@@ -199,7 +195,7 @@ mod tests {
         let schema = Schema::fixed(name.clone(), size).build();
 
         if let Schema::Fixed(fixed_schema) = schema {
-            assert_eq!(fixed_schema.name, name);
+            assert_eq!(fixed_schema.name, name.into());
             assert_eq!(fixed_schema.size, size);
             assert_eq!(fixed_schema.aliases, None);
             assert_eq!(fixed_schema.doc, None);
@@ -227,7 +223,7 @@ mod tests {
             .build();
 
         if let Schema::Fixed(fixed_schema) = schema {
-            assert_eq!(fixed_schema.name, name);
+            assert_eq!(fixed_schema.name, name.into());
             assert_eq!(fixed_schema.size, size);
             assert_eq!(fixed_schema.aliases, Some(aliases));
             assert_eq!(fixed_schema.doc, Some(doc.into()));
@@ -246,7 +242,7 @@ mod tests {
         let schema = Schema::record(name.clone()).build();
 
         if let Schema::Record(record_schema) = schema {
-            assert_eq!(record_schema.name, name);
+            assert_eq!(record_schema.name, name.into());
             assert_eq!(record_schema.fields, vec![]);
             assert_eq!(record_schema.aliases, None);
             assert_eq!(record_schema.doc, None);
@@ -285,7 +281,7 @@ mod tests {
             .build();
 
         if let Schema::Record(fixed_schema) = schema {
-            assert_eq!(fixed_schema.name, name);
+            assert_eq!(fixed_schema.name, name.into());
             assert_eq!(fixed_schema.fields, fields);
             assert_eq!(fixed_schema.aliases, Some(aliases));
             assert_eq!(fixed_schema.doc, Some(doc.into()));

--- a/avro/src/schema/builders.rs
+++ b/avro/src/schema/builders.rs
@@ -19,11 +19,10 @@ use crate::schema::{
     Alias, ArraySchema, EnumSchema, FixedSchema, MapSchema, Name, RecordField, RecordSchema,
     UnionSchema,
 };
-use crate::types::Value;
 use crate::{AvroResult, Schema};
 use bon::bon;
 use serde_json::Value as JsonValue;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap};
 
 #[bon]
 impl Schema {

--- a/avro/src/schema/mod.rs
+++ b/avro/src/schema/mod.rs
@@ -27,8 +27,10 @@ mod union;
 pub use crate::schema::{
     name::{Alias, Aliases, Name, Names, NamesRef, Namespace, NamespaceRef, NameMap, NameSet},
     record::{RecordField, RecordFieldBuilder, RecordSchema, RecordSchemaBuilder},
-    resolve::{ResolvedSchema, ResolvedNode, ResolvedRecord, ResolvedUnion,
-        ResolvedArray, ResolvedMap, ResolvedRecordField, CompleteSchema},
+    resolve::{ResolvedSchema, ResolvedSchemaBuilder, IntoSchemaWithSymbols,
+        ResolvedNode, ResolvedRecord, ResolvedUnion,
+        ResolvedArray, ResolvedMap, ResolvedRecordField, CompleteSchema,
+        Resolver, DefaultResolver},
     union::{UnionSchema, UnionSchemaBuilder},
 };
 use crate::{
@@ -80,10 +82,19 @@ impl fmt::Display for SchemaFingerprint {
     }
 }
 
+
+#[derive(Debug)]
+pub struct DefaultToResolve{
+    field_name: String,
+    record_name: String,
+    schema: Schema,
+    json: JsonValue
+}
+
+/// KDOTO: docs!
 /// Represents a parsed Avro schema with information on
 /// what named schemata are exposed by the schema as well
 /// as schemata names used and defined by this schema.
-
 #[derive(Clone,Debug)]
 pub struct SchemaWithSymbols{
     /// schema fullnames defined in this schema.
@@ -92,11 +103,11 @@ pub struct SchemaWithSymbols{
     /// an internal resolution and those that are internally unresolved.
     pub(crate) referenced_names: HashSet<Arc<Name>>,
     /// The parseed schema tree
-    pub(crate) schema: Arc<Schema>,
+    pub(crate) stub: Arc<Schema>,
     /// Record fields that have defualt values that need to be
     /// resolved.
     /// KTODO: documentation
-    pub(crate) field_defaults_to_resolve: Vec<(Schema, JsonValue)>
+    pub(crate) field_defaults_to_resolve: Arc<Vec<DefaultToResolve>>
 }
 
 
@@ -125,6 +136,77 @@ impl SchemaWithSymbols{
             let parser = Parser::default();
             parser.parse_str(str.as_ref())
         }).collect()
+    }
+
+    pub fn unravel(&self) -> Schema{
+        let mut stub = self.stub.as_ref().clone();
+        unravel_inner(&mut stub, &self.defined_names, &mut HashSet::new(), &mut HashMap::new());
+        return stub
+    }
+}
+pub(crate) fn unravel_inner(schema: &mut Schema, defined_schemata: & NameMap, placed_schemata: &mut NameSet, alias_map: &mut HashMap<Name, Arc<Name>>){
+    match schema {
+        Schema::Ref{name}=> {
+            if !placed_schemata.contains(name) && defined_schemata.contains_key(name){
+                let mut definition = defined_schemata.get(name).unwrap().as_ref().clone();
+                unravel_inner(&mut definition, defined_schemata, placed_schemata, alias_map);
+                *schema = definition;
+            }else if alias_map.contains_key(&name) {
+               *schema = Schema::Ref{name: Arc::clone(alias_map.get(name).unwrap())};
+            }
+        },
+        Schema::Record(record_schema) => {
+            let mut not_placed = placed_schemata.insert(Arc::clone(&record_schema.name));
+            if let Some(aliases) = &record_schema.aliases{
+                not_placed = aliases.iter().fold(not_placed, |acc, alias|{
+                    alias_map.insert(alias.fully_qualified_name(Option::None).into_owned(), Arc::clone(&record_schema.name));
+                    acc && placed_schemata.insert(Arc::new(alias.fully_qualified_name(Option::None).into_owned()))
+                });
+            };
+            if !not_placed {
+                panic!("When converting to complete schema, attempted to double define a schema when unraveling");
+            }
+
+            for field in &mut record_schema.fields {
+               unravel_inner(&mut field.schema, defined_schemata, placed_schemata, alias_map);
+            }
+        }
+        Schema::Array(array_schema) => {
+            unravel_inner(&mut array_schema.items, defined_schemata, placed_schemata, alias_map);
+        }
+        Schema::Map(map_schema) => {
+            unravel_inner(map_schema.types.as_mut(), defined_schemata, placed_schemata, alias_map);
+        }
+        Schema::Union(union_schema) => {
+            for mut el_schema in &mut union_schema.schemas {
+                unravel_inner(&mut el_schema, defined_schemata, placed_schemata, alias_map);
+            }
+        },
+        Schema::Fixed(fixed_schema) => {
+            let mut not_placed = placed_schemata.insert(Arc::clone(&fixed_schema.name));
+            if let Some(aliases) = &fixed_schema.aliases{
+                not_placed = aliases.iter().fold(not_placed, |acc, alias|{
+                    alias_map.insert(alias.fully_qualified_name(Option::None).into_owned(), Arc::clone(&fixed_schema.name));
+                    acc && placed_schemata.insert(Arc::new(alias.fully_qualified_name(Option::None).into_owned()))
+                });
+            };
+            if !not_placed {
+                panic!("When converting to complete schema, attempted to double define a schema when unraveling");
+            }
+        },
+        Schema::Enum(enum_schema) => {
+            let mut not_placed = placed_schemata.insert(Arc::clone(&enum_schema.name));
+            if let Some(aliases) = &enum_schema.aliases{
+                not_placed = aliases.iter().fold(not_placed, |acc, alias|{
+                    alias_map.insert(alias.fully_qualified_name(Option::None).into_owned(), Arc::clone(&enum_schema.name));
+                    acc && placed_schemata.insert(Arc::new(alias.fully_qualified_name(Option::None).into_owned()))
+                });
+            };
+            if !not_placed {
+                panic!("When converting to complete schema, attempted to double define a schema when unraveling");
+            }
+        }
+        _ => {}
     }
 }
 
@@ -273,15 +355,20 @@ impl PartialEq for Schema {
     }
 }
 
+// KTODO, need to test this out the wazoo, big error here!
 impl From<Schema> for SchemaWithSymbols{
     fn from(value: Schema) -> Self {
-        fn transform(schema: Schema, defined_names: &mut HashMap<Arc<Name>, Arc<Schema>>, referenced_names: &mut HashSet<Arc<Name>>, field_defaults_to_resolve: &mut Vec<(Schema,JsonValue)>) -> Schema {
+        fn transform(schema: Schema, defined_names: &mut HashMap<Arc<Name>, Arc<Schema>>, referenced_names: &mut HashSet<Arc<Name>>, field_defaults_to_resolve: &mut Vec<DefaultToResolve>) -> Schema {
             match schema {
                 Schema::Record(mut record_schema) => {
+                    let record_name = record_schema.name.fully_qualified_name(Option::None).to_string();
                     for field in &mut record_schema.fields{
                         field.schema = transform(field.schema.clone(), defined_names, referenced_names, field_defaults_to_resolve);
                         if let Some(value) = &field.default{
-                            field_defaults_to_resolve.push((field.schema.clone(), value.clone()));
+                            field_defaults_to_resolve.push(DefaultToResolve{record_name: record_name.clone(),
+                            field_name: field.name.clone(),
+                            schema: field.schema.clone(),
+                            json: value.clone()});
                         }
                     };
                     let name = Arc::clone(&record_schema.name);
@@ -312,21 +399,25 @@ impl From<Schema> for SchemaWithSymbols{
                     defined_names.insert(Arc::clone(&name), Arc::from(schema));
                     Schema::Ref { name }
                 },
+                Schema::Ref { ref name } => {
+                    referenced_names.insert(Arc::clone(name));
+                    schema
+                }
                 _ => {schema}
             }
         }
 
         let mut defined_names : HashMap<Arc<Name>, Arc<Schema>> = HashMap::new();
         let mut referenced_names : HashSet<Arc<Name>> = HashSet::new();
-        let mut field_defaults_to_resolve : Vec<(Schema, JsonValue)> = Vec::new();
+        let mut field_defaults_to_resolve : Vec<DefaultToResolve> = Vec::new();
 
         let schema = transform(value , &mut defined_names, &mut referenced_names, &mut field_defaults_to_resolve);
 
         return Self{
             defined_names,
             referenced_names,
-            field_defaults_to_resolve,
-            schema: Arc::new(schema)
+            field_defaults_to_resolve: field_defaults_to_resolve.into(),
+            stub: Arc::new(schema)
         }
     }
 }
@@ -630,7 +721,7 @@ impl Schema {
     /// Note: Unless a bare schema is needed, prefer using SchemaWithSymbols::parse_str
     pub fn parse_str(input: &str) -> Result<Schema, Error> {
         let parser = Parser::default();
-        let schema = parser.parse_str(input)?.schema.as_ref().clone();
+        let schema = parser.parse_str(input)?.unravel(); //KTODO this needs changing
         Ok(schema)
     }
 
@@ -657,7 +748,7 @@ impl Schema {
                 if let Err(err) = schem {
                     return Err(err);
                 }else{
-                    schemata.push(schem.unwrap().schema.as_ref().clone());
+                    schemata.push(schem.unwrap().unravel()); //KTODO this needs changing!!
                 }
         };
 
@@ -677,7 +768,7 @@ impl Schema {
     /// Parses an Avro schema from JSON.
     pub fn parse(value: &JsonValue) -> AvroResult<Schema> {
         let parser = Parser::default();
-        Ok(parser.parse(value, None)?.schema.as_ref().clone())
+        Ok(parser.parse(value, None)?.unravel())
     }
 
     /// Returns the custom attributes (metadata) if the schema supports them.
@@ -1284,7 +1375,7 @@ mod tests {
 
         let schema_str_c = r#"["A", "B"]"#;
 
-        let [schema_c, schema_a, schema_b] = ResolvedSchema::from_str_array([&schema_str_c,&schema_str_a, &schema_str_b], vec![])?;
+        let [schema_c, schema_a, schema_b] = ResolvedSchema::resolve().build_array([&schema_str_c,&schema_str_a, &schema_str_b])?;
 
         let schema_a_expected = Schema::Record(RecordSchema {
             name: Name::new("A")?.into(),
@@ -1315,17 +1406,14 @@ mod tests {
         });
 
         let schema_c_expected = Schema::Union(UnionSchema::new(vec![
-            Schema::Ref {
-                name: Name::new("A")?.into(),
-            },
-            Schema::Ref {
-                name: Name::new("B")?.into(),
-            },
+            schema_a_expected.clone()
+            ,
+            schema_b_expected.clone()
         ])?);
 
-        assert_eq!(schema_c.schema.as_ref(), &schema_c_expected);
-        assert_eq!(schema_a.schema.as_ref(), &schema_a_expected);
-        assert_eq!(schema_b.schema.as_ref(), &schema_b_expected);
+        assert_eq!(schema_c.unravel(), schema_c_expected);
+        assert_eq!(schema_a.unravel(), schema_a_expected);
+        assert_eq!(schema_b.unravel(), schema_b_expected);
 
         Ok(())
     }
@@ -1351,12 +1439,12 @@ mod tests {
 
         let schema_str_c = r#"["A", "A"]"#;
 
-        let rs = ResolvedSchema::from_str_array([schema_str_c], [schema_str_a1, schema_str_a2]);
+        let rs = ResolvedSchema::resolve().additional([schema_str_a1, schema_str_a2]).and_then(|b| b.build_array([schema_str_c]));
         match rs {
             Ok(_) => unreachable!("Expected an error that the name is already defined"),
             Err(e) => assert_eq!(
                 e.to_string(),
-                r#"Two schemas with the same fullname were given: "A""#
+                r#"Unions cannot contain more than one named schema with the same name: A"#
             ),
         }
 
@@ -1381,9 +1469,9 @@ mod tests {
             ]
         }"#;
 
-        let schema_str_c = r#"["A", "A"]"#;
+        let schema_str_c = r#"["A"]"#;
 
-        match ResolvedSchema::from_str_array([schema_str_c], [schema_str_a, schema_str_b]) {
+        match ResolvedSchema::resolve().additional([schema_str_a, schema_str_b]).and_then(|b| b.build_array([schema_str_c])) {
             Ok(_) => unreachable!("Expected an error that schema_str_b is missing a name field"),
             Err(e) => assert_eq!(e.to_string(), "No `name` field"),
         }
@@ -2100,7 +2188,7 @@ mod tests {
     #[test]
     fn test_nullable_logical_type() -> TestResult {
         let schema = Schema::parse_str(
-            r#"{"type": ["null", {"type": "long", "logicalType": "timestamp-micros"}]}"#,
+            r#"["null", {"type": "long", "logicalType": "timestamp-micros"}]"#,
         )?;
         assert_eq!(
             schema,
@@ -2420,12 +2508,11 @@ mod tests {
             "fields": [
                 {"type":
                   ["null",
-                   { "name": "accountList",
-                      "type": {
+                    { 
+                        "name": "accountList",
                         "type": "array",
                         "items": "long"
-                      }
-                  }
+                    }
                   ],
                  "name":"NullableLongArray"
                }
@@ -3691,10 +3778,10 @@ mod tests {
             ]
         }
         "#;
-        assert_eq!(
-            Schema::parse_str(schema_str).unwrap_err().to_string(),
-            r#"`default`'s value type of field `f1` in `ns.record1` must be a `"int"`. Got: String("invalid")"#
-        );
+        assert!(
+            ResolvedSchema::parse_str(schema_str).unwrap_err().to_string().contains(
+            r#"Provided defualt for field "f1" in record "ns.record1" with schema Int does not validate with the provided defualt value String("invalid"). Reason: Expected Value::Int, got: String("invalid")"#
+        ));
 
         Ok(())
     }
@@ -3724,10 +3811,10 @@ mod tests {
             ]
         }
         "#;
-        assert_eq!(
-            Schema::parse_str(schema_str).unwrap_err().to_string(),
-            r#"`default`'s value type of field `f1` in `ns.record1` must be a `{"name":"ns.record2","type":"record","fields":[{"name":"f1_1","type":"int"}]}`. Got: String("invalid")"#
-        );
+        assert!(
+            ResolvedSchema::parse_str(schema_str).unwrap_err().to_string().contains(
+            r#"Provided defualt for field "f1" in record "ns.record1" with schema Ref { name: Name { name: "record2", namespace: Some("ns") } } does not validate with the provided defualt value String("invalid"). Reason: Record with fields [("f1_1", Int)] expected, got String("invalid")"#
+        ));
 
         Ok(())
     }
@@ -3752,10 +3839,10 @@ mod tests {
             ]
         }
         "#;
-        assert_eq!(
-            Schema::parse_str(schema_str).unwrap_err().to_string(),
-            r#"`default`'s value type of field `f1` in `ns.record1` must be a `{"name":"ns.enum1","type":"enum","symbols":["a","b","c"]}`. Got: String("invalid")"#
-        );
+        assert!(
+            ResolvedSchema::parse_str(schema_str).unwrap_err().to_string().contains(
+            r#"Provided defualt for field "f1" in record "ns.record1" with schema Ref { name: Name { name: "enum1", namespace: Some("ns") } } does not validate with the provided defualt value String("invalid"). Reason: Enum default "invalid" is not among allowed symbols ["a", "b", "c"]"#
+        ));
 
         Ok(())
     }
@@ -3780,10 +3867,10 @@ mod tests {
             ]
         }
         "#;
-        assert_eq!(
-            Schema::parse_str(schema_str).unwrap_err().to_string(),
-            r#"`default`'s value type of field `f1` in `ns.record1` must be a `{"name":"ns.fixed1","type":"fixed","size":3}`. Got: Number(100)"#
-        );
+        assert!(
+            ResolvedSchema::parse_str(schema_str).unwrap_err().to_string().contains(
+            r#"Provided defualt for field "f1" in record "ns.record1" with schema Ref { name: Name { name: "fixed1", namespace: Some("ns") } } does not validate with the provided defualt value Number(100). Reason: String expected for fixed, got: Int(100)"#
+        ));
 
         Ok(())
     }
@@ -3808,16 +3895,16 @@ mod tests {
         }
         "#;
 
-        let result = Schema::parse_str(schema_str);
+        let result = ResolvedSchema::parse_str(schema_str);
         assert!(result.is_err());
         let err = result
             .map_err(|e| e.to_string())
             .err()
             .unwrap_or_else(|| "unexpected".to_string());
-        assert_eq!(
-            r#"`default`'s value type of field `f1` in `ns.record1` must be a `{"type":"array","items":"int"}`. Got: String("invalid")"#,
-            err
-        );
+        assert!(
+            err.contains(
+            r#"Provided defualt for field "f1" in record "ns.record1" with schema Array(ArraySchema { items: Int, .. }) does not validate with the provided defualt value String("invalid"). Reason: Array(Array) expected, got String("invalid")"#
+        ));
 
         Ok(())
     }
@@ -3842,16 +3929,16 @@ mod tests {
         }
         "#;
 
-        let result = Schema::parse_str(schema_str);
+        let result = ResolvedSchema::parse_str(schema_str);
         assert!(result.is_err());
         let err = result
             .map_err(|e| e.to_string())
             .err()
             .unwrap_or_else(|| "unexpected".to_string());
-        assert_eq!(
-            r#"`default`'s value type of field `f1` in `ns.record1` must be a `{"type":"map","values":"string"}`. Got: String("invalid")"#,
-            err
-        );
+        assert!(
+            err.contains(
+            r#"Provided defualt for field "f1" in record "ns.record1" with schema Map(MapSchema { types: String, .. }) does not validate with the provided defualt value String("invalid"). Reason: Map(Map) expected, got String("invalid")"#,
+        ));
 
         Ok(())
     }
@@ -3884,10 +3971,10 @@ mod tests {
             ]
         }
         "#;
-        assert_eq!(
-            Schema::parse_str(schema_str).unwrap_err().to_string(),
-            r#"`default`'s value type of field `f2` in `ns.record1` must be a `{"name":"ns.record2","type":"record","fields":[{"name":"f1_1","type":"int"}]}`. Got: Object {"f1_1": Bool(true)}"#
-        );
+        assert!(
+            ResolvedSchema::parse_str(schema_str).unwrap_err().to_string().contains(
+            r#"Provided defualt for field "f2" in record "ns.record1" with schema Ref { name: Name { name: "record2", namespace: Some("ns") } } does not validate with the provided defualt value Object {"f1_1": Bool(true)}. Reason: Expected Value::Int, got: Boolean(true)"#
+        ));
 
         Ok(())
     }
@@ -3910,7 +3997,7 @@ mod tests {
             .map_err(|e| e.to_string())
             .err()
             .unwrap_or_else(|| "unexpected".to_string());
-        assert_eq!(expected, err);
+        assert!(err.contains(&expected));
 
         let schema_str = r#"
         {
@@ -3932,7 +4019,7 @@ mod tests {
             .map_err(|e| e.to_string())
             .err()
             .unwrap_or_else(|| "unexpected".to_string());
-        assert_eq!(expected, err);
+        assert!(err.contains(&expected));
 
         Ok(())
     }
@@ -4658,64 +4745,6 @@ mod tests {
     }
 
     #[test]
-    fn avro_4055_should_fail_to_parse_invalid_schema() -> TestResult {
-        // This is invalid because the record type should be inside the type field.
-        let invalid_schema_str = r#"
-        {
-        "type": "record",
-        "name": "SampleSchema",
-        "fields": [
-            {
-            "name": "order",
-            "type": "record",
-            "fields": [
-                {
-                "name": "order_number",
-                "type": ["null", "string"],
-                "default": null
-                },
-                { "name": "order_date", "type": "string" }
-            ]
-            }
-        ]
-        }"#;
-
-        let schema = Schema::parse_str(invalid_schema_str);
-        assert!(schema.is_err());
-        assert_eq!(
-            schema.unwrap_err().to_string(),
-            "Invalid schema: There is no type called 'record', if you meant to define a non-primitive schema, it should be defined inside `type` attribute."
-        );
-
-        let valid_schema = r#"
-        {
-            "type": "record",
-            "name": "SampleSchema",
-            "fields": [
-                {
-                "name": "order",
-                "type": {
-                    "type": "record",
-                    "name": "Order",
-                    "fields": [
-                    {
-                        "name": "order_number",
-                        "type": ["null", "string"],
-                        "default": null
-                    },
-                    { "name": "order_date", "type": "string" }
-                    ]
-                }
-                }
-            ]
-        }"#;
-        let schema = Schema::parse_str(valid_schema);
-        assert!(schema.is_ok());
-
-        Ok(())
-    }
-
-    #[test]
     fn avro_rs_292_array_items_should_be_ignored_in_custom_attributes() -> TestResult {
         let raw_schema = r#"{
                     "type": "array",
@@ -4950,51 +4979,28 @@ mod tests {
 
     #[test]
     fn avro_rs_420_independent_canonical_form() -> TestResult {
-        let [rs] = ResolvedSchema::from_str_array(
-            [r#"{
-            "name": "root",
-            "type": "record",
-            "fields": [{
-                "name": "node",
-                "type": "node"
-            }]
-        }"#],
-            [r#"{
+        let [rs] = ResolvedSchema::resolve()
+            .additional([r#"{
             "name": "node",
             "type": "record",
             "fields": [{
                 "name": "children",
                 "type": ["null", "node"]
             }]
-        }"#],
-        )?;
+        }"#])?
+            .build_array([r#"{
+            "name": "root",
+            "type": "record",
+            "fields": [{
+                "name": "node",
+                "type": "node"
+            }]
+        }"#])?;
         let icf = CompleteSchema::from(&rs).independent_canonical_form()?;
         assert_eq!(
             icf,
             r#"{"name":"root","type":"record","fields":[{"name":"node","type":{"name":"node","type":"record","fields":[{"name":"children","type":["null","node"]}]}}]}"#
         );
-        Ok(())
-    }
-
-    #[test]
-    fn avro_rs_456_bool_instead_of_boolean() -> TestResult {
-        let error = Schema::parse_str(
-            r#"{
-            "type": "record",
-            "name": "defaults",
-            "fields": [
-                {"name": "boolean", "type": "bool", "default": true}
-            ]
-        }"#,
-        )
-        .unwrap_err()
-        .into_details()
-        .to_string();
-        assert_eq!(
-            error,
-            Details::ParsePrimitiveSimilar("bool".to_string(), "boolean").to_string()
-        );
-
         Ok(())
     }
 
@@ -5046,27 +5052,27 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn avro_rs_476_enum_cannot_be_directly_in_field() -> TestResult {
-        let schema_str = r#"{
-            "type": "record",
-            "name": "ExampleEnum",
-            "namespace": "com.schema",
-            "fields": [
-                {
-                "name": "wrong_enum",
-                "type": "enum",
-                "symbols": ["INSERT", "UPDATE"]
-                }
-            ]
-        }"#;
-        let result = Schema::parse_str(schema_str).unwrap_err();
-        assert_eq!(
-            result.to_string(),
-            "Invalid schema: There is no type called 'enum', if you meant to define a non-primitive schema, it should be defined inside `type` attribute."
-        );
-        Ok(())
-    }
+    //#[test] // KTODO -- this should be changed to a WARNING, not an error...
+    //fn avro_rs_476_enum_cannot_be_directly_in_field() -> TestResult {
+    //    let schema_str = r#"{
+    //        "type": "record",
+    //        "name": "ExampleEnum",
+    //        "namespace": "com.schema",
+    //        "fields": [
+    //            {
+    //            "name": "wrong_enum",
+    //            "type": "enum",
+    //            "symbols": ["INSERT", "UPDATE"]
+    //            }
+    //        ]
+    //    }"#;
+    //    let result = Schema::parse_str(schema_str).unwrap_err();
+    //    assert_eq!(
+    //        result.to_string(),
+    //        "Invalid schema: There is no type called 'enum', if you meant to define a non-primitive schema, it should be defined inside `type` attribute."
+    //    );
+    //    Ok(())
+    //}
 
     #[test]
     fn avro_rs_509_default_must_be_in_custom_attributes_for_map_and_enum() -> TestResult {
@@ -5114,28 +5120,35 @@ mod tests {
             "type": "record",
             "fields": [
                 {"name": "a", "type": { "type": "fixed", "name": "inner_fixed_a", "size": 16}},
-                {"name": "b", "type": { "type": "fixed", "name": "inner_fixed_b", "size": 16}}
+                {"name": "b", "type": { "type": "fixed", "name": "inner_fixed_b", "size": 16}},
+                {"name": "c", "type": "SomeUndefinedType"}
             ]
         }"#)?;
 
-        match schema_with_symbols.schema.as_ref(){
+        match schema_with_symbols.stub.as_ref(){
             Schema::Ref{name: _} => {},
             _ => panic!("Expected root schema to be converted into Schema::Ref and its definition placed in the symbol map")
         };
 
-        let inner_fixed_a_schema = Schema::parse_str(r#"{"name": "a", "type": { "type": "fixed", "name": "inner_fixed_a", "size": 16}}"#)?;
-        let inner_fixed_b_schema = Schema::parse_str(r#"{"name": "a", "type": { "type": "fixed", "name": "inner_fixed_b", "size": 16}}"#)?;
+        let inner_fixed_a_schema = Schema::parse_str(r#"{"name": "a", "type": "fixed", "name": "inner_fixed_a", "size": 16}"#)?;
+        let inner_fixed_b_schema = Schema::parse_str(r#"{"name": "b", "type": "fixed", "name": "inner_fixed_b", "size": 16}"#)?;
         let root_schema = Schema::parse_str(r#"{
             "name": "root",
             "type": "record",
             "fields": [
                 {"name": "a", "type": "inner_fixed_a"},
-                {"name": "b", "type": "inner_fixed_b"}
+                {"name": "b", "type": "inner_fixed_b"},
+                {"name": "c", "type": "SomeUndefinedType"}
             ]
         }"#)?;
 
-        assert_eq!(schema_with_symbols.referenced_names,
-                HashSet::from([Arc::new(Name::try_from("root")?), Arc::new(Name::try_from("inner_fixed_a")?), Arc::new(Name::try_from("inner_fixed_b")?)])
+        let key_names : HashSet<_>= schema_with_symbols.defined_names.keys().cloned().collect();
+        assert_eq!(key_names,
+                HashSet::from([Arc::new(Name::try_from("inner_fixed_a")?), Arc::new(Name::try_from("inner_fixed_b")?),Arc::new(Name::try_from("root")?)])
+        );
+
+        assert_eq!( schema_with_symbols.referenced_names,
+                HashSet::from([Arc::new(Name::try_from("SomeUndefinedType")?)])
         );
 
         let parsed_inner_fixed_a = schema_with_symbols.defined_names.get(&Name::try_from("inner_fixed_a")?).expect("Was not able to find defined schema for name inner_fixed_a");
@@ -5155,5 +5168,82 @@ mod tests {
         );
 
         return Ok(())
+    }
+
+    #[test]
+    fn avro_rs_353_test_non_root_schema_resolution()-> TestResult{
+        let schema1 = r#"
+            {
+                "name": "holds_foo_record",
+                "type": "record",
+                "fields": [{"name": "holds_foo", "type":
+                    {
+                        "name": "foo_record",
+                        "type": "record",
+                        "fields": [{"name": "foo", "type": "baz_record"}]
+                    }
+                }]
+            }
+            "#;
+
+        let schema2 = r#"
+            {
+                "name": "holds_baz_record",
+                "type": "record",
+                "fields": [{"name": "holds_baz", "type":
+                    {
+                        "name": "baz_record",
+                        "type": "record",
+                        "fields": [{"name": "baz", "type": "foo_record"}]
+                    }}]
+            }
+            "#;
+
+        Schema::parse_list(vec![schema1, schema2])?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_aliasing_with_schema_resolution() -> TestResult {
+       let schema1 = r#"{
+            "type": "record",
+            "name": "a_record_schema",
+            "aliases": ["an_alias"],
+            "fields": [{"name": "a_field", "type": "long"}]
+       }"#;
+
+       let schema2 = r#""an_alias""#;
+
+       let schema1 = SchemaWithSymbols::parse_str(schema1)?;
+       let schema2 = SchemaWithSymbols::parse_str(schema2)?;
+
+       let _resolved = ResolvedSchema::resolve().additional([schema2])?.build_array([schema1])?;
+
+       return Ok(())
+    }
+
+    #[test]
+    fn test_parse_without_name() -> TestResult{
+           let schema1 = r#"{
+                "type": "record",
+                "name": "a_record_schema",
+                "fields": [{"name": "a_field", "type": "some_name"}]
+           }"#;
+
+           let _schema = SchemaWithSymbols::parse_str(schema1).unwrap();
+           return Ok(())
+    }
+
+    #[test]
+    fn avro_rs_test_schema_with_symbol_parse_references() -> TestResult{
+           let schema1 = r#"{
+                "type": "record",
+                "name": "a_record_schema",
+                "fields": [{"name": "a_field", "type": "myenum"}, {"name": "another_field", "type": {"name": "myenum", "type": "enum", "symbols": ["A","B"]}}]
+           }"#;
+
+           let schema = SchemaWithSymbols::parse_str(schema1).unwrap();
+           assert!(schema.referenced_names.is_empty());
+           Ok(())
     }
 }

--- a/avro/src/schema/mod.rs
+++ b/avro/src/schema/mod.rs
@@ -24,13 +24,11 @@ mod record;
 mod resolve;
 mod union;
 
-pub(crate) use crate::schema::resolve::{
-    ResolvedOwnedSchema, resolve_names, resolve_names_with_schemata,
-};
 pub use crate::schema::{
-    name::{Alias, Aliases, Name, Names, NamesRef, Namespace, NamespaceRef},
+    name::{Alias, Aliases, Name, Names, NamesRef, Namespace, NamespaceRef, NameMap, NameSet},
     record::{RecordField, RecordFieldBuilder, RecordSchema, RecordSchemaBuilder},
-    resolve::ResolvedSchema,
+    resolve::{ResolvedSchema, ResolvedNode, ResolvedRecord, ResolvedUnion,
+        ResolvedArray, ResolvedMap, ResolvedRecordField, CompleteSchema},
     union::{UnionSchema, UnionSchemaBuilder},
 };
 use crate::{
@@ -38,12 +36,12 @@ use crate::{
     error::{Details, Error},
     schema::parser::Parser,
     schema_equality,
-    types::{self, Value},
+    types::{self},
 };
 use digest::Digest;
 use serde::{
     Serialize, Serializer,
-    ser::{Error as _, SerializeMap, SerializeSeq},
+    ser::{SerializeMap, SerializeSeq},
 };
 use serde_json::{Map, Value as JsonValue};
 use std::fmt::Formatter;
@@ -53,6 +51,7 @@ use std::{
     fmt::Debug,
     hash::Hash,
     io::Read,
+    sync::Arc
 };
 use strum::{Display, EnumDiscriminants};
 
@@ -81,6 +80,65 @@ impl fmt::Display for SchemaFingerprint {
     }
 }
 
+/// Represents a parsed Avro schema with information on
+/// what named schemata are exposed by the schema as well
+/// as schemata names used and defined by this schema.
+
+#[derive(Clone,Debug)]
+pub struct SchemaWithSymbols{
+    /// schema fullnames defined in this schema.
+    pub(crate) defined_names: HashMap<Arc<Name>, Arc<Schema>>,
+    /// all schema fullnames references in this schema, both those that have
+    /// an internal resolution and those that are internally unresolved.
+    pub(crate) referenced_names: HashSet<Arc<Name>>,
+    /// The parseed schema tree
+    pub(crate) schema: Arc<Schema>,
+    /// Record fields that have defualt values that need to be
+    /// resolved.
+    /// KTODO: documentation
+    pub(crate) field_defaults_to_resolve: Vec<(Schema, JsonValue)>
+}
+
+
+impl SchemaWithSymbols{
+    pub fn parse_str(input: &str) -> Result<SchemaWithSymbols,Error>{
+        let parser = Parser::default();
+        parser.parse_str(input)
+    }
+
+    pub fn parse(value: &JsonValue) -> AvroResult<SchemaWithSymbols>{
+        let parser = Parser::default();
+        parser.parse(value, None)
+    }
+
+    pub fn parse_array<const N: usize>(input: [impl AsRef<str>; N]) -> AvroResult<[SchemaWithSymbols; N]>{
+        let input = input.into_iter();
+        let mut parsed = Self::parse_list(input)?.into_iter();
+        Ok(std::array::from_fn(|_| {
+            parsed.next().unwrap()
+        }))
+    }
+
+    pub fn parse_list(input: impl IntoIterator<Item = impl AsRef<str>>) -> AvroResult<Vec<SchemaWithSymbols>> {
+        let input = input.into_iter();
+        input.map(|str| {
+            let parser = Parser::default();
+            parser.parse_str(str.as_ref())
+        }).collect()
+    }
+}
+
+impl From<Arc<Schema>> for SchemaWithSymbols{
+    fn from(value: Arc<Schema>) -> Self {
+        value.as_ref().clone().into()
+    }
+}
+
+impl AsRef<SchemaWithSymbols> for SchemaWithSymbols{
+    fn as_ref(&self) -> &SchemaWithSymbols {
+        return self
+    }
+}
 /// Represents any valid Avro schema
 /// More information about Avro schemas can be found in the
 /// [Avro Specification](https://avro.apache.org/docs/++version++/specification/#schema-declaration)
@@ -160,13 +218,12 @@ pub enum Schema {
     /// An amount of time defined by a number of months, days and milliseconds.
     Duration(FixedSchema),
     /// A reference to another schema.
-    Ref { name: Name },
+    Ref { name: Arc<Name> },
 }
 
 #[derive(Clone, PartialEq)]
 pub struct MapSchema {
     pub types: Box<Schema>,
-    pub default: Option<HashMap<String, Value>>,
     pub attributes: BTreeMap<String, JsonValue>,
 }
 
@@ -174,13 +231,10 @@ impl Debug for MapSchema {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut debug = f.debug_struct("MapSchema");
         debug.field("types", &self.types);
-        if let Some(default) = &self.default {
-            debug.field("default", default);
-        }
         if !self.attributes.is_empty() {
             debug.field("attributes", &self.attributes);
         }
-        if self.default.is_none() || self.attributes.is_empty() {
+        if self.attributes.is_empty() {
             debug.finish_non_exhaustive()
         } else {
             debug.finish()
@@ -191,7 +245,6 @@ impl Debug for MapSchema {
 #[derive(Clone, PartialEq)]
 pub struct ArraySchema {
     pub items: Box<Schema>,
-    pub default: Option<Vec<Value>>,
     pub attributes: BTreeMap<String, JsonValue>,
 }
 
@@ -199,13 +252,10 @@ impl Debug for ArraySchema {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut debug = f.debug_struct("ArraySchema");
         debug.field("items", &self.items);
-        if let Some(default) = &self.default {
-            debug.field("default", default);
-        }
         if !self.attributes.is_empty() {
             debug.field("attributes", &self.attributes);
         }
-        if self.default.is_none() || self.attributes.is_empty() {
+        if self.attributes.is_empty() {
             debug.finish_non_exhaustive()
         } else {
             debug.finish()
@@ -220,6 +270,64 @@ impl PartialEq for Schema {
     /// https://avro.apache.org/docs/1.11.1/specification/#parsing-canonical-form-for-schemas
     fn eq(&self, other: &Self) -> bool {
         schema_equality::compare_schemata(self, other)
+    }
+}
+
+impl From<Schema> for SchemaWithSymbols{
+    fn from(value: Schema) -> Self {
+        fn transform(schema: Schema, defined_names: &mut HashMap<Arc<Name>, Arc<Schema>>, referenced_names: &mut HashSet<Arc<Name>>, field_defaults_to_resolve: &mut Vec<(Schema,JsonValue)>) -> Schema {
+            match schema {
+                Schema::Record(mut record_schema) => {
+                    for field in &mut record_schema.fields{
+                        field.schema = transform(field.schema.clone(), defined_names, referenced_names, field_defaults_to_resolve);
+                        if let Some(value) = &field.default{
+                            field_defaults_to_resolve.push((field.schema.clone(), value.clone()));
+                        }
+                    };
+                    let name = Arc::clone(&record_schema.name);
+                    defined_names.insert(Arc::clone(&name), Arc::new(Schema::Record(record_schema)));
+                    Schema::Ref { name }
+                },
+                Schema::Array(mut array_schema) => {
+                    array_schema.items = Box::from(transform(*array_schema.items, defined_names, referenced_names, field_defaults_to_resolve));
+                    Schema::Array(array_schema)
+                }
+                Schema::Map(mut map_schema) => {
+                    map_schema.types = Box::from(transform(*map_schema.types, defined_names, referenced_names, field_defaults_to_resolve));
+                    Schema::Map(map_schema)
+                }
+                Schema::Union(mut union_schema) => {
+                    for el_schema in &mut union_schema.schemas {
+                        *el_schema = transform(el_schema.clone(), defined_names, referenced_names, field_defaults_to_resolve);
+                    }
+                    Schema::Union(union_schema)
+                },
+                Schema::Fixed(ref fixed_schema) => {
+                    let name = Arc::clone(&fixed_schema.name);
+                    defined_names.insert(Arc::clone(&name), Arc::from(schema));
+                    Schema::Ref { name }
+                },
+                Schema::Enum(ref enum_schema) => {
+                    let name = Arc::clone(&enum_schema.name);
+                    defined_names.insert(Arc::clone(&name), Arc::from(schema));
+                    Schema::Ref { name }
+                },
+                _ => {schema}
+            }
+        }
+
+        let mut defined_names : HashMap<Arc<Name>, Arc<Schema>> = HashMap::new();
+        let mut referenced_names : HashSet<Arc<Name>> = HashSet::new();
+        let mut field_defaults_to_resolve : Vec<(Schema, JsonValue)> = Vec::new();
+
+        let schema = transform(value , &mut defined_names, &mut referenced_names, &mut field_defaults_to_resolve);
+
+        return Self{
+            defined_names,
+            referenced_names,
+            field_defaults_to_resolve,
+            schema: Arc::new(schema)
+        }
     }
 }
 
@@ -290,7 +398,7 @@ impl From<&types::Value> for SchemaKind {
 #[derive(bon::Builder, Clone)]
 pub struct EnumSchema {
     /// The name of the schema
-    pub name: Name,
+    pub name: Arc<Name>,
     /// The aliases of the schema
     #[builder(default)]
     pub aliases: Aliases,
@@ -339,7 +447,7 @@ impl Debug for EnumSchema {
 #[derive(bon::Builder, Clone)]
 pub struct FixedSchema {
     /// The name of the schema
-    pub name: Name,
+    pub name: Arc<Name>,
     /// The aliases of the schema
     #[builder(default)]
     pub aliases: Aliases,
@@ -406,7 +514,7 @@ impl FixedSchema {
     /// All other fields are `None` or empty.
     pub(crate) fn copy_only_size(&self) -> Self {
         Self {
-            name: Name::invalid_empty_name(),
+            name: Name::invalid_empty_name().into(),
             aliases: None,
             doc: None,
             size: self.size,
@@ -478,19 +586,6 @@ impl Schema {
         parsing_canonical_form(&json, &mut defined_names)
     }
 
-    /// Returns the [Parsing Canonical Form] of `self` that is self contained (not dependent on
-    /// any definitions in `schemata`)
-    ///
-    /// If you require a self contained schema including `default` and `doc` attributes, see [`denormalize`][Schema::denormalize].
-    ///
-    /// [Parsing Canonical Form]:
-    /// https://avro.apache.org/docs/++version++/specification/#parsing-canonical-form-for-schemas
-    pub fn independent_canonical_form(&self, schemata: &[Schema]) -> Result<String, Error> {
-        let mut this = self.clone();
-        this.denormalize(schemata)?;
-        Ok(this.canonical_form())
-    }
-
     /// Generate the [fingerprint] of the schema's [Parsing Canonical Form].
     ///
     /// # Example
@@ -532,9 +627,11 @@ impl Schema {
     }
 
     /// Create a `Schema` from a string representing a JSON Avro schema.
+    /// Note: Unless a bare schema is needed, prefer using SchemaWithSymbols::parse_str
     pub fn parse_str(input: &str) -> Result<Schema, Error> {
-        let mut parser = Parser::default();
-        parser.parse_str(input)
+        let parser = Parser::default();
+        let schema = parser.parse_str(input)?.schema.as_ref().clone();
+        Ok(schema)
     }
 
     /// Create an array of `Schema`'s from a list of named JSON Avro schemas (Record, Enum, and
@@ -544,78 +641,29 @@ impl Schema {
     /// during parsing.
     ///
     /// If two of the input schemas have the same fullname, an Error will be returned.
+    ///
+    /// Note: Unless a bare schema is needed, prefer using SchemaWithSymbols::parse_list
     pub fn parse_list(input: impl IntoIterator<Item = impl AsRef<str>>) -> AvroResult<Vec<Schema>> {
         let input = input.into_iter();
-        let input_len = input.size_hint().0;
-        let mut input_schemas: HashMap<Name, JsonValue> = HashMap::with_capacity(input_len);
-        let mut input_order: Vec<Name> = Vec::with_capacity(input_len);
-        for json in input {
-            let json = json.as_ref();
-            let schema: JsonValue = serde_json::from_str(json).map_err(Details::ParseSchemaJson)?;
-            if let JsonValue::Object(inner) = &schema {
-                let name = Name::parse(inner, None)?;
-                let previous_value = input_schemas.insert(name.clone(), schema);
-                if previous_value.is_some() {
-                    return Err(Details::NameCollision(name.fullname(None)).into());
+
+        let parsed : Vec<AvroResult<SchemaWithSymbols>> = input.map(|str| {
+            let parser = Parser::default();
+            parser.parse_str(str.as_ref())
+        }).collect();
+
+        let mut schemata = Vec::with_capacity(parsed.len());
+
+        for schem in parsed {
+                if let Err(err) = schem {
+                    return Err(err);
+                }else{
+                    schemata.push(schem.unwrap().schema.as_ref().clone());
                 }
-                input_order.push(name);
-            } else {
-                return Err(Details::GetNameField.into());
-            }
-        }
-        let mut parser = Parser::new(
-            input_schemas,
-            input_order,
-            HashMap::with_capacity(input_len),
-        );
-        parser.parse_list()
+        };
+
+        return Ok(schemata)
     }
 
-    /// Create a `Schema` from a string representing a JSON Avro schema,
-    /// along with an array of `Schema`'s from a list of named JSON Avro schemas (Record, Enum, and
-    /// Fixed).
-    ///
-    /// It is allowed that the schemas have cross-dependencies; these will be resolved
-    /// during parsing.
-    ///
-    /// If two of the named input schemas have the same fullname, an Error will be returned.
-    ///
-    /// # Arguments
-    /// * `schema` - the JSON string of the schema to parse
-    /// * `schemata` - a slice of additional schemas that is used to resolve cross-references
-    pub fn parse_str_with_list(
-        schema: &str,
-        schemata: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> AvroResult<(Schema, Vec<Schema>)> {
-        let schemata = schemata.into_iter();
-        let schemata_len = schemata.size_hint().0;
-        let mut input_schemas: HashMap<Name, JsonValue> = HashMap::with_capacity(schemata_len);
-        let mut input_order: Vec<Name> = Vec::with_capacity(schemata_len);
-        for json in schemata {
-            let json = json.as_ref();
-            let schema: JsonValue = serde_json::from_str(json).map_err(Details::ParseSchemaJson)?;
-            if let JsonValue::Object(inner) = &schema {
-                let name = Name::parse(inner, None)?;
-                if let Some(_previous) = input_schemas.insert(name.clone(), schema) {
-                    return Err(Details::NameCollision(name.fullname(None)).into());
-                }
-                input_order.push(name);
-            } else {
-                return Err(Details::GetNameField.into());
-            }
-        }
-        let mut parser = Parser::new(
-            input_schemas,
-            input_order,
-            HashMap::with_capacity(schemata_len),
-        );
-        parser.parse_input_schemas()?;
-
-        let value = serde_json::from_str(schema).map_err(Details::ParseSchemaJson)?;
-        let schema = parser.parse(&value, None)?;
-        let schemata = parser.parse_list()?;
-        Ok((schema, schemata))
-    }
 
     /// Create a `Schema` from a reader which implements [`Read`].
     pub fn parse_reader(reader: &mut (impl Read + ?Sized)) -> AvroResult<Schema> {
@@ -628,15 +676,8 @@ impl Schema {
 
     /// Parses an Avro schema from JSON.
     pub fn parse(value: &JsonValue) -> AvroResult<Schema> {
-        let mut parser = Parser::default();
-        parser.parse(value, None)
-    }
-
-    /// Parses an Avro schema from JSON.
-    /// Any `Schema::Ref`s must be known in the `names` map.
-    pub(crate) fn parse_with_names(value: &JsonValue, names: Names) -> AvroResult<Schema> {
-        let mut parser = Parser::new(HashMap::with_capacity(1), Vec::with_capacity(1), names);
-        parser.parse(value, None)
+        let parser = Parser::default();
+        Ok(parser.parse(value, None)?.schema.as_ref().clone())
     }
 
     /// Returns the custom attributes (metadata) if the schema supports them.
@@ -675,7 +716,7 @@ impl Schema {
     }
 
     /// Returns the name of the schema if it has one.
-    pub fn name(&self) -> Option<&Name> {
+    pub fn name(&self) -> Option<&Arc<Name>> {
         match self {
             Schema::Ref { name, .. }
             | Schema::Record(RecordSchema { name, .. })
@@ -727,73 +768,8 @@ impl Schema {
             _ => None,
         }
     }
-
-    /// Remove all external references from the schema.
-    ///
-    /// `schemata` must contain all externally referenced schemas.
-    ///
-    /// # Errors
-    /// Will return a [`Details::SchemaResolutionError`] if it fails to find
-    /// a referenced schema. This will put the schema in a partly denormalized state.
-    pub fn denormalize(&mut self, schemata: &[Schema]) -> AvroResult<()> {
-        self.denormalize_inner(schemata, &mut HashSet::new())
-    }
-
-    fn denormalize_inner(
-        &mut self,
-        schemata: &[Schema],
-        defined_names: &mut HashSet<Name>,
-    ) -> AvroResult<()> {
-        // If this name already exists in this schema we can reference it.
-        // This makes the denormalized form as small as possible and prevent infinite loops for recursive types.
-        if let Some(name) = self.name()
-            && defined_names.contains(name)
-        {
-            *self = Schema::Ref { name: name.clone() };
-            return Ok(());
-        }
-        match self {
-            Schema::Ref { name } => {
-                let replacement_schema = schemata
-                    .iter()
-                    .find(|s| s.name().map(|n| *n == *name).unwrap_or(false));
-                if let Some(schema) = replacement_schema {
-                    let mut denorm = schema.clone();
-                    denorm.denormalize_inner(schemata, defined_names)?;
-                    *self = denorm;
-                } else {
-                    return Err(Details::SchemaResolutionError(name.clone()).into());
-                }
-            }
-            Schema::Record(record_schema) => {
-                defined_names.insert(record_schema.name.clone());
-                for field in &mut record_schema.fields {
-                    field.schema.denormalize_inner(schemata, defined_names)?;
-                }
-            }
-            Schema::Array(array_schema) => {
-                array_schema
-                    .items
-                    .denormalize_inner(schemata, defined_names)?;
-            }
-            Schema::Map(map_schema) => {
-                map_schema
-                    .types
-                    .denormalize_inner(schemata, defined_names)?;
-            }
-            Schema::Union(union_schema) => {
-                for schema in &mut union_schema.schemas {
-                    schema.denormalize_inner(schemata, defined_names)?;
-                }
-            }
-            schema if schema.is_named() => {
-                defined_names.insert(schema.name().expect("Schema is named").clone());
-            }
-            _ => (),
-        }
-        Ok(())
-    }
 }
+
 
 impl Serialize for Schema {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -810,41 +786,19 @@ impl Serialize for Schema {
             Schema::Double => serializer.serialize_str("double"),
             Schema::Bytes => serializer.serialize_str("bytes"),
             Schema::String => serializer.serialize_str("string"),
-            Schema::Array(ArraySchema {
-                items,
-                default,
-                attributes,
-            }) => {
-                let mut map = serializer.serialize_map(Some(
-                    2 + attributes.len() + if default.is_some() { 1 } else { 0 },
-                ))?;
+            Schema::Array(ArraySchema { items, attributes }) => {
+                let mut map = serializer.serialize_map(Some(2 + attributes.len()))?;
                 map.serialize_entry("type", "array")?;
                 map.serialize_entry("items", items)?;
-                if let Some(default) = default {
-                    let value = JsonValue::try_from(Value::Array(default.clone()))
-                        .map_err(S::Error::custom)?;
-                    map.serialize_entry("default", &value)?;
-                }
                 for (key, value) in attributes {
                     map.serialize_entry(key, value)?;
                 }
                 map.end()
             }
-            Schema::Map(MapSchema {
-                types,
-                default,
-                attributes,
-            }) => {
-                let mut map = serializer.serialize_map(Some(
-                    2 + attributes.len() + if default.is_some() { 1 } else { 0 },
-                ))?;
+            Schema::Map(MapSchema { types, attributes }) => {
+                let mut map = serializer.serialize_map(Some(2 + attributes.len()))?;
                 map.serialize_entry("type", "map")?;
                 map.serialize_entry("values", types)?;
-                if let Some(default) = default {
-                    let value = JsonValue::try_from(Value::Map(default.clone()))
-                        .map_err(S::Error::custom)?;
-                    map.serialize_entry("default", &value)?;
-                }
                 for (key, value) in attributes {
                     map.serialize_entry(key, value)?;
                 }
@@ -1168,6 +1122,7 @@ fn field_ordering_position(field: &str) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::schema::resolve::CompleteSchema;
     use crate::writer::datum::GenericDatumWriter;
     use crate::{error::Details, rabin::Rabin, reader::datum::GenericDatumReader};
     use apache_avro_test_helper::{
@@ -1293,10 +1248,10 @@ mod tests {
                         .name("field_one".to_string())
                         .schema(Schema::Union(UnionSchema::new(vec![
                             Schema::Ref {
-                                name: Name::new("A")?,
+                                name: Name::new("A")?.into(),
                             },
                             Schema::Ref {
-                                name: Name::new("B")?,
+                                name: Name::new("B")?.into(),
                             },
                         ])?))
                         .build(),
@@ -1329,11 +1284,10 @@ mod tests {
 
         let schema_str_c = r#"["A", "B"]"#;
 
-        let (schema_c, schemata) =
-            Schema::parse_str_with_list(schema_str_c, [schema_str_a, schema_str_b])?;
+        let [schema_c, schema_a, schema_b] = ResolvedSchema::from_str_array([&schema_str_c,&schema_str_a, &schema_str_b], vec![])?;
 
         let schema_a_expected = Schema::Record(RecordSchema {
-            name: Name::new("A")?,
+            name: Name::new("A")?.into(),
             aliases: None,
             doc: None,
             fields: vec![
@@ -1347,7 +1301,7 @@ mod tests {
         });
 
         let schema_b_expected = Schema::Record(RecordSchema {
-            name: Name::new("B")?,
+            name: Name::new("B")?.into(),
             aliases: None,
             doc: None,
             fields: vec![
@@ -1362,16 +1316,16 @@ mod tests {
 
         let schema_c_expected = Schema::Union(UnionSchema::new(vec![
             Schema::Ref {
-                name: Name::new("A")?,
+                name: Name::new("A")?.into(),
             },
             Schema::Ref {
-                name: Name::new("B")?,
+                name: Name::new("B")?.into(),
             },
         ])?);
 
-        assert_eq!(schema_c, schema_c_expected);
-        assert_eq!(schemata[0], schema_a_expected);
-        assert_eq!(schemata[1], schema_b_expected);
+        assert_eq!(schema_c.schema.as_ref(), &schema_c_expected);
+        assert_eq!(schema_a.schema.as_ref(), &schema_a_expected);
+        assert_eq!(schema_b.schema.as_ref(), &schema_b_expected);
 
         Ok(())
     }
@@ -1397,7 +1351,8 @@ mod tests {
 
         let schema_str_c = r#"["A", "A"]"#;
 
-        match Schema::parse_str_with_list(schema_str_c, [schema_str_a1, schema_str_a2]) {
+        let rs = ResolvedSchema::from_str_array([schema_str_c], [schema_str_a1, schema_str_a2]);
+        match rs {
             Ok(_) => unreachable!("Expected an error that the name is already defined"),
             Err(e) => assert_eq!(
                 e.to_string(),
@@ -1428,7 +1383,7 @@ mod tests {
 
         let schema_str_c = r#"["A", "A"]"#;
 
-        match Schema::parse_str_with_list(schema_str_c, [schema_str_a, schema_str_b]) {
+        match ResolvedSchema::from_str_array([schema_str_c], [schema_str_a, schema_str_b]) {
             Ok(_) => unreachable!("Expected an error that schema_str_b is missing a name field"),
             Err(e) => assert_eq!(e.to_string(), "No `name` field"),
         }
@@ -1460,7 +1415,7 @@ mod tests {
                 let f1 = fields.first();
 
                 let ref_schema = Schema::Ref {
-                    name: Name::new("B")?,
+                    name: Name::new("B")?.into(),
                 };
                 assert_eq!(ref_schema, f1.unwrap().schema);
             }
@@ -1497,7 +1452,7 @@ mod tests {
             .clone();
 
         let schema_option_a_expected = Schema::Record(RecordSchema {
-            name: Name::new("OptionA")?,
+            name: Name::new("OptionA")?.into(),
             aliases: None,
             doc: None,
             fields: vec![
@@ -1507,7 +1462,7 @@ mod tests {
                     .schema(Schema::Union(UnionSchema::new(vec![
                         Schema::Null,
                         Schema::Ref {
-                            name: Name::new("A")?,
+                            name: Name::new("A")?.into(),
                         },
                     ])?))
                     .build(),
@@ -1541,7 +1496,7 @@ mod tests {
         lookup.insert("b".to_owned(), 1);
 
         let expected = Schema::Record(RecordSchema {
-            name: Name::new("test")?,
+            name: Name::new("test")?.into(),
             aliases: None,
             doc: None,
             fields: vec![
@@ -1594,14 +1549,14 @@ mod tests {
         node_lookup.insert("label".to_owned(), 0);
 
         let expected = Schema::Record(RecordSchema {
-            name: Name::new("test")?,
+            name: Name::new("test")?.into(),
             aliases: None,
             doc: None,
             fields: vec![
                 RecordField::builder()
                     .name("recordField".to_string())
                     .schema(Schema::Record(RecordSchema {
-                        name: Name::new("Node")?,
+                        name: Name::new("Node")?.into(),
                         aliases: None,
                         doc: None,
                         fields: vec![
@@ -1613,7 +1568,7 @@ mod tests {
                                 .name("children".to_string())
                                 .schema(
                                     Schema::array(Schema::Ref {
-                                        name: Name::new("Node")?,
+                                        name: Name::new("Node")?.into(),
                                     })
                                     .build(),
                                 )
@@ -1761,7 +1716,7 @@ mod tests {
         lookup.insert("next".to_owned(), 1);
 
         let expected = Schema::Record(RecordSchema {
-            name: Name::new("LongList")?,
+            name: Name::new("LongList")?.into(),
             aliases: Some(vec![Alias::new("LinkedLongs").unwrap()]),
             doc: None,
             fields: vec![
@@ -1774,7 +1729,7 @@ mod tests {
                     .schema(Schema::Union(UnionSchema::new(vec![
                         Schema::Null,
                         Schema::Ref {
-                            name: Name::new("LongList")?,
+                            name: Name::new("LongList")?.into(),
                         },
                     ])?))
                     .build(),
@@ -1811,7 +1766,7 @@ mod tests {
         lookup.insert("next".to_owned(), 1);
 
         let expected = Schema::Record(RecordSchema {
-            name: Name::new("record")?,
+            name: Name::new("record")?.into(),
             aliases: None,
             doc: None,
             fields: vec![
@@ -1822,7 +1777,7 @@ mod tests {
                 RecordField::builder()
                     .name("next".to_string())
                     .schema(Schema::Ref {
-                        name: Name::new("record")?,
+                        name: Name::new("record")?.into(),
                     })
                     .build(),
             ],
@@ -1865,7 +1820,7 @@ mod tests {
         lookup.insert("next".to_owned(), 1);
 
         let expected = Schema::Record(RecordSchema {
-            name: Name::new("record")?,
+            name: Name::new("record")?.into(),
             aliases: None,
             doc: None,
             fields: vec![
@@ -1873,7 +1828,7 @@ mod tests {
                     .name("enum".to_string())
                     .schema(Schema::Enum(
                         EnumSchema::builder()
-                            .name(Name::new("enum")?)
+                            .name(Name::new("enum")?.into())
                             .symbols(vec![
                                 "one".to_string(),
                                 "two".to_string(),
@@ -1885,7 +1840,7 @@ mod tests {
                 RecordField::builder()
                     .name("next".to_string())
                     .schema(Schema::Ref {
-                        name: Name::new("enum")?,
+                        name: Name::new("enum")?.into(),
                     })
                     .build(),
             ],
@@ -1928,14 +1883,14 @@ mod tests {
         lookup.insert("next".to_owned(), 1);
 
         let expected = Schema::Record(RecordSchema {
-            name: Name::new("record")?,
+            name: Name::new("record")?.into(),
             aliases: None,
             doc: None,
             fields: vec![
                 RecordField::builder()
                     .name("fixed".to_string())
                     .schema(Schema::Fixed(FixedSchema {
-                        name: Name::new("fixed")?,
+                        name: Name::new("fixed")?.into(),
                         aliases: None,
                         doc: None,
                         size: 456,
@@ -1945,7 +1900,7 @@ mod tests {
                 RecordField::builder()
                     .name("next".to_string())
                     .schema(Schema::Ref {
-                        name: Name::new("fixed")?,
+                        name: Name::new("fixed")?.into(),
                     })
                     .build(),
             ],
@@ -1968,7 +1923,7 @@ mod tests {
         )?;
 
         let expected = Schema::Enum(EnumSchema {
-            name: Name::new("Suit")?,
+            name: Name::new("Suit")?.into(),
             aliases: None,
             doc: None,
             symbols: vec![
@@ -2013,7 +1968,7 @@ mod tests {
         let schema = Schema::parse_str(r#"{"type": "fixed", "name": "test", "size": 16}"#)?;
 
         let expected = Schema::Fixed(FixedSchema {
-            name: Name::new("test")?,
+            name: Name::new("test")?.into(),
             aliases: None,
             doc: None,
             size: 16_usize,
@@ -2032,7 +1987,7 @@ mod tests {
         )?;
 
         let expected = Schema::Fixed(FixedSchema {
-            name: Name::new("test")?,
+            name: Name::new("test")?.into(),
             aliases: None,
             doc: Some(String::from("FixedSchema documentation")),
             size: 16_usize,
@@ -2480,7 +2435,7 @@ mod tests {
         let schema = Schema::parse_str(schema_str)?;
 
         if let Schema::Record(RecordSchema { name, fields, .. }) = schema {
-            assert_eq!(name, Name::new("AccountEvent")?);
+            assert_eq!(name, Name::new("AccountEvent")?.into());
 
             let field = &fields[0];
             assert_eq!(&field.name, "NullableLongArray");
@@ -2646,7 +2601,7 @@ mod tests {
 
         match schema {
             Schema::Record(RecordSchema { name, fields, .. }) => {
-                assert_eq!(name, Name::new("Rec")?);
+                assert_eq!(name, Name::new("Rec")?.into());
                 assert_eq!(fields.len(), 1);
                 let field = &fields[0];
                 assert_eq!(&field.name, "field_one");
@@ -2676,7 +2631,7 @@ mod tests {
 
         match schema {
             Schema::Record(RecordSchema { name, fields, .. }) => {
-                assert_eq!(name, Name::new("union_schema_test")?);
+                assert_eq!(name, Name::new("union_schema_test")?.into());
                 assert_eq!(fields.len(), 1);
                 let field = &fields[0];
                 assert_eq!(&field.name, "a");
@@ -2715,7 +2670,7 @@ mod tests {
 
         match schema {
             Schema::Record(RecordSchema { name, fields, .. }) => {
-                assert_eq!(name, Name::new("union_schema_test")?);
+                assert_eq!(name, Name::new("union_schema_test")?.into());
                 assert_eq!(fields.len(), 1);
                 let field = &fields[0];
                 assert_eq!(&field.name, "a");
@@ -2753,7 +2708,7 @@ mod tests {
 
         match schema {
             Schema::Record(RecordSchema { name, fields, .. }) => {
-                assert_eq!(name, Name::new("union_schema_test")?);
+                assert_eq!(name, Name::new("union_schema_test")?.into());
                 assert_eq!(fields.len(), 1);
                 let field = &fields[0];
                 assert_eq!(&field.name, "a");
@@ -2792,7 +2747,7 @@ mod tests {
 
         match schema {
             Schema::Record(RecordSchema { name, fields, .. }) => {
-                assert_eq!(name, Name::new("union_schema_test")?);
+                assert_eq!(name, Name::new("union_schema_test")?.into());
                 assert_eq!(fields.len(), 1);
                 let field = &fields[0];
                 assert_eq!(&field.name, "a");
@@ -4213,7 +4168,7 @@ mod tests {
 
         // Test serialize enum attributes
         let schema = Schema::Enum(EnumSchema {
-            name: Name::new("a")?,
+            name: Name::new("a")?.into(),
             aliases: None,
             doc: None,
             symbols: vec![],
@@ -4228,7 +4183,7 @@ mod tests {
 
         // Test serialize fixed custom_attributes
         let schema = Schema::Fixed(FixedSchema {
-            name: Name::new("a")?,
+            name: Name::new("a")?.into(),
             aliases: None,
             doc: None,
             size: 1,
@@ -4242,7 +4197,7 @@ mod tests {
 
         // Test serialize record custom_attributes
         let schema = Schema::Record(RecordSchema {
-            name: Name::new("a")?,
+            name: Name::new("a")?.into(),
             aliases: None,
             doc: None,
             fields: vec![],
@@ -4322,7 +4277,7 @@ mod tests {
         assert_eq!(
             parse_result,
             Schema::Uuid(UuidSchema::Fixed(FixedSchema {
-                name: Name::new("FixedUUID")?,
+                name: Name::new("FixedUUID")?.into(),
                 aliases: None,
                 doc: None,
                 size: 16,
@@ -4364,7 +4319,7 @@ mod tests {
         assert_eq!(
             parse_result,
             Schema::Fixed(FixedSchema {
-                name: Name::new("FixedUUID")?,
+                name: Name::new("FixedUUID")?.into(),
                 aliases: None,
                 doc: None,
                 size: 6,
@@ -4474,7 +4429,7 @@ mod tests {
             let mut lookup = BTreeMap::new();
             lookup.insert("value".to_owned(), 0);
             Schema::Record(RecordSchema {
-                name: Name::new("LongList")?,
+                name: Name::new("LongList")?.into(),
                 aliases: Some(vec![Alias::new("LinkedLongs").unwrap()]),
                 doc: None,
                 fields: vec![
@@ -4506,7 +4461,7 @@ mod tests {
             precision: 36,
             scale: 10,
             inner: InnerDecimalSchema::Fixed(FixedSchema {
-                name: Name::new("decimal_36_10").unwrap(),
+                name: Arc::new(Name::new("decimal_36_10").unwrap()),
                 aliases: None,
                 doc: None,
                 size: 16,
@@ -4790,11 +4745,7 @@ mod tests {
 
         let schema1 = Schema::parse_str(raw_schema)?;
         match &schema1 {
-            Schema::Array(ArraySchema {
-                items,
-                default: _,
-                attributes,
-            }) => {
+            Schema::Array(ArraySchema { items, attributes }) => {
                 assert!(attributes.is_empty());
 
                 match **items {
@@ -4813,7 +4764,6 @@ mod tests {
                         match &fields[0].schema {
                             Schema::Array(ArraySchema {
                                 items: _,
-                                default: _,
                                 attributes,
                             }) => {
                                 assert!(attributes.is_empty());
@@ -4865,11 +4815,7 @@ mod tests {
 
         let schema1 = Schema::parse_str(raw_schema)?;
         match &schema1 {
-            Schema::Array(ArraySchema {
-                items,
-                default: _,
-                attributes,
-            }) => {
+            Schema::Array(ArraySchema { items, attributes }) => {
                 assert!(attributes.is_empty());
 
                 match **items {
@@ -4888,7 +4834,6 @@ mod tests {
                         match &fields[0].schema {
                             Schema::Map(MapSchema {
                                 types: _,
-                                default: _,
                                 attributes,
                             }) => {
                                 assert!(attributes.is_empty());
@@ -4914,7 +4859,7 @@ mod tests {
     #[test]
     fn avro_rs_382_serialize_duration_schema() -> TestResult {
         let schema = Schema::Duration(FixedSchema {
-            name: Name::try_from("Duration")?,
+            name: Name::try_from("Duration")?.into(),
             aliases: None,
             doc: None,
             size: 12,
@@ -5005,15 +4950,15 @@ mod tests {
 
     #[test]
     fn avro_rs_420_independent_canonical_form() -> TestResult {
-        let (record, schemata) = Schema::parse_str_with_list(
-            r#"{
+        let [rs] = ResolvedSchema::from_str_array(
+            [r#"{
             "name": "root",
             "type": "record",
             "fields": [{
                 "name": "node",
                 "type": "node"
             }]
-        }"#,
+        }"#],
             [r#"{
             "name": "node",
             "type": "record",
@@ -5023,7 +4968,7 @@ mod tests {
             }]
         }"#],
         )?;
-        let icf = record.independent_canonical_form(&schemata)?;
+        let icf = CompleteSchema::from(&rs).independent_canonical_form()?;
         assert_eq!(
             icf,
             r#"{"name":"root","type":"record","fields":[{"name":"node","type":{"name":"node","type":"record","fields":[{"name":"children","type":["null","node"]}]}}]}"#
@@ -5102,271 +5047,6 @@ mod tests {
     }
 
     #[test]
-    fn avro_rs_467_array_default() -> TestResult {
-        let schema = Schema::parse_str(
-            r#"{
-            "type": "array",
-            "items": "string",
-            "default": []
-        }"#,
-        )?;
-
-        let Schema::Array(array) = schema else {
-            panic!("Expected Schema::Array, got {schema:?}");
-        };
-
-        assert_eq!(array.attributes, BTreeMap::new());
-        assert_eq!(array.default, Some(Vec::new()));
-
-        let json = serde_json::to_string(&Schema::Array(array))?;
-        assert!(json.contains(r#""default":[]"#));
-
-        Ok(())
-    }
-
-    #[test]
-    fn avro_rs_467_array_default_with_actual_values() -> TestResult {
-        let schema = Schema::parse_str(
-            r#"{
-            "type": "array",
-            "items": "string",
-            "default": ["foo", "bar"]
-        }"#,
-        )?;
-
-        let Schema::Array(array) = schema else {
-            panic!("Expected Schema::Array, got {schema:?}");
-        };
-
-        assert_eq!(array.attributes, BTreeMap::new());
-        assert_eq!(
-            array.default,
-            Some(vec![
-                Value::String("foo".into()),
-                Value::String("bar".into())
-            ])
-        );
-
-        let json = serde_json::to_string(&Schema::Array(array))?;
-        assert!(json.contains(r#""default":["foo","bar"]"#));
-
-        Ok(())
-    }
-
-    #[test]
-    fn avro_rs_467_array_default_with_invalid_values() -> TestResult {
-        let err = Schema::parse_str(
-            r#"{
-            "type": "array",
-            "items": "string",
-            "default": [false, true]
-        }"#,
-        )
-        .unwrap_err();
-
-        assert_eq!(
-            err.to_string(),
-            "Default value for an array must be an array of String! Found: Boolean(false)"
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn avro_rs_467_array_default_with_mixed_values() -> TestResult {
-        let err = Schema::parse_str(
-            r#"{
-            "type": "array",
-            "items": "string",
-            "default": ["foo", true]
-        }"#,
-        )
-        .unwrap_err();
-
-        assert_eq!(
-            err.to_string(),
-            "Default value for an array must be an array of String! Found: Boolean(true)"
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn avro_rs_467_array_default_with_reference() -> TestResult {
-        let schema = Schema::parse_str(
-            r#"{
-            "type": "record",
-            "name": "Something",
-            "fields": [
-                {
-                    "name": "one",
-                    "type": {
-                        "type": "enum",
-                        "name": "ABC",
-                        "symbols": ["A", "B", "C"]
-                    }
-                },
-                {
-                    "name": "two",
-                    "type": {
-                        "type": "array",
-                        "items": "ABC",
-                        "default": ["A", "B", "C"]
-                    }
-                }
-            ]
-        }"#,
-        )?;
-
-        let Schema::Record(record) = schema else {
-            panic!("Expected Schema::Record, got {schema:?}");
-        };
-        let Schema::Array(array) = &record.fields[1].schema else {
-            panic!("Expected Schema::Array, got {:?}", record.fields[1].schema);
-        };
-
-        assert_eq!(array.attributes, BTreeMap::new());
-        assert_eq!(
-            array.default,
-            Some(vec![
-                Value::String("A".into()),
-                Value::String("B".into()),
-                Value::String("C".into())
-            ])
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn avro_rs_467_map_default() -> TestResult {
-        let schema = Schema::parse_str(
-            r#"{
-            "type": "map",
-            "values": "string",
-            "default": {}
-        }"#,
-        )?;
-
-        let Schema::Map(map) = schema else {
-            panic!("Expected Schema::Map, got {schema:?}");
-        };
-
-        assert_eq!(map.attributes, BTreeMap::new());
-        assert_eq!(map.default, Some(HashMap::new()));
-
-        let json = serde_json::to_string(&Schema::Map(map))?;
-        assert!(json.contains(r#""default":{}"#));
-
-        Ok(())
-    }
-
-    #[test]
-    fn avro_rs_467_map_default_with_actual_values() -> TestResult {
-        let schema = Schema::parse_str(
-            r#"{
-            "type": "map",
-            "values": "string",
-            "default": {"foo": "bar"}
-        }"#,
-        )?;
-
-        let Schema::Map(map) = schema else {
-            panic!("Expected Schema::Map, got {schema:?}");
-        };
-
-        let mut hashmap = HashMap::new();
-        hashmap.insert("foo".to_string(), Value::String("bar".into()));
-        assert_eq!(map.attributes, BTreeMap::new());
-        assert_eq!(map.default, Some(hashmap));
-
-        let json = serde_json::to_string(&Schema::Map(map))?;
-        assert!(json.contains(r#""default":{"foo":"bar"}"#));
-
-        Ok(())
-    }
-
-    #[test]
-    fn avro_rs_467_map_default_with_invalid_values() -> TestResult {
-        let err = Schema::parse_str(
-            r#"{
-            "type": "map",
-            "values": "string",
-            "default": {"foo": true}
-        }"#,
-        )
-        .unwrap_err();
-
-        assert_eq!(
-            err.to_string(),
-            "Default value for a map must be an object with (String, String)! Found: (String, Boolean(true))"
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn avro_rs_467_map_default_with_mixed_values() -> TestResult {
-        let err = Schema::parse_str(
-            r#"{
-            "type": "map",
-            "values": "string",
-            "default": {"foo": "bar", "spam": true}
-        }"#,
-        )
-        .unwrap_err();
-
-        assert_eq!(
-            err.to_string(),
-            "Default value for a map must be an object with (String, String)! Found: (String, Boolean(true))"
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn avro_rs_467_map_default_with_reference() -> TestResult {
-        let schema = Schema::parse_str(
-            r#"{
-            "type": "record",
-            "name": "Something",
-            "fields": [
-                {
-                    "name": "one",
-                    "type": {
-                        "type": "enum",
-                        "name": "ABC",
-                        "symbols": ["A", "B", "C"]
-                    }
-                },
-                {
-                    "name": "two",
-                    "type": {
-                        "type": "map",
-                        "values": "ABC",
-                        "default": {"foo": "A"}
-                    }
-                }
-            ]
-        }"#,
-        )?;
-
-        let Schema::Record(record) = schema else {
-            panic!("Expected Schema::Record, got {schema:?}");
-        };
-        let Schema::Map(map) = &record.fields[1].schema else {
-            panic!("Expected Schema::Map, got {:?}", record.fields[1].schema);
-        };
-
-        let mut hashmap = HashMap::new();
-        hashmap.insert("foo".to_string(), Value::String("A".into()));
-        assert_eq!(map.attributes, BTreeMap::new());
-        assert_eq!(map.default, Some(hashmap));
-
-        Ok(())
-    }
-
-    #[test]
     fn avro_rs_476_enum_cannot_be_directly_in_field() -> TestResult {
         let schema_str = r#"{
             "type": "record",
@@ -5386,5 +5066,94 @@ mod tests {
             "Invalid schema: There is no type called 'enum', if you meant to define a non-primitive schema, it should be defined inside `type` attribute."
         );
         Ok(())
+    }
+
+    #[test]
+    fn avro_rs_509_default_must_be_in_custom_attributes_for_map_and_enum() -> TestResult {
+        let schema = Schema::parse_str(
+            r#"{
+            "name": "ignore_defaults",
+            "type": "record",
+            "fields": [
+                {"name": "a", "type": { "type": "map", "values": "string", "default": null }},
+                {"name": "b", "type": { "type": "array", "items": "string", "default": null }}
+            ]
+        }"#,
+        )?;
+
+        let Schema::Record(record) = schema else {
+            panic!("Expect Schema::Record for {schema:?}");
+        };
+        println!("{:?}", record);
+        let Schema::Map(map) = &record.fields[0].schema else {
+            panic!("Expect Schema::Map for first field of {record:?}");
+        };
+        assert_eq!(map.attributes.len(), 1);
+        assert_eq!(
+            map.attributes.get("default"),
+            Some(&serde_json::Value::Null)
+        );
+
+        let Schema::Array(array) = &record.fields[1].schema else {
+            panic!("Expect Schema::Array for second field of {record:?}");
+        };
+        assert_eq!(array.attributes.len(), 1);
+        assert_eq!(
+            array.attributes.get("default"),
+            Some(&serde_json::Value::Null)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn avro_rs_test_schema_with_symbol_parse() -> TestResult{
+        let schema_with_symbols = SchemaWithSymbols::parse_str(
+            r#"{
+            "name": "root",
+            "type": "record",
+            "fields": [
+                {"name": "a", "type": { "type": "fixed", "name": "inner_fixed_a", "size": 16}},
+                {"name": "b", "type": { "type": "fixed", "name": "inner_fixed_b", "size": 16}}
+            ]
+        }"#)?;
+
+        match schema_with_symbols.schema.as_ref(){
+            Schema::Ref{name: _} => {},
+            _ => panic!("Expected root schema to be converted into Schema::Ref and its definition placed in the symbol map")
+        };
+
+        let inner_fixed_a_schema = Schema::parse_str(r#"{"name": "a", "type": { "type": "fixed", "name": "inner_fixed_a", "size": 16}}"#)?;
+        let inner_fixed_b_schema = Schema::parse_str(r#"{"name": "a", "type": { "type": "fixed", "name": "inner_fixed_b", "size": 16}}"#)?;
+        let root_schema = Schema::parse_str(r#"{
+            "name": "root",
+            "type": "record",
+            "fields": [
+                {"name": "a", "type": "inner_fixed_a"},
+                {"name": "b", "type": "inner_fixed_b"}
+            ]
+        }"#)?;
+
+        assert_eq!(schema_with_symbols.referenced_names,
+                HashSet::from([Arc::new(Name::try_from("root")?), Arc::new(Name::try_from("inner_fixed_a")?), Arc::new(Name::try_from("inner_fixed_b")?)])
+        );
+
+        let parsed_inner_fixed_a = schema_with_symbols.defined_names.get(&Name::try_from("inner_fixed_a")?).expect("Was not able to find defined schema for name inner_fixed_a");
+        let parsed_inner_fixed_b = schema_with_symbols.defined_names.get(&Name::try_from("inner_fixed_b")?).expect("Was not able to find defined schema for name inner_fixed_b");
+        let parsed_root = schema_with_symbols.defined_names.get(&Name::try_from("root")?).expect("Was not able to find defined schema for name root");
+
+        assert_eq!(parsed_root.as_ref(),
+            &root_schema
+        );
+
+        assert_eq!(parsed_inner_fixed_a.as_ref(),
+            &inner_fixed_a_schema
+        );
+
+        assert_eq!(parsed_inner_fixed_b.as_ref(),
+            &inner_fixed_b_schema
+        );
+
+        return Ok(())
     }
 }

--- a/avro/src/schema/mod.rs
+++ b/avro/src/schema/mod.rs
@@ -30,7 +30,7 @@ pub use crate::schema::{
     resolve::{ResolvedSchema, ResolvedSchemaBuilder, IntoSchemaWithSymbols,
         ResolvedNode, ResolvedRecord, ResolvedUnion,
         ResolvedArray, ResolvedMap, ResolvedRecordField, CompleteSchema,
-        Resolver, DefaultResolver},
+        Resolver, DefaultResolver, ResolvedContext},
     union::{UnionSchema, UnionSchemaBuilder},
 };
 use crate::{
@@ -91,37 +91,78 @@ pub struct DefaultToResolve{
     json: JsonValue
 }
 
-/// KDOTO: docs!
-/// Represents a parsed Avro schema with information on
-/// what named schemata are exposed by the schema as well
-/// as schemata names used and defined by this schema.
+
+/// Represents a parsed Avro Schema with the following additional information
+/// - What schema names are defined within this schema
+/// - What schema names are references by this schema but are not provided a definition.
+/// - What field defualts have been provided and what schema they must match.
+///   `SchemaWithSymbols` is designed to provided the suite of information necessary that when
+///   evaluation if two schemata can be included in the same context a walk of the schema tree is not
+///   required.
+///
+///   `SchemaWithSymbols` wraps `Arc` references and `HashMap`/`HashSet`'s of Arc references and is
+///   therefore fairly cheap to clone.
+/// # Construction
+/// A `SchemaWithSymbols` can be constructed from a `&str` using [`SchemaWithSymbols::parse_str`]. To
+/// construct several `SchemaWithSymbols`, use [`SchemaWithSymbols::parse_array`] or
+/// [`SchemaWithSymbols::parse_list`]. If one wishes to get a standalone [`Schema`] representation of a
+/// `SchemaWithSymbols`, use [`SchemaWithSymbols::unravel`].
+/// # Examples
+/// ```
+/// use apache_avro::schema::SchemaWithSymbols;
+/// let schema = r#"
+///     {
+///         "name": "helloWorldRecord",
+///         "type": "record",
+///         "fields": [{"name": "field", "type": "string"}] 
+///     }
+/// "#;
+///
+/// let schema2 = r#"{
+///     "name": "helloWorldEnum",
+///     "type": "enum",
+///     "symbols": ["HELLO", "WORLD"]
+/// }"#;
+///
+/// let schema_vec = vec![&schema, &schema2];
+///
+/// let with_symbols = SchemaWithSymbols::parse_str(&schema).unwrap();
+///
+/// let [with_symbols1, with_symbols2] = SchemaWithSymbols::parse_array([&schema, &schema2]).unwrap();
+///
+/// let with_symbols_vec = SchemaWithSymbols::parse_list(schema_vec).unwrap();
+/// ```
 #[derive(Clone,Debug)]
 pub struct SchemaWithSymbols{
-    /// schema fullnames defined in this schema.
-    pub(crate) defined_names: HashMap<Arc<Name>, Arc<Schema>>,
-    /// all schema fullnames references in this schema, both those that have
-    /// an internal resolution and those that are internally unresolved.
-    pub(crate) referenced_names: HashSet<Arc<Name>>,
-    /// The parseed schema tree
-    pub(crate) stub: Arc<Schema>,
-    /// Record fields that have defualt values that need to be
-    /// resolved.
-    /// KTODO: documentation
-    pub(crate) field_defaults_to_resolve: Arc<Vec<DefaultToResolve>>
+    /// Schemata defined within this Schema
+    pub defined_names: HashMap<Arc<Name>, Arc<Schema>>,
+    /// Referenced Schema names that do not have a definition inside this Schema.
+    pub referenced_names: HashSet<Arc<Name>>,
+    /// The root stub of this schema
+    pub stub: Arc<Schema>,
+    /// Fields within this Schema that have a default and need to be resolved against the appropriate
+    /// field schema.
+    pub field_defaults_to_resolve: Arc<Vec<DefaultToResolve>>
 }
 
 
 impl SchemaWithSymbols{
+    /// Parse a single `&str` into a `SchemaWithSymbols`. This function does not check
+    /// to ensure that all named schema are given defintions. If this check is desired, use [`ResolvedSchema`].
     pub fn parse_str(input: &str) -> Result<SchemaWithSymbols,Error>{
         let parser = Parser::default();
         parser.parse_str(input)
     }
-
+    /// Parse a [`JsonValue`] into a `SchemaWithSymbols`
     pub fn parse(value: &JsonValue) -> AvroResult<SchemaWithSymbols>{
         let parser = Parser::default();
         parser.parse(value, None)
     }
 
+    /// Parse the provided array of `impl AsRev<str>` into an array of `SchemaWithSymbols` of the
+    /// same length. This function does not check for naming conflicts in the provided schemata or
+    /// that all referenced schema names are given definitions. To check that an array of schemata 
+    /// is consistent, consider using [`ResolvedSchema`] or [`ResolvedContext`]
     pub fn parse_array<const N: usize>(input: [impl AsRef<str>; N]) -> AvroResult<[SchemaWithSymbols; N]>{
         let input = input.into_iter();
         let mut parsed = Self::parse_list(input)?.into_iter();
@@ -130,6 +171,11 @@ impl SchemaWithSymbols{
         }))
     }
 
+    /// Parse the provided `impl IntoIterator<impl AsRef<str>>` into a `Vec` of
+    /// `SchemaWithSymbols`. This function does not check for naming conflicts 
+    /// in the provided schemata or that all referenced schema names are given 
+    /// definitions. To check that an array of schemata is consistent, consider 
+    /// using [`ResolvedSchema`] or [`ResolvedContext`]
     pub fn parse_list(input: impl IntoIterator<Item = impl AsRef<str>>) -> AvroResult<Vec<SchemaWithSymbols>> {
         let input = input.into_iter();
         input.map(|str| {
@@ -138,10 +184,12 @@ impl SchemaWithSymbols{
         }).collect()
     }
 
+    /// Take this `SchemaWithSymbols` and unravel it's stub given the definitions contained in the field `defined_names`.
+    /// This produces a standalone [`Schema`] representation of this `SchemaWithSymbols`.
     pub fn unravel(&self) -> Schema{
         let mut stub = self.stub.as_ref().clone();
         unravel_inner(&mut stub, &self.defined_names, &mut HashSet::new(), &mut HashMap::new());
-        return stub
+        stub
     }
 }
 pub(crate) fn unravel_inner(schema: &mut Schema, defined_schemata: & NameMap, placed_schemata: &mut NameSet, alias_map: &mut HashMap<Name, Arc<Name>>){
@@ -151,7 +199,7 @@ pub(crate) fn unravel_inner(schema: &mut Schema, defined_schemata: & NameMap, pl
                 let mut definition = defined_schemata.get(name).unwrap().as_ref().clone();
                 unravel_inner(&mut definition, defined_schemata, placed_schemata, alias_map);
                 *schema = definition;
-            }else if alias_map.contains_key(&name) {
+            }else if alias_map.contains_key(name) {
                *schema = Schema::Ref{name: Arc::clone(alias_map.get(name).unwrap())};
             }
         },
@@ -178,8 +226,8 @@ pub(crate) fn unravel_inner(schema: &mut Schema, defined_schemata: & NameMap, pl
             unravel_inner(map_schema.types.as_mut(), defined_schemata, placed_schemata, alias_map);
         }
         Schema::Union(union_schema) => {
-            for mut el_schema in &mut union_schema.schemas {
-                unravel_inner(&mut el_schema, defined_schemata, placed_schemata, alias_map);
+            for el_schema in &mut union_schema.schemas {
+                unravel_inner(el_schema, defined_schemata, placed_schemata, alias_map);
             }
         },
         Schema::Fixed(fixed_schema) => {
@@ -218,7 +266,7 @@ impl From<Arc<Schema>> for SchemaWithSymbols{
 
 impl AsRef<SchemaWithSymbols> for SchemaWithSymbols{
     fn as_ref(&self) -> &SchemaWithSymbols {
-        return self
+        self
     }
 }
 /// Represents any valid Avro schema
@@ -355,7 +403,6 @@ impl PartialEq for Schema {
     }
 }
 
-// KTODO, need to test this out the wazoo, big error here!
 impl From<Schema> for SchemaWithSymbols{
     fn from(value: Schema) -> Self {
         fn transform(schema: Schema, defined_names: &mut HashMap<Arc<Name>, Arc<Schema>>, referenced_names: &mut HashSet<Arc<Name>>, field_defaults_to_resolve: &mut Vec<DefaultToResolve>) -> Schema {
@@ -413,7 +460,7 @@ impl From<Schema> for SchemaWithSymbols{
 
         let schema = transform(value , &mut defined_names, &mut referenced_names, &mut field_defaults_to_resolve);
 
-        return Self{
+        Self{
             defined_names,
             referenced_names,
             field_defaults_to_resolve: field_defaults_to_resolve.into(),
@@ -718,22 +765,19 @@ impl Schema {
     }
 
     /// Create a `Schema` from a string representing a JSON Avro schema.
-    /// Note: Unless a bare schema is needed, prefer using SchemaWithSymbols::parse_str
+    /// **Note:** Unless a bare schema is needed, prefer using [`SchemaWithSymbols::parse_str`]
     pub fn parse_str(input: &str) -> Result<Schema, Error> {
         let parser = Parser::default();
-        let schema = parser.parse_str(input)?.unravel(); //KTODO this needs changing
+        let schema = parser.parse_str(input)?.unravel();
         Ok(schema)
     }
 
     /// Create an array of `Schema`'s from a list of named JSON Avro schemas (Record, Enum, and
-    /// Fixed).
+    /// Fixed). This method will not check that the provided list of schemata has the property that
+    /// every named schema reference has a unique unambiguous definition. If this check is desired, look
+    /// at building a [`ResolvedSchema`].
     ///
-    /// It is allowed that the schemas have cross-dependencies; these will be resolved
-    /// during parsing.
-    ///
-    /// If two of the input schemas have the same fullname, an Error will be returned.
-    ///
-    /// Note: Unless a bare schema is needed, prefer using SchemaWithSymbols::parse_list
+    /// **Note:** Unless a bare schema is needed, prefer using [`SchemaWithSymbols::parse_list`]
     pub fn parse_list(input: impl IntoIterator<Item = impl AsRef<str>>) -> AvroResult<Vec<Schema>> {
         let input = input.into_iter();
 
@@ -748,11 +792,11 @@ impl Schema {
                 if let Err(err) = schem {
                     return Err(err);
                 }else{
-                    schemata.push(schem.unwrap().unravel()); //KTODO this needs changing!!
+                    schemata.push(schem.unwrap().unravel());
                 }
         };
 
-        return Ok(schemata)
+        Ok(schemata)
     }
 
 
@@ -1375,7 +1419,7 @@ mod tests {
 
         let schema_str_c = r#"["A", "B"]"#;
 
-        let [schema_c, schema_a, schema_b] = ResolvedSchema::resolve().build_array([&schema_str_c,&schema_str_a, &schema_str_b])?;
+        let [schema_c, schema_a, schema_b] = ResolvedSchema::builder().build_array([&schema_str_c,&schema_str_a, &schema_str_b])?;
 
         let schema_a_expected = Schema::Record(RecordSchema {
             name: Name::new("A")?.into(),
@@ -1439,7 +1483,7 @@ mod tests {
 
         let schema_str_c = r#"["A", "A"]"#;
 
-        let rs = ResolvedSchema::resolve().additional([schema_str_a1, schema_str_a2]).and_then(|b| b.build_array([schema_str_c]));
+        let rs = ResolvedSchema::builder().additional([schema_str_a1, schema_str_a2]).and_then(|b| b.build_array([schema_str_c]));
         match rs {
             Ok(_) => unreachable!("Expected an error that the name is already defined"),
             Err(e) => assert_eq!(
@@ -1471,7 +1515,7 @@ mod tests {
 
         let schema_str_c = r#"["A"]"#;
 
-        match ResolvedSchema::resolve().additional([schema_str_a, schema_str_b]).and_then(|b| b.build_array([schema_str_c])) {
+        match ResolvedSchema::builder().additional([schema_str_a, schema_str_b]).and_then(|b| b.build_array([schema_str_c])) {
             Ok(_) => unreachable!("Expected an error that schema_str_b is missing a name field"),
             Err(e) => assert_eq!(e.to_string(), "No `name` field"),
         }
@@ -4979,7 +5023,7 @@ mod tests {
 
     #[test]
     fn avro_rs_420_independent_canonical_form() -> TestResult {
-        let [rs] = ResolvedSchema::resolve()
+        let [rs] = ResolvedSchema::builder()
             .additional([r#"{
             "name": "node",
             "type": "record",
@@ -5051,28 +5095,6 @@ mod tests {
 
         Ok(())
     }
-
-    //#[test] // KTODO -- this should be changed to a WARNING, not an error...
-    //fn avro_rs_476_enum_cannot_be_directly_in_field() -> TestResult {
-    //    let schema_str = r#"{
-    //        "type": "record",
-    //        "name": "ExampleEnum",
-    //        "namespace": "com.schema",
-    //        "fields": [
-    //            {
-    //            "name": "wrong_enum",
-    //            "type": "enum",
-    //            "symbols": ["INSERT", "UPDATE"]
-    //            }
-    //        ]
-    //    }"#;
-    //    let result = Schema::parse_str(schema_str).unwrap_err();
-    //    assert_eq!(
-    //        result.to_string(),
-    //        "Invalid schema: There is no type called 'enum', if you meant to define a non-primitive schema, it should be defined inside `type` attribute."
-    //    );
-    //    Ok(())
-    //}
 
     #[test]
     fn avro_rs_509_default_must_be_in_custom_attributes_for_map_and_enum() -> TestResult {
@@ -5167,7 +5189,7 @@ mod tests {
             &inner_fixed_b_schema
         );
 
-        return Ok(())
+        Ok(())
     }
 
     #[test]
@@ -5217,9 +5239,9 @@ mod tests {
        let schema1 = SchemaWithSymbols::parse_str(schema1)?;
        let schema2 = SchemaWithSymbols::parse_str(schema2)?;
 
-       let _resolved = ResolvedSchema::resolve().additional([schema2])?.build_array([schema1])?;
+       let _resolved = ResolvedSchema::builder().additional([schema2])?.build_array([schema1])?;
 
-       return Ok(())
+       Ok(())
     }
 
     #[test]
@@ -5231,7 +5253,7 @@ mod tests {
            }"#;
 
            let _schema = SchemaWithSymbols::parse_str(schema1).unwrap();
-           return Ok(())
+           Ok(())
     }
 
     #[test]
@@ -5244,6 +5266,36 @@ mod tests {
 
            let schema = SchemaWithSymbols::parse_str(schema1).unwrap();
            assert!(schema.referenced_names.is_empty());
+           Ok(())
+    }
+
+    #[test]
+    fn avro_rs_json_schema_not_allowed_for_type_when_at_root() -> TestResult{
+           let schema1 = r#"
+                        {
+                            "type":  {
+                                               "type": "enum",
+                                               "name": "testEnum",
+                                               "symbols": ["A","B","C"]
+                                           }
+                        }
+                        "#;
+
+           let schema = SchemaWithSymbols::parse_str(schema1);
+           assert!(schema.expect_err("Expected not to parse correctly!").into_details().to_string().contains("Only built-in type names as strings are allowed"));
+           Ok(())
+    }
+
+    #[test]
+    fn avro_rs_user_type_name_not_allowed_for_type_when_at_root() -> TestResult{
+           let schema = r#"
+                        {
+                            "type": "testEnum"
+                        }
+                        "#;
+
+           let schema = SchemaWithSymbols::parse_str(schema);
+           assert!(schema.expect_err("Expected not to parse correctly!").into_details().to_string().contains("Only built-in type names as strings are allowed"));
            Ok(())
     }
 }

--- a/avro/src/schema/name.rs
+++ b/avro/src/schema/name.rs
@@ -18,9 +18,10 @@
 use serde::{Deserialize, Serialize, Serializer};
 use serde_json::{Map, Value};
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
+use std::sync::Arc;
+use std::collections::{HashSet, HashMap};
 
 use crate::{
     AvroResult, Error, Schema,
@@ -59,6 +60,10 @@ pub type NamesRef<'a> = HashMap<Name, &'a Schema>;
 pub type Namespace = Option<String>;
 /// Represents the namespace for Named Schema
 pub type NamespaceRef<'a> = Option<&'a str>;
+
+// convenience types KTODO: make these the "main" names types we use..
+pub type NameMap = HashMap<Arc<Name>, Arc<Schema>>;
+pub type NameSet = HashSet<Arc<Name>>;
 
 impl Name {
     /// Create a new `Name`.

--- a/avro/src/schema/name.rs
+++ b/avro/src/schema/name.rs
@@ -61,7 +61,7 @@ pub type Namespace = Option<String>;
 /// Represents the namespace for Named Schema
 pub type NamespaceRef<'a> = Option<&'a str>;
 
-// convenience types KTODO: make these the "main" names types we use..
+// convenience types
 pub type NameMap = HashMap<Arc<Name>, Arc<Schema>>;
 pub type NameSet = HashSet<Arc<Name>>;
 

--- a/avro/src/schema/parser.rs
+++ b/avro/src/schema/parser.rs
@@ -17,10 +17,9 @@
 
 use crate::error::Details;
 use crate::schema::{
-    Alias, Aliases, ArraySchema, DecimalMetadata, DecimalSchema, EnumSchema, FixedSchema,
-    MapSchema, Name, NamespaceRef, Precision, RecordField, RecordSchema, Scale, Schema,
-    SchemaKind, UnionSchema, UuidSchema, SchemaWithSymbols
+    self, Alias, Aliases, ArraySchema, DecimalMetadata, DecimalSchema, DefaultToResolve, EnumSchema, FixedSchema, MapSchema, Name, NamespaceRef, Precision, RecordField, RecordSchema, Scale, Schema, SchemaKind, SchemaWithSymbols, UnionSchema, UuidSchema
 };
+use crate::serde::fixed;
 use crate::types;
 use crate::util::MapHelper;
 use crate::validator::validate_enum_symbol_name;
@@ -29,16 +28,6 @@ use log::{debug, error, warn};
 use serde_json::{Map, Value};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
-
-#[derive(Debug, Default)]
-pub(crate) enum RecordSchemaParseLocation {
-    /// When the parse is happening at root level
-    #[default]
-    Root,
-
-    /// When the parse is happening inside a record field
-    FromField,
-}
 
 enum ReservedSchema {
     Reserved,
@@ -55,7 +44,7 @@ pub(crate) struct Parser {
     /// in the schema tree
     referenced_names: HashSet<Arc<Name>>,
     /// Keeps track of fields that have a defualt value we need to resolve against.
-    pub(crate) field_defaults_to_resolve: Vec<(Schema, Value)>
+    pub(crate) field_defaults_to_resolve: Vec<DefaultToResolve>
 }
 
 impl Parser {
@@ -69,29 +58,31 @@ impl Parser {
     /// Create a `SchemaWithSymbols` from a `serde_json::Value` representing a JSON Avro
     /// schema.
     pub(super) fn parse(mut self, value: &Value, enclosing_namespace: NamespaceRef) -> AvroResult<SchemaWithSymbols>{
-        let schema = self.parse_internal(&value, enclosing_namespace)?;
+        let schema = self.parse_schema(&value, enclosing_namespace)?;
         let defined_names : HashMap<Arc<Name>, Arc<Schema>> = HashMap::from_iter(self.defined_names.drain().map(|(key, val)| {
             match val {
-                ReservedSchema::Reserved => {panic!("reserved schema encountered that was not provided a definition")}
+                ReservedSchema::Reserved => {panic!("reserved schema encountered that was not provided a definition")} // KTODO: clean this message up!!
                 ReservedSchema::Completed(schema_ref) => (key, schema_ref)
             }
         }));
 
+        let referenced_names : HashSet<Arc<Name>> = self.referenced_names.drain().filter(|name|{!defined_names.contains_key(name)}).collect();
+
         Ok(SchemaWithSymbols{
-            field_defaults_to_resolve: self.field_defaults_to_resolve,
+            field_defaults_to_resolve: self.field_defaults_to_resolve.into(),
             defined_names,
-            referenced_names: self.referenced_names,
-            schema: Arc::new(schema)
+            referenced_names,
+            stub: Arc::new(schema)
         })
     }
 
     /// Create a `Schema` from a `serde_json::Value` representing a JSON Avro
     /// schema.
-    fn parse_internal(&mut self, value: &Value, enclosing_namespace: NamespaceRef) -> AvroResult<Schema> {
+    pub(crate) fn parse_schema(&mut self, value: &Value, enclosing_namespace: NamespaceRef) -> AvroResult<Schema> {
         match *value {
             Value::String(ref t) => self.parse_known_schema(t.as_str(), enclosing_namespace),
             Value::Object(ref data) => {
-                self.parse_complex(data, enclosing_namespace, RecordSchemaParseLocation::Root)
+                self.parse_json_object_as_schema(data, enclosing_namespace)
             }
             Value::Array(ref data) => self.parse_union(data, enclosing_namespace),
             _ => Err(Details::ParseSchemaFromValidJson.into()),
@@ -172,11 +163,10 @@ impl Parser {
     ///
     /// Avro supports "recursive" definition of types.
     /// e.g: `{"type": {"type": "string"}}`
-    pub(super) fn parse_complex(
+    pub(super) fn parse_json_object_as_schema(
         &mut self,
         complex: &Map<String, Value>,
         enclosing_namespace: NamespaceRef,
-        parse_location: RecordSchemaParseLocation,
     ) -> AvroResult<Schema> {
         // Try to parse this as a native complex type.
         fn parse_as_native_complex(
@@ -189,7 +179,7 @@ impl Parser {
                     Value::String(s) if s == "fixed" => {
                         parser.parse_fixed(complex, enclosing_namespace)
                     }
-                    _ => parser.parse_internal(value, enclosing_namespace),
+                    _ => parser.parse_schema(value, enclosing_namespace),
                 },
                 None => Err(Details::GetLogicalTypeField.into()),
             }
@@ -205,10 +195,10 @@ impl Parser {
             logical_type: &str,
             schema: Schema,
             supported_schema_kinds: &[SchemaKind],
-            convert: F,
+            mut convert: F,
         ) -> AvroResult<Schema>
         where
-            F: Fn(Schema) -> AvroResult<Schema>,
+            F: FnMut(Schema) -> AvroResult<Schema>,
         {
             let kind = SchemaKind::from(schema.clone());
             if supported_schema_kinds.contains(&kind) {
@@ -230,14 +220,35 @@ impl Parser {
                         &[SchemaKind::Fixed, SchemaKind::Bytes],
                         |inner| -> AvroResult<Schema> {
                             match self.parse_precision_and_scale(complex) {
-                                Ok((precision, scale)) => Ok(Schema::Decimal(DecimalSchema {
-                                    precision,
-                                    scale,
-                                    inner: inner.try_into()?,
-                                })),
+                                Ok((precision, scale)) => {
+                                    match inner{
+                                        Schema::Fixed(inner) => {
+                                            let schema = Schema::Decimal(DecimalSchema {
+                                                precision,
+                                                scale,
+                                                inner: schema::InnerDecimalSchema::Fixed(inner.clone()),
+                                            });
+                                            let _ = self.insert_parsed_for_reserved(&inner.name, &inner.aliases, &Arc::new(schema))?;
+                                            Ok(Schema::Ref{name: Arc::clone(&inner.name)})
+                                        },
+                                        Schema::Bytes => {
+                                            Ok(Schema::Decimal(DecimalSchema {
+                                                precision,
+                                                scale,
+                                                inner: schema::InnerDecimalSchema::Bytes,
+                                            }))
+                                        }
+                                        _ => Err(Details::ResolveDecimalSchema(inner.into()).into())
+                                    }
+                                },
                                 Err(err) => {
                                     warn!("Ignoring invalid decimal logical type: {err}");
-                                    Ok(inner)
+                                    if let Schema::Fixed(ref fixed_inner) = inner {
+                                        let _ = self.insert_parsed_for_reserved(&fixed_inner.name, &fixed_inner.aliases, &Arc::new(inner.clone()))?;
+                                        Ok(Schema::Ref{name: Arc::clone(&fixed_inner.name)})
+                                    }else{
+                                        Ok(inner)
+                                    }
                                 }
                             }
                         },
@@ -259,13 +270,17 @@ impl Parser {
                         |schema| match schema {
                             Schema::String => Ok(Schema::Uuid(UuidSchema::String)),
                             Schema::Fixed(fixed @ FixedSchema { size: 16, .. }) => {
-                                Ok(Schema::Uuid(UuidSchema::Fixed(fixed)))
+                                let schema = Schema::Uuid(UuidSchema::Fixed(fixed.clone()));
+                                let _ = self.insert_parsed_for_reserved(&fixed.name, &fixed.aliases, &Arc::new(schema))?;
+                                Ok(Schema::Ref{name: Arc::clone(&fixed.name)})
                             }
-                            Schema::Fixed(FixedSchema { size, .. }) => {
+                            Schema::Fixed(ref fixed) => {
                                 warn!(
-                                    "Ignoring uuid logical type for a Fixed schema because its size ({size:?}) is not 16! Schema: {schema:?}"
+                                    "Ignoring uuid logical type for a Fixed schema because its size ({:?}) is not 16! Schema: {schema:?}",
+                                    fixed.size
                                 );
-                                Ok(schema)
+                                let _ = self.insert_parsed_for_reserved(&fixed.name, &fixed.aliases, &Arc::new(schema.clone()))?;
+                                Ok(Schema::Ref{name: Arc::clone(&fixed.name)})
                             }
                             Schema::Bytes => Ok(Schema::Uuid(UuidSchema::Bytes)),
                             _ => {
@@ -355,13 +370,17 @@ impl Parser {
                         |schema| -> AvroResult<Schema> {
                             match schema {
                                 Schema::Fixed(fixed @ FixedSchema { size: 12, .. }) => {
-                                    Ok(Schema::Duration(fixed))
+                                    let schema = Schema::Duration(fixed.clone());
+                                    let _ = self.insert_parsed_for_reserved(&fixed.name, &fixed.aliases, &Arc::new(schema))?;
+                                    Ok(Schema::Ref{name: Arc::clone(&fixed.name)})
                                 }
-                                Schema::Fixed(FixedSchema { size, .. }) => {
+                                Schema::Fixed(ref fixed) => {
                                     warn!(
-                                        "Ignoring duration logical type on fixed type because size ({size}) is not 12! Schema: {schema:?}"
+                                        "Ignoring duration logical type on fixed type because size ({}) is not 12! Schema: {schema:?}",
+                                        fixed.size
                                     );
-                                    Ok(schema)
+                                    let _ = self.insert_parsed_for_reserved(&fixed.name, &fixed.aliases, &Arc::new(schema.clone()))?;
+                                    Ok(Schema::Ref{name: Arc::clone(&fixed.name)})
                                 }
                                 _ => {
                                     warn!(
@@ -383,28 +402,36 @@ impl Parser {
             Some(value) => return Err(Details::GetLogicalTypeFieldType(value.clone()).into()),
             _ => {}
         }
-        match complex.get("type") {
-            Some(Value::String(t)) => match t.as_str() {
-                "record" => match parse_location {
-                    RecordSchemaParseLocation::Root => {
-                        self.parse_record(complex, enclosing_namespace)
-                    }
-                    RecordSchemaParseLocation::FromField => {
-                        self.fetch_schema_ref(t, enclosing_namespace)
-                    }
-                },
-                "enum" => self.parse_enum(complex, enclosing_namespace),
-                "array" => self.parse_array(complex, enclosing_namespace),
-                "map" => self.parse_map(complex, enclosing_namespace),
-                "fixed" => self.parse_fixed(complex, enclosing_namespace),
-                other => self.parse_known_schema(other, enclosing_namespace),
-            },
-            Some(Value::Object(data)) => {
-                self.parse_complex(data, enclosing_namespace, RecordSchemaParseLocation::Root)
+
+        match complex.get("type"){
+            Some(Value::String(t))=> { match t.as_str() {
+                    "null" => Ok(Schema::Null),
+                    "boolean" => Ok(Schema::Boolean),
+                    "int" => Ok(Schema::Int),
+                    "long" => Ok(Schema::Long),
+                    "double" => Ok(Schema::Double),
+                    "float" => Ok(Schema::Float),
+                    "bytes" => Ok(Schema::Bytes),
+                    "string" => Ok(Schema::String),
+                    "record" => self.parse_record(complex, enclosing_namespace),
+                    "enum" => self.parse_enum(complex, enclosing_namespace),
+                    "array" => self.parse_array(complex, enclosing_namespace),
+                    "map" => self.parse_map(complex, enclosing_namespace),
+                    "fixed" => {
+                        let fixed = self.parse_fixed(complex, enclosing_namespace)?;
+                        match fixed {
+                            Schema::Fixed(ref fixed_internal) => {
+                                let _ = self.insert_parsed_for_reserved(&fixed_internal.name, &fixed_internal.aliases, &Arc::new(fixed.clone()))?;
+                                Ok(Schema::Ref{name: Arc::clone(&fixed_internal.name)})
+                            },
+                            _ => panic!("Internal error, parse_fixed did not return a schema variant of Schema::Fixed!")
+                        }
+                    },
+                    _ => Err(Details::JsonSchemaTypeNotAllowed { value: serde_json::Value::String(t.clone()) }.into())
+                }
             }
-            Some(Value::Array(variants)) => self.parse_union(variants, enclosing_namespace),
-            Some(unknown) => Err(Details::GetComplexType(unknown.clone()).into()),
-            None => Err(Details::GetComplexTypeField.into()),
+            Some(value) => {Err(Details::JsonSchemaTypeNotAllowed { value: value.clone() }.into())}
+            None => {Err(Details::GetComplexTypeField.into())}
         }
     }
 
@@ -505,7 +532,7 @@ impl Parser {
             attributes: self.get_custom_attributes(complex, vec!["fields"]),
         });
 
-        self.insert_parsed_for_reserved(&fully_qualified_name, &aliases, &Arc::new(schema));
+        let _ = self.insert_parsed_for_reserved(&fully_qualified_name, &aliases, &Arc::new(schema))?;
         Ok(Schema::Ref{name: fully_qualified_name})
     }
 
@@ -606,7 +633,7 @@ impl Parser {
         let items = complex
             .get("items")
             .ok_or_else(|| Details::GetArrayItemsField.into())
-            .and_then(|items| self.parse_internal(items, enclosing_namespace))?;
+            .and_then(|items| self.parse_schema(items, enclosing_namespace))?;
         Ok(Schema::Array(ArraySchema {
             items: Box::new(items),
             attributes: self.get_custom_attributes(complex, vec!["items"]),
@@ -622,7 +649,7 @@ impl Parser {
         let types = complex
             .get("values")
             .ok_or_else(|| Details::GetMapValuesField.into())
-            .and_then(|types| self.parse_internal(types, enclosing_namespace))?;
+            .and_then(|types| self.parse_schema(types, enclosing_namespace))?;
 
         Ok(Schema::Map(MapSchema {
             types: Box::new(types),
@@ -638,7 +665,7 @@ impl Parser {
     ) -> AvroResult<Schema> {
         items
             .iter()
-            .map(|v| self.parse_internal(v, enclosing_namespace))
+            .map(|v| self.parse_schema(v, enclosing_namespace))
             .collect::<Result<Vec<_>, _>>()
             .and_then(|schemas| {
                 if schemas.is_empty() {
@@ -692,9 +719,12 @@ impl Parser {
             attributes: self.get_custom_attributes(complex, vec!["size"]),
         });
 
-        self.insert_parsed_for_reserved(&fully_qualified_name, &aliases, &Arc::new(schema));
+        // note that we do NOT add the fixed we just created into the named spot we created in the
+        // symbol table. This is becuase if this fixed is being used by a logical type, we want the
+        // name to refer to that type, so it's up to the caller of this function to decide what
+        // schema to place in this reserved spot!
 
-        Ok(Schema::Ref{name: fully_qualified_name})
+        Ok(schema)
     }
 
     // A type alias may be specified either as a fully namespace-qualified, or relative

--- a/avro/src/schema/parser.rs
+++ b/avro/src/schema/parser.rs
@@ -18,8 +18,8 @@
 use crate::error::Details;
 use crate::schema::{
     Alias, Aliases, ArraySchema, DecimalMetadata, DecimalSchema, EnumSchema, FixedSchema,
-    MapSchema, Name, Names, NamespaceRef, Precision, RecordField, RecordSchema, Scale, Schema,
-    SchemaKind, UnionSchema, UuidSchema,
+    MapSchema, Name, NamespaceRef, Precision, RecordField, RecordSchema, Scale, Schema,
+    SchemaKind, UnionSchema, UuidSchema, SchemaWithSymbols
 };
 use crate::types;
 use crate::util::MapHelper;
@@ -28,88 +28,71 @@ use crate::{AvroResult, Error};
 use log::{debug, error, warn};
 use serde_json::{Map, Value};
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
+
+#[derive(Debug, Default)]
+pub(crate) enum RecordSchemaParseLocation {
+    /// When the parse is happening at root level
+    #[default]
+    Root,
+
+    /// When the parse is happening inside a record field
+    FromField,
+}
+
+enum ReservedSchema {
+    Reserved,
+    Completed(Arc<Schema>)
+}
+
 
 #[derive(Default)]
 pub(crate) struct Parser {
-    input_schemas: HashMap<Name, Value>,
-    /// Used to resolve cyclic references, i.e. when a
-    /// field's type is a reference to its record's type
-    resolving_schemas: Names,
-    input_order: Vec<Name>,
-    /// Used to avoid parsing the same schema twice
-    parsed_schemas: Names,
+    /// Keeps track of the names defined for this schema, as well as where it is located
+    /// in the schema tree
+    defined_names: HashMap<Arc<Name>, ReservedSchema>,
+    /// Keeps track of the names references by this schema, as well as where they are located
+    /// in the schema tree
+    referenced_names: HashSet<Arc<Name>>,
+    /// Keeps track of fields that have a defualt value we need to resolve against.
+    pub(crate) field_defaults_to_resolve: Vec<(Schema, Value)>
 }
 
 impl Parser {
-    pub(crate) fn new(
-        input_schemas: HashMap<Name, Value>,
-        input_order: Vec<Name>,
-        parsed_schemas: Names,
-    ) -> Self {
-        Self {
-            input_schemas,
-            resolving_schemas: HashMap::default(),
-            input_order,
-            parsed_schemas,
-        }
-    }
-
-    pub(crate) fn get_parsed_schemas(&mut self) -> &Names {
-        &self.parsed_schemas
-    }
-
     /// Create a `Schema` from a string representing a JSON Avro schema.
-    pub(super) fn parse_str(&mut self, input: &str) -> AvroResult<Schema> {
+    /// Consumes the parser in the process.
+    pub(super) fn parse_str(self, input: &str) -> Result<SchemaWithSymbols, Error> {
         let value = serde_json::from_str(input).map_err(Details::ParseSchemaJson)?;
         self.parse(&value, None)
     }
 
-    /// Create an array of `Schema`s from an iterator of JSON Avro schemas.
-    ///
-    /// It is allowed that the schemas have cross-dependencies; these will be resolved during parsing.
-    pub(super) fn parse_list(&mut self) -> AvroResult<Vec<Schema>> {
-        self.parse_input_schemas()?;
+    /// Create a `SchemaWithSymbols` from a `serde_json::Value` representing a JSON Avro
+    /// schema.
+    pub(super) fn parse(mut self, value: &Value, enclosing_namespace: NamespaceRef) -> AvroResult<SchemaWithSymbols>{
+        let schema = self.parse_internal(&value, enclosing_namespace)?;
+        let defined_names : HashMap<Arc<Name>, Arc<Schema>> = HashMap::from_iter(self.defined_names.drain().map(|(key, val)| {
+            match val {
+                ReservedSchema::Reserved => {panic!("reserved schema encountered that was not provided a definition")}
+                ReservedSchema::Completed(schema_ref) => (key, schema_ref)
+            }
+        }));
 
-        let mut parsed_schemas = Vec::with_capacity(self.parsed_schemas.len());
-        for name in self.input_order.drain(0..) {
-            let parsed = self
-                .parsed_schemas
-                .remove(&name)
-                .expect("One of the input schemas was unexpectedly not parsed");
-            parsed_schemas.push(parsed);
-        }
-        Ok(parsed_schemas)
+        Ok(SchemaWithSymbols{
+            field_defaults_to_resolve: self.field_defaults_to_resolve,
+            defined_names,
+            referenced_names: self.referenced_names,
+            schema: Arc::new(schema)
+        })
     }
 
-    /// Convert the input schemas to `parsed_schemas`.
-    pub(super) fn parse_input_schemas(&mut self) -> Result<(), Error> {
-        while !self.input_schemas.is_empty() {
-            let next_name = self
-                .input_schemas
-                .keys()
-                .next()
-                .expect("Input schemas unexpectedly empty")
-                .to_owned();
-            let (name, value) = self
-                .input_schemas
-                .remove_entry(&next_name)
-                .expect("Key unexpectedly missing");
-            let parsed = self.parse(&value, None)?;
-            self.parsed_schemas
-                .insert(self.get_schema_type_name(name, value), parsed);
-        }
-        Ok(())
-    }
-
-    /// Create a `Schema` from a `serde_json::Value` representing a JSON Avro schema.
-    pub(super) fn parse(
-        &mut self,
-        value: &Value,
-        enclosing_namespace: NamespaceRef,
-    ) -> AvroResult<Schema> {
+    /// Create a `Schema` from a `serde_json::Value` representing a JSON Avro
+    /// schema.
+    fn parse_internal(&mut self, value: &Value, enclosing_namespace: NamespaceRef) -> AvroResult<Schema> {
         match *value {
             Value::String(ref t) => self.parse_known_schema(t.as_str(), enclosing_namespace),
-            Value::Object(ref data) => self.parse_complex(data, enclosing_namespace),
+            Value::Object(ref data) => {
+                self.parse_complex(data, enclosing_namespace, RecordSchemaParseLocation::Root)
+            }
             Value::Array(ref data) => self.parse_union(data, enclosing_namespace),
             _ => Err(Details::ParseSchemaFromValidJson.into()),
         }
@@ -134,74 +117,15 @@ impl Parser {
         }
     }
 
-    /// Given a name, tries to retrieve the parsed schema from `parsed_schemas`.
-    ///
-    /// If a parsed schema is not found, it checks if a currently resolving
-    /// schema with that name exists.
-    /// If a resolving schema is not found, it checks if a JSON with that name exists
-    /// in `input_schemas` and then parses it (removing it from `input_schemas`)
-    /// and adds the parsed schema to `parsed_schemas`.
-    ///
-    /// This method allows schemas definitions that depend on other types to
-    /// parse their dependencies (or look them up if already parsed).
-    pub(super) fn fetch_schema_ref(
+    /// Registers that we are referencing a schema by name
+    fn fetch_schema_ref(
         &mut self,
         name: &str,
         enclosing_namespace: NamespaceRef,
     ) -> AvroResult<Schema> {
-        fn get_schema_ref(parsed: &Schema) -> Schema {
-            match parsed {
-                &Schema::Record(RecordSchema { ref name, .. })
-                | &Schema::Enum(EnumSchema { ref name, .. })
-                | &Schema::Fixed(FixedSchema { ref name, .. }) => {
-                    Schema::Ref { name: name.clone() }
-                }
-                _ => parsed.clone(),
-            }
-        }
-
-        let fully_qualified_name = Name::new_with_enclosing_namespace(name, enclosing_namespace)?;
-
-        if self.parsed_schemas.contains_key(&fully_qualified_name) {
-            return Ok(Schema::Ref {
-                name: fully_qualified_name,
-            });
-        }
-        if let Some(resolving_schema) = self.resolving_schemas.get(&fully_qualified_name) {
-            return Ok(resolving_schema.clone());
-        }
-
-        // For good error reporting we add this check
-        match fully_qualified_name.name() {
-            "record" | "enum" | "fixed" => {
-                return Err(
-                    Details::InvalidSchemaRecord(fully_qualified_name.name().to_string()).into(),
-                );
-            }
-            _ => (),
-        }
-
-        let value = self
-            .input_schemas
-            .remove(&fully_qualified_name)
-            // TODO make a better descriptive error message here that conveys that a named schema cannot be found
-            .ok_or_else(|| {
-                let full_name = fully_qualified_name.fullname(None);
-                if full_name == "bool" {
-                    Details::ParsePrimitiveSimilar(full_name, "boolean")
-                } else {
-                    Details::ParsePrimitive(full_name)
-                }
-            })?;
-
-        // parsing a full schema from inside another schema. Other full schema will not inherit namespace
-        let parsed = self.parse(&value, None)?;
-        self.parsed_schemas.insert(
-            self.get_schema_type_name(fully_qualified_name, value),
-            parsed.clone(),
-        );
-
-        Ok(get_schema_ref(&parsed))
+        let fully_qualified_name = Arc::new(Name::new_with_enclosing_namespace(name, enclosing_namespace)?);
+        self.referenced_names.insert(Arc::clone(&fully_qualified_name));
+        Ok(Schema::Ref { name: fully_qualified_name })
     }
 
     fn get_decimal_integer(
@@ -252,6 +176,7 @@ impl Parser {
         &mut self,
         complex: &Map<String, Value>,
         enclosing_namespace: NamespaceRef,
+        parse_location: RecordSchemaParseLocation,
     ) -> AvroResult<Schema> {
         // Try to parse this as a native complex type.
         fn parse_as_native_complex(
@@ -264,7 +189,7 @@ impl Parser {
                     Value::String(s) if s == "fixed" => {
                         parser.parse_fixed(complex, enclosing_namespace)
                     }
-                    _ => parser.parse(value, enclosing_namespace),
+                    _ => parser.parse_internal(value, enclosing_namespace),
                 },
                 None => Err(Details::GetLogicalTypeField.into()),
             }
@@ -460,76 +385,76 @@ impl Parser {
         }
         match complex.get("type") {
             Some(Value::String(t)) => match t.as_str() {
-                "record" => self.parse_record(complex, enclosing_namespace),
+                "record" => match parse_location {
+                    RecordSchemaParseLocation::Root => {
+                        self.parse_record(complex, enclosing_namespace)
+                    }
+                    RecordSchemaParseLocation::FromField => {
+                        self.fetch_schema_ref(t, enclosing_namespace)
+                    }
+                },
                 "enum" => self.parse_enum(complex, enclosing_namespace),
                 "array" => self.parse_array(complex, enclosing_namespace),
                 "map" => self.parse_map(complex, enclosing_namespace),
                 "fixed" => self.parse_fixed(complex, enclosing_namespace),
                 other => self.parse_known_schema(other, enclosing_namespace),
             },
-            Some(Value::Object(data)) => self.parse_complex(data, enclosing_namespace),
+            Some(Value::Object(data)) => {
+                self.parse_complex(data, enclosing_namespace, RecordSchemaParseLocation::Root)
+            }
             Some(Value::Array(variants)) => self.parse_union(variants, enclosing_namespace),
             Some(unknown) => Err(Details::GetComplexType(unknown.clone()).into()),
             None => Err(Details::GetComplexTypeField.into()),
         }
     }
 
-    fn register_resolving_schema(&mut self, name: &Name, aliases: &Aliases) {
-        let resolving_schema = Schema::Ref { name: name.clone() };
-        self.resolving_schemas
-            .insert(name.clone(), resolving_schema.clone());
+    /// checks if a fullname or its aliases have been registered with the parser yet. If so, fails
+    /// on NameCollision, else, reserves spots in the defined_names map that will be filled in when
+    /// the definition is complete.
+    fn check_and_reserve_name_and_aliases(&mut self, name: &Arc<Name>, aliases: &Aliases) -> AvroResult<()>{
+
+        if let Option::None = self.defined_names.insert(Arc::clone(name), ReservedSchema::Reserved) {
+        }else{
+            return Err(Details::NameCollision(name.fullname(Option::None)).into());
+        }
 
         let namespace = name.namespace();
 
         if let Some(aliases) = aliases {
-            aliases.iter().for_each(|alias| {
-                let alias_fullname = alias.fully_qualified_name(namespace).into_owned();
-                self.resolving_schemas
-                    .insert(alias_fullname, resolving_schema.clone());
-            });
+            for alias in aliases {
+                let alias_name : Arc<Name> = Arc::new(alias.fully_qualified_name(namespace).into_owned()); //KTODO: is this okay??
+
+                if let Option::Some(_) = self.defined_names.insert(Arc::clone(&alias_name), ReservedSchema::Reserved) {
+                    return Err(Details::NameCollision(alias_name.fullname(Option::None)).into());
+                }
+            }
         }
+
+        Ok(())
     }
 
-    fn register_parsed_schema(
-        &mut self,
-        fully_qualified_name: &Name,
-        schema: &Schema,
-        aliases: &Aliases,
-    ) {
-        // FIXME, this should be globally aware, so if there is something overwriting something
-        // else then there is an ambiguous schema definition. An appropriate error should be thrown
-        self.parsed_schemas
-            .insert(fully_qualified_name.clone(), schema.clone());
-        self.resolving_schemas.remove(fully_qualified_name);
+    /// adds the completed parsed schema into a spot previously reserved via
+    /// check_and_reserve_name_and_aliases
+    fn insert_parsed_for_reserved(&mut self, name: &Arc<Name>, aliases: &Aliases, schema: &Arc<Schema>) -> AvroResult<()>{
 
-        let namespace = fully_qualified_name.namespace();
+        if let Some(ReservedSchema::Reserved) = self.defined_names.insert(Arc::clone(name), ReservedSchema::Completed(Arc::clone(schema))) {
+        }else{
+            panic!("Attempting to write into a spot that has not been reserved!"); // TODO: IMPROVE THIS MESSAGE
+        }
+
+        let namespace = name.namespace();
 
         if let Some(aliases) = aliases {
-            aliases.iter().for_each(|alias| {
-                let alias_fullname = alias.fully_qualified_name(namespace);
-                self.resolving_schemas.remove(&alias_fullname);
-                self.parsed_schemas
-                    .insert(alias_fullname.into_owned(), schema.clone());
-            });
-        }
-    }
+            for alias in aliases {
+                let alias_name : Arc<Name> = Arc::new(alias.fully_qualified_name(namespace).into_owned()); // KTODO: same with this, is this okay??
 
-    /// Returns already parsed schema or a schema that is currently being resolved.
-    fn get_already_seen_schema(
-        &self,
-        complex: &Map<String, Value>,
-        enclosing_namespace: NamespaceRef,
-    ) -> Option<&Schema> {
-        match complex.get("type") {
-            Some(Value::String(typ)) => {
-                let name =
-                    Name::new_with_enclosing_namespace(typ.as_str(), enclosing_namespace).unwrap();
-                self.resolving_schemas
-                    .get(&name)
-                    .or_else(|| self.parsed_schemas.get(&name))
+                if let Option::None = self.defined_names.insert(Arc::clone(&alias_name), ReservedSchema::Completed(Arc::clone(schema))) {
+                    panic!("Attempting to write into a spot that has not been reserved!"); // TODO: IMPROVE THIS MESSAGE
+                }
             }
-            _ => None,
         }
+
+        Ok(())
     }
 
     /// Parse a `serde_json::Value` representing an Avro record type into a `Schema`.
@@ -540,19 +465,13 @@ impl Parser {
     ) -> AvroResult<Schema> {
         let fields_opt = complex.get("fields");
 
-        if fields_opt.is_none()
-            && let Some(seen) = self.get_already_seen_schema(complex, enclosing_namespace)
-        {
-            return Ok(seen.clone());
-        }
-
-        let fully_qualified_name = Name::parse(complex, enclosing_namespace)?;
+        let fully_qualified_name = Arc::new(Name::parse(complex, enclosing_namespace)?);
         let aliases =
             self.fix_aliases_namespace(complex.aliases(), fully_qualified_name.namespace());
 
         let mut lookup = BTreeMap::new();
 
-        self.register_resolving_schema(&fully_qualified_name, &aliases);
+        self.check_and_reserve_name_and_aliases(&fully_qualified_name, &aliases)?;
 
         debug!("Going to parse record schema: {:?}", &fully_qualified_name);
 
@@ -578,7 +497,7 @@ impl Parser {
         }
 
         let schema = Schema::Record(RecordSchema {
-            name: fully_qualified_name.clone(),
+            name: Arc::clone(&fully_qualified_name),
             aliases: aliases.clone(),
             doc: complex.doc(),
             fields,
@@ -586,8 +505,8 @@ impl Parser {
             attributes: self.get_custom_attributes(complex, vec!["fields"]),
         });
 
-        self.register_parsed_schema(&fully_qualified_name, &schema, &aliases);
-        Ok(schema)
+        self.insert_parsed_for_reserved(&fully_qualified_name, &aliases, &Arc::new(schema));
+        Ok(Schema::Ref{name: fully_qualified_name})
     }
 
     fn get_custom_attributes(
@@ -614,15 +533,11 @@ impl Parser {
     ) -> AvroResult<Schema> {
         let symbols_opt = complex.get("symbols");
 
-        if symbols_opt.is_none()
-            && let Some(seen) = self.get_already_seen_schema(complex, enclosing_namespace)
-        {
-            return Ok(seen.clone());
-        }
-
-        let fully_qualified_name = Name::parse(complex, enclosing_namespace)?;
+        let fully_qualified_name = Arc::new(Name::parse(complex, enclosing_namespace)?);
         let aliases =
             self.fix_aliases_namespace(complex.aliases(), fully_qualified_name.namespace());
+
+        self.check_and_reserve_name_and_aliases(&fully_qualified_name, &aliases)?;
 
         let symbols: Vec<String> = symbols_opt
             .and_then(|v| v.as_array())
@@ -658,7 +573,7 @@ impl Parser {
 
         if let Some(ref value) = default {
             let resolved = types::Value::from(value.clone())
-                .resolve_enum(&symbols, &Some(value.to_string()), &None)
+                .resolve_enum(&symbols, &Some(value.to_string()))
                 .is_ok();
             if !resolved {
                 return Err(Details::GetEnumDefault {
@@ -670,7 +585,7 @@ impl Parser {
         }
 
         let schema = Schema::Enum(EnumSchema {
-            name: fully_qualified_name.clone(),
+            name: Arc::clone(&fully_qualified_name),
             aliases: aliases.clone(),
             doc: complex.doc(),
             symbols,
@@ -678,9 +593,8 @@ impl Parser {
             attributes: self.get_custom_attributes(complex, vec!["symbols", "default"]),
         });
 
-        self.register_parsed_schema(&fully_qualified_name, &schema, &aliases);
-
-        Ok(schema)
+        self.insert_parsed_for_reserved(&fully_qualified_name, &aliases, &Arc::new(schema));
+        Ok(Schema::Ref { name: fully_qualified_name })
     }
 
     /// Parse a `serde_json::Value` representing a Avro array type into a `Schema`.
@@ -692,31 +606,10 @@ impl Parser {
         let items = complex
             .get("items")
             .ok_or_else(|| Details::GetArrayItemsField.into())
-            .and_then(|items| self.parse(items, enclosing_namespace))?;
-        let default = if let Some(default) = complex.get("default").cloned() {
-            if let Value::Array(_) = default {
-                let crate::types::Value::Array(array) = crate::types::Value::try_from(default)?
-                else {
-                    unreachable!("JsonValue::Array can only become a Value::Array")
-                };
-                // Check that the default type matches the schema type
-                if let Some(value) = array.iter().find(|v| {
-                    v.validate_internal(&items, &self.parsed_schemas, enclosing_namespace)
-                        .is_some()
-                }) {
-                    return Err(Details::ArrayDefaultWrongInnerType(items, value.clone()).into());
-                }
-                Some(array)
-            } else {
-                return Err(Details::ArrayDefaultWrongType(default).into());
-            }
-        } else {
-            None
-        };
+            .and_then(|items| self.parse_internal(items, enclosing_namespace))?;
         Ok(Schema::Array(ArraySchema {
             items: Box::new(items),
-            default,
-            attributes: self.get_custom_attributes(complex, vec!["items", "default"]),
+            attributes: self.get_custom_attributes(complex, vec!["items"]),
         }))
     }
 
@@ -729,32 +622,11 @@ impl Parser {
         let types = complex
             .get("values")
             .ok_or_else(|| Details::GetMapValuesField.into())
-            .and_then(|types| self.parse(types, enclosing_namespace))?;
-
-        let default = if let Some(default) = complex.get("default").cloned() {
-            if let Value::Object(_) = default {
-                let crate::types::Value::Map(map) = crate::types::Value::try_from(default)? else {
-                    unreachable!("JsonValue::Object can only become a Value::Map")
-                };
-                // Check that the default type matches the schema type
-                if let Some(value) = map.values().find(|v| {
-                    v.validate_internal(&types, &self.parsed_schemas, enclosing_namespace)
-                        .is_some()
-                }) {
-                    return Err(Details::MapDefaultWrongInnerType(types, value.clone()).into());
-                }
-                Some(map)
-            } else {
-                return Err(Details::MapDefaultWrongType(default).into());
-            }
-        } else {
-            None
-        };
+            .and_then(|types| self.parse_internal(types, enclosing_namespace))?;
 
         Ok(Schema::Map(MapSchema {
             types: Box::new(types),
-            default,
-            attributes: self.get_custom_attributes(complex, vec!["values", "default"]),
+            attributes: self.get_custom_attributes(complex, vec!["values"]),
         }))
     }
 
@@ -766,7 +638,7 @@ impl Parser {
     ) -> AvroResult<Schema> {
         items
             .iter()
-            .map(|v| self.parse(v, enclosing_namespace))
+            .map(|v| self.parse_internal(v, enclosing_namespace))
             .collect::<Result<Vec<_>, _>>()
             .and_then(|schemas| {
                 if schemas.is_empty() {
@@ -793,11 +665,6 @@ impl Parser {
         enclosing_namespace: NamespaceRef,
     ) -> AvroResult<Schema> {
         let size_opt = complex.get("size");
-        if size_opt.is_none()
-            && let Some(seen) = self.get_already_seen_schema(complex, enclosing_namespace)
-        {
-            return Ok(seen.clone());
-        }
 
         let doc = complex.get("doc").and_then(|v| match &v {
             &Value::String(docstr) => Some(docstr.clone()),
@@ -811,21 +678,23 @@ impl Parser {
             None => Err(Details::GetFixedSizeField),
         }?;
 
-        let fully_qualified_name = Name::parse(complex, enclosing_namespace)?;
+        let fully_qualified_name = Arc::new(Name::parse(complex, enclosing_namespace)?);
         let aliases =
             self.fix_aliases_namespace(complex.aliases(), fully_qualified_name.namespace());
 
+        self.check_and_reserve_name_and_aliases(&fully_qualified_name, &aliases)?;
+
         let schema = Schema::Fixed(FixedSchema {
-            name: fully_qualified_name.clone(),
+            name: Arc::clone(&fully_qualified_name),
             aliases: aliases.clone(),
             doc,
             size: size as usize,
             attributes: self.get_custom_attributes(complex, vec!["size"]),
         });
 
-        self.register_parsed_schema(&fully_qualified_name, &schema, &aliases);
+        self.insert_parsed_for_reserved(&fully_qualified_name, &aliases, &Arc::new(schema));
 
-        Ok(schema)
+        Ok(Schema::Ref{name: fully_qualified_name})
     }
 
     // A type alias may be specified either as a fully namespace-qualified, or relative

--- a/avro/src/schema/parser.rs
+++ b/avro/src/schema/parser.rs
@@ -19,7 +19,6 @@ use crate::error::Details;
 use crate::schema::{
     self, Alias, Aliases, ArraySchema, DecimalMetadata, DecimalSchema, DefaultToResolve, EnumSchema, FixedSchema, MapSchema, Name, NamespaceRef, Precision, RecordField, RecordSchema, Scale, Schema, SchemaKind, SchemaWithSymbols, UnionSchema, UuidSchema
 };
-use crate::serde::fixed;
 use crate::types;
 use crate::util::MapHelper;
 use crate::validator::validate_enum_symbol_name;
@@ -29,6 +28,7 @@ use serde_json::{Map, Value};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
+#[derive(Debug)]
 enum ReservedSchema {
     Reserved,
     Completed(Arc<Schema>)
@@ -58,10 +58,10 @@ impl Parser {
     /// Create a `SchemaWithSymbols` from a `serde_json::Value` representing a JSON Avro
     /// schema.
     pub(super) fn parse(mut self, value: &Value, enclosing_namespace: NamespaceRef) -> AvroResult<SchemaWithSymbols>{
-        let schema = self.parse_schema(&value, enclosing_namespace)?;
+        let schema = self.parse_schema(value, enclosing_namespace)?;
         let defined_names : HashMap<Arc<Name>, Arc<Schema>> = HashMap::from_iter(self.defined_names.drain().map(|(key, val)| {
             match val {
-                ReservedSchema::Reserved => {panic!("reserved schema encountered that was not provided a definition")} // KTODO: clean this message up!!
+                ReservedSchema::Reserved => {unreachable!("apache_avro internal parser error, reserved a spot for schema name {key:?} that never resolved to a schema definition.")}
                 ReservedSchema::Completed(schema_ref) => (key, schema_ref)
             }
         }));
@@ -228,7 +228,7 @@ impl Parser {
                                                 scale,
                                                 inner: schema::InnerDecimalSchema::Fixed(inner.clone()),
                                             });
-                                            let _ = self.insert_parsed_for_reserved(&inner.name, &inner.aliases, &Arc::new(schema))?;
+                                            self.insert_parsed_for_reserved(&inner.name, &inner.aliases, &Arc::new(schema))?;
                                             Ok(Schema::Ref{name: Arc::clone(&inner.name)})
                                         },
                                         Schema::Bytes => {
@@ -244,7 +244,7 @@ impl Parser {
                                 Err(err) => {
                                     warn!("Ignoring invalid decimal logical type: {err}");
                                     if let Schema::Fixed(ref fixed_inner) = inner {
-                                        let _ = self.insert_parsed_for_reserved(&fixed_inner.name, &fixed_inner.aliases, &Arc::new(inner.clone()))?;
+                                        self.insert_parsed_for_reserved(&fixed_inner.name, &fixed_inner.aliases, &Arc::new(inner.clone()))?;
                                         Ok(Schema::Ref{name: Arc::clone(&fixed_inner.name)})
                                     }else{
                                         Ok(inner)
@@ -271,7 +271,7 @@ impl Parser {
                             Schema::String => Ok(Schema::Uuid(UuidSchema::String)),
                             Schema::Fixed(fixed @ FixedSchema { size: 16, .. }) => {
                                 let schema = Schema::Uuid(UuidSchema::Fixed(fixed.clone()));
-                                let _ = self.insert_parsed_for_reserved(&fixed.name, &fixed.aliases, &Arc::new(schema))?;
+                                self.insert_parsed_for_reserved(&fixed.name, &fixed.aliases, &Arc::new(schema))?;
                                 Ok(Schema::Ref{name: Arc::clone(&fixed.name)})
                             }
                             Schema::Fixed(ref fixed) => {
@@ -279,7 +279,7 @@ impl Parser {
                                     "Ignoring uuid logical type for a Fixed schema because its size ({:?}) is not 16! Schema: {schema:?}",
                                     fixed.size
                                 );
-                                let _ = self.insert_parsed_for_reserved(&fixed.name, &fixed.aliases, &Arc::new(schema.clone()))?;
+                                self.insert_parsed_for_reserved(&fixed.name, &fixed.aliases, &Arc::new(schema.clone()))?;
                                 Ok(Schema::Ref{name: Arc::clone(&fixed.name)})
                             }
                             Schema::Bytes => Ok(Schema::Uuid(UuidSchema::Bytes)),
@@ -371,7 +371,7 @@ impl Parser {
                             match schema {
                                 Schema::Fixed(fixed @ FixedSchema { size: 12, .. }) => {
                                     let schema = Schema::Duration(fixed.clone());
-                                    let _ = self.insert_parsed_for_reserved(&fixed.name, &fixed.aliases, &Arc::new(schema))?;
+                                    self.insert_parsed_for_reserved(&fixed.name, &fixed.aliases, &Arc::new(schema))?;
                                     Ok(Schema::Ref{name: Arc::clone(&fixed.name)})
                                 }
                                 Schema::Fixed(ref fixed) => {
@@ -379,7 +379,7 @@ impl Parser {
                                         "Ignoring duration logical type on fixed type because size ({}) is not 12! Schema: {schema:?}",
                                         fixed.size
                                     );
-                                    let _ = self.insert_parsed_for_reserved(&fixed.name, &fixed.aliases, &Arc::new(schema.clone()))?;
+                                    self.insert_parsed_for_reserved(&fixed.name, &fixed.aliases, &Arc::new(schema.clone()))?;
                                     Ok(Schema::Ref{name: Arc::clone(&fixed.name)})
                                 }
                                 _ => {
@@ -421,7 +421,7 @@ impl Parser {
                         let fixed = self.parse_fixed(complex, enclosing_namespace)?;
                         match fixed {
                             Schema::Fixed(ref fixed_internal) => {
-                                let _ = self.insert_parsed_for_reserved(&fixed_internal.name, &fixed_internal.aliases, &Arc::new(fixed.clone()))?;
+                                self.insert_parsed_for_reserved(&fixed_internal.name, &fixed_internal.aliases, &Arc::new(fixed.clone()))?;
                                 Ok(Schema::Ref{name: Arc::clone(&fixed_internal.name)})
                             },
                             _ => panic!("Internal error, parse_fixed did not return a schema variant of Schema::Fixed!")
@@ -436,11 +436,11 @@ impl Parser {
     }
 
     /// checks if a fullname or its aliases have been registered with the parser yet. If so, fails
-    /// on NameCollision, else, reserves spots in the defined_names map that will be filled in when
+    /// with a name collision, else, reserves spots in the `defined_names` map that will be filled in when
     /// the definition is complete.
     fn check_and_reserve_name_and_aliases(&mut self, name: &Arc<Name>, aliases: &Aliases) -> AvroResult<()>{
 
-        if let Option::None = self.defined_names.insert(Arc::clone(name), ReservedSchema::Reserved) {
+        if self.defined_names.insert(Arc::clone(name), ReservedSchema::Reserved).is_none() {
         }else{
             return Err(Details::NameCollision(name.fullname(Option::None)).into());
         }
@@ -449,9 +449,9 @@ impl Parser {
 
         if let Some(aliases) = aliases {
             for alias in aliases {
-                let alias_name : Arc<Name> = Arc::new(alias.fully_qualified_name(namespace).into_owned()); //KTODO: is this okay??
+                let alias_name : Arc<Name> = Arc::new(alias.fully_qualified_name(namespace).into_owned());
 
-                if let Option::Some(_) = self.defined_names.insert(Arc::clone(&alias_name), ReservedSchema::Reserved) {
+                if self.defined_names.insert(Arc::clone(&alias_name), ReservedSchema::Reserved).is_some() {
                     return Err(Details::NameCollision(alias_name.fullname(Option::None)).into());
                 }
             }
@@ -461,22 +461,27 @@ impl Parser {
     }
 
     /// adds the completed parsed schema into a spot previously reserved via
-    /// check_and_reserve_name_and_aliases
+    /// `check_and_reserve_name_and_aliases`
     fn insert_parsed_for_reserved(&mut self, name: &Arc<Name>, aliases: &Aliases, schema: &Arc<Schema>) -> AvroResult<()>{
 
         if let Some(ReservedSchema::Reserved) = self.defined_names.insert(Arc::clone(name), ReservedSchema::Completed(Arc::clone(schema))) {
         }else{
-            panic!("Attempting to write into a spot that has not been reserved!"); // TODO: IMPROVE THIS MESSAGE
+            unreachable!("apache_avro internal parser error: Attempting to write into schema name {name:?} into a spot in defined_names that has not been reserved! Value already at name {:?}",
+                    self.defined_names.get(name)
+                );
         }
 
         let namespace = name.namespace();
 
         if let Some(aliases) = aliases {
             for alias in aliases {
-                let alias_name : Arc<Name> = Arc::new(alias.fully_qualified_name(namespace).into_owned()); // KTODO: same with this, is this okay??
+                let alias_name : Arc<Name> = Arc::new(alias.fully_qualified_name(namespace).into_owned());
 
-                if let Option::None = self.defined_names.insert(Arc::clone(&alias_name), ReservedSchema::Completed(Arc::clone(schema))) {
-                    panic!("Attempting to write into a spot that has not been reserved!"); // TODO: IMPROVE THIS MESSAGE
+                if let Some(ReservedSchema::Reserved) = self.defined_names.insert(Arc::clone(&alias_name), ReservedSchema::Completed(Arc::clone(schema))) {
+                }else{
+                    unreachable!("apache_avro internal parser error: Attempting to write into schema name {name:?} into a spot in defined_names that has not been reserved! Value already at name {:?}",
+                                self.defined_names.get(name)
+                    );
                 }
             }
         }
@@ -532,7 +537,7 @@ impl Parser {
             attributes: self.get_custom_attributes(complex, vec!["fields"]),
         });
 
-        let _ = self.insert_parsed_for_reserved(&fully_qualified_name, &aliases, &Arc::new(schema))?;
+        self.insert_parsed_for_reserved(&fully_qualified_name, &aliases, &Arc::new(schema))?;
         Ok(Schema::Ref{name: fully_qualified_name})
     }
 
@@ -620,7 +625,7 @@ impl Parser {
             attributes: self.get_custom_attributes(complex, vec!["symbols", "default"]),
         });
 
-        self.insert_parsed_for_reserved(&fully_qualified_name, &aliases, &Arc::new(schema));
+        self.insert_parsed_for_reserved(&fully_qualified_name, &aliases, &Arc::new(schema))?;
         Ok(Schema::Ref { name: fully_qualified_name })
     }
 
@@ -753,16 +758,6 @@ impl Parser {
                 .map(|alias| Alias::new(alias.as_str()).unwrap())
                 .collect()
         })
-    }
-
-    fn get_schema_type_name(&self, name: Name, value: Value) -> Name {
-        match value.get("type") {
-            Some(Value::Object(complex_type)) => match complex_type.name() {
-                Some(name) => Name::new(name).unwrap(),
-                _ => name,
-            },
-            _ => name,
-        }
     }
 
     fn parse_json_integer_for_decimal(

--- a/avro/src/schema/record/field.rs
+++ b/avro/src/schema/record/field.rs
@@ -17,7 +17,7 @@
 
 use crate::AvroResult;
 use crate::error::Details;
-use crate::schema::{Documentation, Name, Parser, Schema, parser::RecordSchemaParseLocation};
+use crate::schema::{Documentation, Name, Parser, Schema, DefaultToResolve};
 use crate::util::MapHelper;
 use crate::validator::validate_record_field_name;
 use log::warn;
@@ -90,11 +90,10 @@ impl RecordField {
 
         validate_record_field_name(name)?;
 
-        let _ty = field.get("type").ok_or(Details::GetRecordFieldTypeField)?;
-        let schema = parser.parse_complex(
-            field,
-            enclosing_record.namespace(),
-            RecordSchemaParseLocation::FromField,
+        let ty = field.get("type").ok_or(Details::GetRecordFieldTypeField)?;
+        let schema = parser.parse_schema(
+            ty,
+            enclosing_record.namespace()
         )?;
 
         if let Some(logical_type) = field.get("logicalType") {
@@ -104,7 +103,11 @@ impl RecordField {
         }
 
         let default = field.get("default").cloned().and_then(|value|{
-            parser.field_defaults_to_resolve.push((schema.clone(), value.clone()));
+            parser.field_defaults_to_resolve.push(DefaultToResolve {
+                field_name: name.to_string(),
+                record_name: enclosing_record.fully_qualified_name(Option::None).to_string(),
+                schema: schema.clone(),
+                json: value.clone() });
             Some(value)
         });
 

--- a/avro/src/schema/record/field.rs
+++ b/avro/src/schema/record/field.rs
@@ -102,13 +102,12 @@ impl RecordField {
             );
         }
 
-        let default = field.get("default").cloned().and_then(|value|{
+        field.get("default").cloned().inspect(|value|{
             parser.field_defaults_to_resolve.push(DefaultToResolve {
                 field_name: name.to_string(),
                 record_name: enclosing_record.fully_qualified_name(Option::None).to_string(),
                 schema: schema.clone(),
                 json: value.clone() });
-            Some(value)
         });
 
         let aliases = field
@@ -127,7 +126,7 @@ impl RecordField {
         Ok(RecordField {
             name: name.into(),
             doc: field.doc(),
-            default,
+            default: field.get("default").cloned(),
             aliases,
             custom_attributes: RecordField::get_field_custom_attributes(field),
             schema,

--- a/avro/src/schema/record/field.rs
+++ b/avro/src/schema/record/field.rs
@@ -17,8 +17,7 @@
 
 use crate::AvroResult;
 use crate::error::Details;
-use crate::schema::{Documentation, Name, Names, Parser, Schema, SchemaKind};
-use crate::types;
+use crate::schema::{Documentation, Name, Parser, Schema, parser::RecordSchemaParseLocation};
 use crate::util::MapHelper;
 use crate::validator::validate_record_field_name;
 use log::warn;
@@ -91,8 +90,12 @@ impl RecordField {
 
         validate_record_field_name(name)?;
 
-        let ty = field.get("type").ok_or(Details::GetRecordFieldTypeField)?;
-        let schema = parser.parse(ty, enclosing_record.namespace())?;
+        let _ty = field.get("type").ok_or(Details::GetRecordFieldTypeField)?;
+        let schema = parser.parse_complex(
+            field,
+            enclosing_record.namespace(),
+            RecordSchemaParseLocation::FromField,
+        )?;
 
         if let Some(logical_type) = field.get("logicalType") {
             warn!(
@@ -100,14 +103,10 @@ impl RecordField {
             );
         }
 
-        let default = field.get("default").cloned();
-        Self::resolve_default_value(
-            &schema,
-            name,
-            &enclosing_record.fullname(None),
-            parser.get_parsed_schemas(),
-            &default,
-        )?;
+        let default = field.get("default").cloned().and_then(|value|{
+            parser.field_defaults_to_resolve.push((schema.clone(), value.clone()));
+            Some(value)
+        });
 
         let aliases = field
             .get("aliases")
@@ -130,61 +129,6 @@ impl RecordField {
             custom_attributes: RecordField::get_field_custom_attributes(field),
             schema,
         })
-    }
-
-    fn resolve_default_value(
-        field_schema: &Schema,
-        field_name: &str,
-        record_name: &str,
-        names: &Names,
-        default: &Option<Value>,
-    ) -> AvroResult<()> {
-        if let Some(value) = default {
-            let avro_value = types::Value::try_from(value.clone())?;
-            match field_schema {
-                Schema::Union(union_schema) => {
-                    let schemas = &union_schema.schemas;
-                    let resolved = schemas.iter().any(|schema| {
-                        avro_value
-                            .to_owned()
-                            .resolve_internal(schema, names, schema.namespace(), &None)
-                            .is_ok()
-                    });
-
-                    if !resolved {
-                        let schema: Option<&Schema> = schemas.first();
-                        return match schema {
-                            Some(first_schema) => Err(Details::GetDefaultUnion(
-                                SchemaKind::from(first_schema),
-                                types::ValueKind::from(avro_value),
-                            )
-                            .into()),
-                            None => Err(Details::EmptyUnion.into()),
-                        };
-                    }
-                }
-                _ => {
-                    let resolved = avro_value
-                        .resolve_internal(field_schema, names, field_schema.namespace(), &None)
-                        .is_ok();
-
-                    if !resolved {
-                        let schemata = names.values().cloned().collect::<Vec<_>>();
-                        return Err(Details::GetDefaultRecordField(
-                            field_name.to_string(),
-                            record_name.to_string(),
-                            field_schema
-                                .independent_canonical_form(&schemata)
-                                .unwrap_or_else(|_| field_schema.canonical_form()),
-                            value.clone(),
-                        )
-                        .into());
-                    }
-                }
-            };
-        }
-
-        Ok(())
     }
 
     fn get_field_custom_attributes(field: &Map<String, Value>) -> BTreeMap<String, Value> {
@@ -250,7 +194,7 @@ mod tests {
             .schema(Schema::Union(UnionSchema::new(vec![
                 Schema::Null,
                 Schema::Ref {
-                    name: Name::new("LongList")?,
+                    name: Name::new("LongList")?.into(),
                 },
             ])?))
             .build();

--- a/avro/src/schema/record/schema.rs
+++ b/avro/src/schema/record/schema.rs
@@ -19,12 +19,13 @@ use crate::schema::{Aliases, Documentation, Name, RecordField};
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
 
 /// A description of a Record schema.
 #[derive(bon::Builder, Clone)]
 pub struct RecordSchema {
     /// The name of the schema
-    pub name: Name,
+    pub name: Arc<Name>,
     /// The aliases of the schema
     #[builder(default)]
     pub aliases: Aliases,
@@ -76,7 +77,7 @@ impl<S: record_schema_builder::State> RecordSchemaBuilder<S> {
         T: TryInto<Name>,
     {
         let name = name.try_into()?;
-        Ok(self.name(name))
+        Ok(self.name(name.into()))
     }
 }
 
@@ -100,9 +101,9 @@ mod tests {
     fn avro_rs_403_record_schema_builder_no_fields() -> TestResult {
         let name = Name::new("TestRecord")?;
 
-        let record_schema = RecordSchema::builder().name(name.clone()).build();
+        let record_schema = RecordSchema::builder().name(name.clone().into()).build();
 
-        assert_eq!(record_schema.name, name);
+        assert_eq!(record_schema.name, name.into());
         assert_eq!(record_schema.aliases, None);
         assert_eq!(record_schema.doc, None);
         assert_eq!(record_schema.fields.len(), 0);
@@ -117,11 +118,11 @@ mod tests {
         let name = Name::new("TestRecord")?;
 
         let record_schema = RecordSchema::builder()
-            .name(name.clone())
+            .name(name.clone().into())
             .aliases(Some(vec!["alias_1".try_into()?]))
             .build();
 
-        assert_eq!(record_schema.name, name);
+        assert_eq!(record_schema.name, name.into());
         assert_eq!(record_schema.aliases, Some(vec!["alias_1".try_into()?]));
         assert_eq!(record_schema.doc, None);
         assert_eq!(record_schema.fields.len(), 0);
@@ -136,11 +137,11 @@ mod tests {
         let name = Name::new("TestRecord")?;
 
         let record_schema = RecordSchema::builder()
-            .name(name.clone())
+            .name(name.clone().into())
             .doc(Some("some_doc".into()))
             .build();
 
-        assert_eq!(record_schema.name, name);
+        assert_eq!(record_schema.name, name.into());
         assert_eq!(record_schema.aliases, None);
         assert_eq!(record_schema.doc, Some("some_doc".into()));
         assert_eq!(record_schema.fields.len(), 0);
@@ -161,11 +162,11 @@ mod tests {
         .collect();
 
         let record_schema = RecordSchema::builder()
-            .name(name.clone())
+            .name(name.clone().into())
             .attributes(attrs.clone())
             .build();
 
-        assert_eq!(record_schema.name, name);
+        assert_eq!(record_schema.name, name.into());
         assert_eq!(record_schema.aliases, None);
         assert_eq!(record_schema.doc, None);
         assert_eq!(record_schema.fields.len(), 0);
@@ -190,7 +191,7 @@ mod tests {
         ];
 
         let record_schema = RecordSchema::builder()
-            .name(name.clone())
+            .name(name.clone().into())
             .fields(fields.clone())
             .build();
 
@@ -200,7 +201,7 @@ mod tests {
                 .cloned()
                 .collect();
 
-        assert_eq!(record_schema.name, name);
+        assert_eq!(record_schema.name, name.into());
         assert_eq!(record_schema.aliases, None);
         assert_eq!(record_schema.doc, None);
         assert_eq!(record_schema.fields, fields);
@@ -213,12 +214,12 @@ mod tests {
     #[test]
     fn avro_rs_419_name_into() -> TestResult {
         let schema = RecordSchema::builder().try_name("str_slice")?.build();
-        assert_eq!(schema.name, "str_slice".try_into()?);
+        assert_eq!(schema.name, Arc::new("str_slice".try_into()?));
 
         let schema = RecordSchema::builder()
             .try_name("String".to_string())?
             .build();
-        assert_eq!(schema.name, "String".try_into()?);
+        assert_eq!(schema.name, Arc::new("String".try_into()?));
 
         Ok(())
     }

--- a/avro/src/schema/resolve.rs
+++ b/avro/src/schema/resolve.rs
@@ -26,65 +26,26 @@ use crate::{AvroResult, types};
 use crate::error::{Details,Error};
 use std::collections::BTreeMap;
 use std::fmt::Debug;
-use std::{collections::{HashMap, HashSet}, sync::Arc, iter::once};
+use std::{collections::{HashMap, HashSet}, sync::Arc};
 
-/// a map of names and definitions that is consistent: that is, we have all named schemata refered
-/// by any of the component schemata has a unique definition in this context.
+/// A map of names and definitions that is valid in that any reference to a named schema has a unambiguous definition.
 #[derive(Debug,Clone)]
 pub struct ResolvedContext(NameMap);
 
 impl ResolvedContext{
     /// gets the resolved context from a `ResolvedSchema`
-    pub fn from_resolved_schema(resolved_schema : &ResolvedSchema) -> ResolvedContext{
+    fn from_resolved_schema(resolved_schema : &ResolvedSchema) -> ResolvedContext{
         resolved_schema.context.clone()
     }
 
+    /// Returns a new empty `ResolvedContext`.
     pub fn empty() -> ResolvedContext{
-        ResolvedContext(HashMap::new().into())
+        ResolvedContext(HashMap::new())
     }
 
-    // convenience method for copying (pointer copy) ony the definitions we need for a given schema
-    // KTODO: bug with this, see notes, need to get to a stable testing environment to look at
-    // more...
-    //pub fn copy_needed_definitions(&self, schema_with_symbols: &SchemaWithSymbols) -> AvroResult<ResolvedContext> {
-    //    let needed_references = &schema_with_symbols.referenced_names;
-    //    let mut needed_defs : NameMap = HashMap::new();
-    //    for needed in needed_references{
-    //        if let Some(def) = self.0.get(needed){
-    //            needed_defs.insert(Arc::clone(needed), Arc::clone(def));
-    //        }else{
-    //            return Err(Details::SchemaLookupError(needed.as_ref().clone()).into());
-    //        }
-    //    };
-
-    //    // *Why we can form another resolved*: since we provided a schema_with_symbols, we are
-    //    // guarenteed that we we have the complete set of definitions needed to descend through
-    //    // that schema, since part of our parsing is to track this.
-    //    Ok(ResolvedContext(needed_defs.into()))
-    //}
-
-    // checks that the provided definition names do not conflict with existing definitions.
-    fn check_if_conflicts<'a>(defined_names: &NameMap, added: &NameMap) -> AvroResult<()>{
-        let mut conflicting_fullnames : Vec<String> = Vec::new();
-        for (name, schema) in added{
-            if defined_names.contains_key(name) && Some(schema) != defined_names.get(name){
-                conflicting_fullnames.push(name.fullname(Option::None));
-            }
-        }
-
-        if conflicting_fullnames.len() == 0 {
-            Ok(())
-        }else{
-            Err(Details::MultipleNameCollision(conflicting_fullnames).into())
-        }
-    }
-
-    //pub fn new_context(schemata: impl Iterator<Item = SchemaWithSymbols>) -> AvroResult<ResolvedContext>{
-    //    Self::new_context_with_resolver(schemata, &mut DefaultResolver::new())
-    //}
-
-    /// KTODO: docs
-    pub fn new_context_with_resolver<'s>(schemata: &Vec<SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<ResolvedContext>{
+    /// Attempts to form a context from the provided schemata. This will use the provided custom
+    /// resolver if a referenced schema name is not found in the provided schemata.
+    pub fn new_context_with_resolver(schemata: &Vec<SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<ResolvedContext>{
         let mut context : NameMap = HashMap::new();
         let mut defaults : Vec<Arc<Vec<DefaultToResolve>>> = Vec::new();
         Self::add_to_context(&mut context, &mut defaults, schemata, resolver)?;
@@ -93,8 +54,10 @@ impl ResolvedContext{
         Ok(context)
     }
 
-    /// KTODO: docs
-    pub fn needed_context_with_resolver<'s>(schema: &'s SchemaWithSymbols, schemata: &Vec<SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<ResolvedContext>{
+    /// Attempts to form the minimal context needed to resolve all references in `schema` from definitions
+    /// in `schemata`. This will use the provided custom resolver if a referenced schema name is
+    /// not found in the provided schemata.
+    pub fn needed_context_with_resolver(schema: &SchemaWithSymbols, schemata: &[SchemaWithSymbols], resolver: &mut impl Resolver) -> AvroResult<ResolvedContext>{
         let mut context : NameMap = HashMap::new();
         let mut defaults : Vec<Arc<Vec<DefaultToResolve>>> = Vec::new();
         Self::check_if_schemata_redefine_names(schemata.iter())?;
@@ -102,6 +65,22 @@ impl ResolvedContext{
         let context = ResolvedContext(context);
         Self::check_defaults(&defaults, &context)?;
         Ok(context)
+    }
+
+    // checks that the provided definition names do not conflict with existing definitions.
+    fn check_if_conflicts(defined_names: &NameMap, added: &NameMap) -> AvroResult<()>{
+        let mut conflicting_fullnames : Vec<String> = Vec::new();
+        for (name, schema) in added{
+            if defined_names.contains_key(name) && Some(schema) != defined_names.get(name){
+                conflicting_fullnames.push(name.fullname(Option::None));
+            }
+        }
+
+        if conflicting_fullnames.is_empty() {
+            Ok(())
+        }else{
+            Err(Details::MultipleNameCollision(conflicting_fullnames).into())
+        }
     }
 
     // add the with_symbols into the defined_names and check for naming conflicts.
@@ -112,7 +91,7 @@ impl ResolvedContext{
 
         for schema_with_symbol in schemata{
             defaults.push(Arc::clone(&schema_with_symbol.field_defaults_to_resolve));
-            Self::check_if_conflicts(&defined_names, &schema_with_symbol.defined_names)?;
+            Self::check_if_conflicts(defined_names, &schema_with_symbol.defined_names)?;
             defined_names.extend(schema_with_symbol.defined_names.clone());
             references.extend(schema_with_symbol.referenced_names.clone());
         }
@@ -125,8 +104,7 @@ impl ResolvedContext{
 
     }
 
-    /// KTODO: docs
-    fn add_needed_to_context(schema: &SchemaWithSymbols, defined_names: &mut NameMap, defaults: &mut Vec<Arc<Vec<DefaultToResolve>>>, schemata: &Vec<SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<()>{
+    fn add_needed_to_context(schema: &SchemaWithSymbols, defined_names: &mut NameMap, defaults: &mut Vec<Arc<Vec<DefaultToResolve>>>, schemata: &[SchemaWithSymbols], resolver: &mut impl Resolver) -> AvroResult<()>{
         defined_names.extend(schema.defined_names.clone());
         defaults.push(Arc::clone(&schema.field_defaults_to_resolve));
         let mut worklist: HashSet<Arc<Name>> = schema.referenced_names.clone();
@@ -171,7 +149,7 @@ impl ResolvedContext{
             defined_names.extend(&schema.defined_names);
         }
 
-        if conflicting_fullnames.len() == 0 {
+        if conflicting_fullnames.is_empty() {
             Ok(())
         }else{
             Err(Details::MultipleNameCollision(conflicting_fullnames).into())
@@ -200,7 +178,7 @@ impl ResolvedContext{
                 Ok(())
             },
             Err(msg) => {
-                return Err(Details::SchemaResolutionErrorWithMsg(name.as_ref().clone(), msg).into());
+                Err(Details::SchemaResolutionErrorWithMsg(name.as_ref().clone(), msg).into())
             }
         }
     }
@@ -212,14 +190,14 @@ impl ResolvedContext{
                        avro_value.resolve_internal(ResolvedNode::new(&ResolvedSchema{
                            stub: Arc::new(default.schema.clone()), // TODO: would be nice to get rid of clones here!
                            context: context.clone()
-                       })).or_else(|error| {
-                           Err(Details::DefaultValidationWithReason {
+                       })).map_err(|error| {
+                           Details::DefaultValidationWithReason {
                                record_name: default.record_name.clone(),
                                field_name: default.field_name.clone(),
                                value: default.json.clone() ,
                                schema: default.schema.clone(),
-                               reason: error.to_string() })}
-                           )?;
+                               reason: error.to_string() }
+                       })?;
             }
         }
 
@@ -256,23 +234,42 @@ impl IntoSchemaWithSymbols for SchemaWithSymbols {
 
 /// Builder for resolving one or more schemas into [`ResolvedSchema`] values.
 ///
-/// Created via [`ResolvedSchema::resolve()`]. Accepts schema strings, `&Schema` references,
+/// Created via [`ResolvedSchema::builder()`]. Accepts schema strings, `&Schema` references,
 /// or [`SchemaWithSymbols`] values as input — all via the [`IntoSchemaWithSymbols`] trait.
 ///
 /// # Examples
 ///
-/// ```rust,ignore
+/// ```rust
+/// use apache_avro::schema::{SchemaWithSymbols, ResolvedSchema};
 /// // Resolve a single schema:
-/// let resolved = ResolvedSchema::resolve().build_one(schema_str)?;
+/// let schema = r#"
+///     {
+///         "name": "helloWorldRecord",
+///         "type": "record",
+///         "fields": [{"name": "field", "type": "string"}]
+///     }
+/// "#;
+///
+/// let resolved = ResolvedSchema::parse_str(&schema).unwrap();
+///
+/// // Multiple schemas with context:
+///
+/// let schema_name_ref = r#""mySchema""#;
+/// let schema_union = r#"["mySchema", "long"]"#;
+/// let schema_definition = r#"{
+///     "name": "mySchema",
+///     "type": "enum",
+///     "symbols": ["A", "B", "C"]
+/// }"#;
 ///
 /// // Resolve with additional context schemas:
-/// let [resolved] = ResolvedSchema::resolve()
-///     .additional(vec![context_schema])?
-///     .build_array([main_schema])?;
+/// let [resolved_name_ref, resvoled_union] = ResolvedSchema::builder()
+///     .additional(vec![schema_definition]).unwrap()
+///     .build_array([schema_name_ref, schema_union]).unwrap();
 ///
 /// // With a custom resolver (e.g. schema registry):
-/// let [resolved] = ResolvedSchema::resolve()
-///     .build_array_with_resolver([schema], &mut my_resolver)?;
+/// // let [resolved] = ResolvedSchema::builder()
+/// //    .build_array_with_resolver([schema], &mut my_resolver).unwrap();
 /// ```
 pub struct ResolvedSchemaBuilder {
     additional: Vec<SchemaWithSymbols>,
@@ -328,7 +325,7 @@ impl ResolvedSchemaBuilder {
 
     /// Resolve a dynamic list of schemas.
     pub fn build_list(self, to_resolve: impl IntoIterator<Item = impl IntoSchemaWithSymbols>) -> AvroResult<Vec<ResolvedSchema>> {
-        self.build_list_with_resolver(to_resolve, &mut DefaultResolver::new())
+        self.build_list_with_resolver(to_resolve, &mut DefaultResolver::default())
     }
 
     /// Resolve a dynamic list of schemas with a custom [`Resolver`].
@@ -341,27 +338,44 @@ impl ResolvedSchemaBuilder {
     }
 }
 
-/// Contains a schema with all of the schema definitions it needs to be completely resolved.
-///
-/// This type is a promise from the API that each named type in the schema has exactly one
-/// unique definition and every named reference in the schema can be uniquely resolved to
-/// one of these definitions.
+/// Contains a schema with a map of schema definitions such that each named type
+/// in the schema has exactly one unique definition and every named reference
+/// in the schema can be uniquely resolved to one of these definitions.
 ///
 /// `ResolvedSchema` wraps `Arc` references and is therefore cheap to clone.
 ///
 /// # Construction
 ///
-/// Use [`ResolvedSchema::resolve()`] to get a [`ResolvedSchemaBuilder`], or
+/// Use [`ResolvedSchema::builder()`] to get a [`ResolvedSchemaBuilder`], or
 /// [`ResolvedSchema::parse_str()`] for the single-schema convenience method.
 ///
-/// ```rust,ignore
+/// ```rust
+/// use apache_avro::schema::ResolvedSchema;
+///
 /// // Single schema:
-/// let resolved = ResolvedSchema::parse_str(r#"{"type":"record", ...}"#)?;
+/// let schema = r#"
+///     {
+///         "name": "helloWorldRecord",
+///         "type": "record",
+///         "fields": [{"name": "field", "type": "string"}]
+///     }
+/// "#;
+///
+/// let resolved = ResolvedSchema::parse_str(&schema).unwrap();
 ///
 /// // Multiple schemas with context:
-/// let [a, b] = ResolvedSchema::resolve()
-///     .additional(vec![context])?
-///     .build_array([schema_a, schema_b])?;
+///
+/// let schema_name_ref = r#""mySchema""#;
+/// let schema_union = r#"["mySchema", "long"]"#;
+/// let schema_definition = r#"{
+///     "name": "mySchema",
+///     "type": "enum",
+///     "symbols": ["A", "B", "C"]
+/// }"#;
+///
+/// let [a, b] = ResolvedSchema::builder()
+///     .additional(vec![schema_definition]).unwrap()
+///     .build_array([schema_name_ref, schema_union]).unwrap();
 /// ```
 #[derive(Debug,Clone)]
 pub struct ResolvedSchema{
@@ -371,27 +385,27 @@ pub struct ResolvedSchema{
 
 impl ResolvedSchema{
 
-    /// Start building a schema resolution. Returns a [`ResolvedSchemaBuilder`].
-    pub fn resolve() -> ResolvedSchemaBuilder {
+    /// Start building a `ResolvedSchema`. Returns a [`ResolvedSchemaBuilder`].
+    pub fn builder() -> ResolvedSchemaBuilder {
         ResolvedSchemaBuilder::new()
     }
 
+    /// Returns the stub of this `ResolvedSchema` as a fully unwrapped standalone [`Schema`].
     pub fn unravel(&self) -> Schema{
         let complete : CompleteSchema = self.into();
         complete.0
     }
 
+    /// creates and returns an empty [`ResolvedSchema`] with stub `Schema::Null`
     pub fn new_empty() -> Self{
        Schema::Null.try_into().unwrap()
     }
 
-    /// Parse and resolve a single JSON schema string. Convenience for
-    /// `ResolvedSchema::resolve().build_one(string)`.
+    /// Parse and resolve a single schema string. Convenience for
+    /// `ResolvedSchema::builder().build_one(string)`.
     pub fn parse_str(string: impl AsRef<str>) -> AvroResult<ResolvedSchema>{
-        Self::resolve().build_one(string)
+        Self::builder().build_one(string)
     }
-
-    // ----- internal implementation methods -----
 
     fn resolve_symbols_array<const N : usize>(to_resolve: [SchemaWithSymbols; N], additional: Vec<SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<[ResolvedSchema; N]> {
 
@@ -436,7 +450,7 @@ impl ResolvedSchema{
             return Err(Details::ResolvedSchemaCreationError(context_errs).into())
         }
 
-        let schema_and_context = to_resolve.into_iter().zip(contexts.into_iter());
+        let schema_and_context = to_resolve.into_iter().zip(contexts);
         Ok(schema_and_context.into_iter().map(|(schema_with_symbols, context)|{ResolvedSchema{
                 stub: schema_with_symbols.stub,
                 context: context.unwrap()
@@ -445,15 +459,18 @@ impl ResolvedSchema{
 
 
 
-    pub fn get_names<'b>(&'b self) -> &'b NameMap{
+    /// Get a reference to the [`NameMap`] for this `ResolvedSchema`.
+    pub fn get_names(&self) -> &NameMap{
         &self.context.0
     }
 
+    /// Get an [`Iterator`] of this `ResolvedSchema`'s defined schemata.
     pub fn get_schemata(&self) -> impl Iterator<Item = &Arc<Schema>>{
         self.context.0.values()
     }
 }
 
+/// An Avro array that makes a type level promise that its `"item"` schema is fully resolved.
 #[derive(Clone, Debug)]
 pub struct ResolvedArray<'a>{
     pub attributes: &'a BTreeMap<String, JsonValue>,
@@ -463,6 +480,7 @@ pub struct ResolvedArray<'a>{
     schema: &'a Schema,
 }
 
+/// An Avro map that makes a type level promise that its `"types"` schema is fully resolved
 #[derive(Clone, Debug)]
 pub struct ResolvedMap<'a>{
     pub attributes: &'a BTreeMap<String, JsonValue>,
@@ -472,6 +490,7 @@ pub struct ResolvedMap<'a>{
     schema: &'a Schema
 }
 
+/// An Avro union that makes a type level promise that the schemata it contains are all fully resolved.
 #[derive(Clone, Debug)]
 pub struct ResolvedUnion<'a>{
     pub variant_index: &'a BTreeMap<SchemaKind, usize>,
@@ -483,6 +502,8 @@ pub struct ResolvedUnion<'a>{
     schema: &'a Schema
 }
 
+/// An Avro record that makes a type level promise that each of its field's schemata are fully
+/// resolved and any provided default value has been resolved against this schema.
 #[derive(Clone,Debug)]
 pub struct ResolvedRecord<'a>{
     pub name: &'a Arc<Name>,
@@ -497,6 +518,8 @@ pub struct ResolvedRecord<'a>{
     schema: &'a Schema,
 }
 
+/// An Avro record field that makes a type level promise that its schema is fully resolved and any
+/// provided default value has been resolved against this schema.
 #[derive(Clone,Debug)]
 pub struct ResolvedRecordField<'a>{
     pub name: &'a String,
@@ -510,6 +533,8 @@ pub struct ResolvedRecordField<'a>{
     root: &'a ResolvedSchema
 }
 
+/// A node within a walk of a Avro Schema that makes the type level promise that its children
+/// schema are resovled unambiguously.
 #[derive(Clone,Debug, Display)]
 pub enum ResolvedNode<'a>{
     Null,
@@ -541,9 +566,6 @@ pub enum ResolvedNode<'a>{
     Record(ResolvedRecord<'a>),
 }
 
-/// Represents a node inside a resolved schema.
-/// This is can be used when traversing down a resolved schema tree as it couples
-/// the root definintion information with a reference into the schema.
 impl<'a> ResolvedNode<'a> {
    pub fn new(root: &'a ResolvedSchema)->ResolvedNode<'a>{
        let schema = root.stub.as_ref();
@@ -559,7 +581,10 @@ impl<'a> ResolvedNode<'a> {
             let fields = fields.iter()
                 .map(|field|{
                     let RecordField {name, doc, aliases, default, schema, custom_attributes} = field;
-                    let default_value = default.as_ref().and_then(|json_value|{Some(crate::types::Value::try_from(json_value.clone()).expect("unable to resolve defualt json value into value. This is an internal error and should never be reached."))});
+                    let default_value = default.as_ref().map(|json_value|{
+                        crate::types::Value::try_from(json_value.clone())
+                        .expect("unable to resolve defualt json value into value. This is an internal error and should never be reached.")
+                    });
                     ResolvedRecordField{name, doc, aliases, default: default_value, schema, custom_attributes, record_field: field, root}
                 }).collect();
             ResolvedNode::Record(ResolvedRecord{ name, aliases, doc, fields, lookup, attributes, root, schema})
@@ -591,8 +616,8 @@ impl<'a> ResolvedNode<'a> {
        }
    }
 
-   /// For a given resolved node, recreates the ResolvedSchema context. KTODO, need better
-   /// documentation
+   /// For a given resolved node, recreates the [`ResolvedContext`] used to start create this node
+   /// and uses the current node as the stub of this context.
    pub fn get_resolved(&self) -> ResolvedSchema{
        match self {
         ResolvedNode::Map(resolved_map) => ResolvedSchema{stub: resolved_map.schema.clone().into(), context: resolved_map.root.context.clone()},
@@ -662,7 +687,7 @@ impl From<&ResolvedNode<'_>> for SchemaKind {
 
 impl<'a> ResolvedMap<'a>{
     pub fn resolve_types(&'a self)->ResolvedNode<'a>{
-       ResolvedNode::from_schema(&self.types, self.root)
+       ResolvedNode::from_schema(self.types, self.root)
     }
 }
 
@@ -683,11 +708,12 @@ impl<'a> ResolvedUnion<'a>{
         let value_schema_kind = SchemaKind::from(value);
         let resolved_nodes = self.resolve_schemas();
         if let Some(i) = self.get_variant_index(&value_schema_kind) {
-            // fast path KTODO double check this!
+            // fast path
             let variant_clone = resolved_nodes.get(i).unwrap().clone();
-            if let Ok(_) = value
+            if value
                 .clone()
-                .resolve_internal(variant_clone.clone()){
+                .resolve_internal(variant_clone.clone())
+                .is_ok(){
                 Some((i, variant_clone))
             }else{
                 None
@@ -710,13 +736,13 @@ impl<'a> ResolvedUnion<'a>{
 
 impl<'a> ResolvedArray<'a>{
     pub fn resolve_items(&self)->ResolvedNode<'a>{
-        ResolvedNode::from_schema(&self.items, self.root)
+        ResolvedNode::from_schema(self.items, self.root)
     }
 }
 
 impl<'a> ResolvedRecordField<'a>{
     pub fn resolve_field(&self)->ResolvedNode<'a>{
-        ResolvedNode::from_schema(&self.schema, self.root)
+        ResolvedNode::from_schema(self.schema, self.root)
     }
 
     // delegate to implementation on Schema
@@ -725,8 +751,8 @@ impl<'a> ResolvedRecordField<'a>{
     }
 }
 
-/// this is a schema object that is "self contained" in that it contains all named definitions
-/// needed to encode/decode form this schema.
+/// Represents an Avro [Schema] with a type level promise that this `Schema` is self contained and
+/// complete in that all named schema references have a unique defintion within this `Schema`.
 #[derive(Debug)]
 pub struct CompleteSchema(Schema);
 
@@ -737,7 +763,8 @@ impl CompleteSchema{
     /// [Parsing Canonical Form]:
     /// https://avro.apache.org/docs/current/specification/#parsing-canonical-form-for-schemas
     pub fn independent_canonical_form(&self) -> Result<String, Error> { // TODO: I think this will
-                                                                        // never panic..
+                                                                        // never *actually* return
+                                                                        // Error..
         Ok(self.0.canonical_form())
     }
 }
@@ -755,7 +782,7 @@ impl TryFrom<Schema> for CompleteSchema{
 
     fn try_from(value: Schema) -> Result<Self, Error> {
         let resolved : ResolvedSchema = value.try_into()?;
-        return Ok((&resolved).into())
+        Ok((&resolved).into())
     }
 }
 
@@ -788,13 +815,11 @@ impl PartialEq for ResolvedSchema{
     }
 }
 
-/// technically this is a tighter bound that we need, as we may have
-/// iterated far enough down that we don't need to check the entire conext definitions.
 impl PartialEq for ResolvedNode<'_>{
     fn eq(&self, other: &Self) -> bool {
         let resolved_self = self.get_resolved();
         let resolved_other = other.get_resolved();
-        return resolved_other.unravel() == resolved_self.unravel()
+        resolved_other.unravel() == resolved_self.unravel()
     }
 }
 
@@ -808,7 +833,7 @@ impl TryFrom<SchemaWithSymbols> for ResolvedSchema{
     type Error = Error;
 
     fn try_from(schema: SchemaWithSymbols) -> AvroResult<Self> {
-        ResolvedSchema::resolve().build_one(schema)
+        ResolvedSchema::builder().build_one(schema)
     }
 }
 
@@ -816,7 +841,7 @@ impl TryFrom<&SchemaWithSymbols> for ResolvedSchema{
     type Error = Error;
 
     fn try_from(schema: &SchemaWithSymbols) -> AvroResult<Self> {
-        ResolvedSchema::resolve().build_one(schema.clone())
+        ResolvedSchema::builder().build_one(schema.clone())
     }
 }
 
@@ -825,7 +850,7 @@ impl TryFrom<Schema> for ResolvedSchema{
 
     fn try_from(schema: Schema) -> AvroResult<Self> {
         let with_symbols: SchemaWithSymbols = schema.into();
-        ResolvedSchema::resolve().build_one(with_symbols)
+        ResolvedSchema::builder().build_one(with_symbols)
     }
 }
 
@@ -834,30 +859,55 @@ impl TryFrom<&Schema> for ResolvedSchema{
     type Error = Error;
 
     fn try_from(schema: &Schema) -> AvroResult<Self> {
-        ResolvedSchema::resolve().build_one(schema)
+        ResolvedSchema::builder().build_one(schema)
     }
 }
 
-//impl<'a> TryFrom<UnionSchema> for ResolvedUnion<'a>{ // KTODO: is this something I should do??
-//    type Error = Error;
-//
-//    fn try_from(value: UnionSchema) -> Result<Self, Self::Error> {
-//        let [resolved] = ResolvedSchema::from_raw_schema_array([&Schema::Union(value)], vec![])?;
-//        let node = ResolvedNode::new(&resolved);
-//        match node {
-//            ResolvedNode::Union(resolved_union) => {resolved_union},
-//            _ => unreachable!()
-//        }
-//    }
-//}
-
-/// trait for implementing a custom schema name resolver. For instance this
-/// could be used to create resolvers that lookup schema names
-/// from a shcema registry.
+/// Trait for implementing a custom schema name resolver. This resolved is designed to be used with
+/// [`ResolvedSchema`]/[`ResolvedContext`] and will be called during schema name resolution if a local
+/// defintion for the schema name can't be found.
+/// # Example
+/// ```rust
+/// use apache_avro::schema::{ResolvedSchema,SchemaWithSymbols,Resolver, Name};
+/// use std::{collections::HashMap, sync::Arc};
+///
+/// // Here is a basic resolver that stores schema definitions in a map.
+/// struct MapResolver {
+///     registry: HashMap<String, String>,
+///     call_log: Vec<String>,
+/// }
+///
+/// impl MapResolver {
+///     fn new(entries: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>) -> Self {
+///         MapResolver {
+///             registry: entries.into_iter().map(|(k, v)| (k.into(), v.into())).collect(),
+///             call_log: Vec::new(),
+///         }
+///     }
+///
+///     fn calls(&self) -> &[String] {
+///         &self.call_log
+///     }
+/// }
+///
+/// impl Resolver for MapResolver {
+///     fn find_schema(&mut self, name: &Arc<Name>) -> Result<SchemaWithSymbols, String> {
+///         let fullname = name.fullname(None);
+///         self.call_log.push(fullname.clone());
+///         match self.registry.get(&fullname) {
+///             Some(json) => SchemaWithSymbols::parse_str(json)
+///                 .map_err(|e| format!("parse error: {e}")),
+///             None => Err(format!("not found: {fullname}")),
+///         }
+///     }
+/// }
+///
+/// ```
 pub trait Resolver{
     fn find_schema(&mut self, name: &Arc<Name>) -> Result<SchemaWithSymbols, String>;
 }
 
+#[derive(Default)]
 pub struct DefaultResolver{}
 impl Resolver for DefaultResolver{
     fn find_schema(&mut self, _name: &Arc<Name>) -> Result<SchemaWithSymbols, String> {
@@ -879,8 +929,8 @@ fn compare_schema_and_context(schema_one: &Schema, schema_two: &Schema, context_
     }
 
     // verify the provided definitions are the same:
-    let one_contains_two = context_one.keys().fold(true, |acc, val|{acc && context_two.contains_key(val)});
-    let two_contains_one = context_two.keys().fold(true, |acc, val|{acc && context_one.contains_key(val)});
+    let one_contains_two = context_one.keys().all(|val|{context_two.contains_key(val)});
+    let two_contains_one = context_two.keys().all(|val|{context_one.contains_key(val)});
 
     if !(one_contains_two && two_contains_one){
         return false
@@ -908,11 +958,10 @@ mod tests {
         schema::{Alias, CompleteSchema, Name, RecordField, RecordSchema, ResolvedNode, SchemaWithSymbols, UnionSchema},
     };
     use apache_avro_test_helper::TestResult;
-    use log::RecordBuilder;
 
     // ---------- custom resolver infrastructure for tests ----------
 
-    /// A simple resolver backed by a HashMap of JSON schema strings keyed by fullname.
+    // A simple resolver backed by a HashMap of JSON schema strings keyed by fullname.
     struct MapResolver {
         registry: HashMap<String, String>,
         call_log: Vec<String>,
@@ -969,7 +1018,7 @@ mod tests {
         }"#;
 
         let mut resolver = MapResolver::new([("ext.Address", address)]);
-        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([person], &mut resolver)?;
+        let [rs] = ResolvedSchema::builder().build_array_with_resolver([person], &mut resolver)?;
 
         // The resolver was called for ext.Address
         assert!(resolver.calls().contains(&"ext.Address".to_string()));
@@ -1002,7 +1051,7 @@ mod tests {
         }"#;
 
         let mut resolver = MapResolver::new([("shop.OrderStatus", status_enum)]);
-        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([order], &mut resolver)?;
+        let [rs] = ResolvedSchema::builder().build_array_with_resolver([order], &mut resolver)?;
 
         assert!(resolver.calls().contains(&"shop.OrderStatus".to_string()));
         assert!(rs.get_names().contains_key(&Name::new("shop.Order")?));
@@ -1031,7 +1080,7 @@ mod tests {
         }"#;
 
         let mut resolver = MapResolver::new([("proto.Checksum", checksum_fixed)]);
-        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([msg], &mut resolver)?;
+        let [rs] = ResolvedSchema::builder().build_array_with_resolver([msg], &mut resolver)?;
 
         assert!(resolver.calls().contains(&"proto.Checksum".to_string()));
         assert!(rs.get_names().contains_key(&Name::new("proto.Message")?));
@@ -1063,7 +1112,7 @@ mod tests {
         }"#;
 
         let mut resolver = MapResolver::new(Vec::<(&str, &str)>::new());
-        let [rs] = ResolvedSchema::resolve().additional(vec![address])?.build_array_with_resolver([person], &mut resolver)?;
+        let [rs] = ResolvedSchema::builder().additional(vec![address])?.build_array_with_resolver([person], &mut resolver)?;
 
         assert!(resolver.calls().is_empty(), "resolver should not be called when all names resolve locally");
         assert_eq!(rs.get_names().len(), 2);
@@ -1100,7 +1149,7 @@ mod tests {
             ("chain.C", schema_c),
         ]);
 
-        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([schema_a], &mut resolver)?;
+        let [rs] = ResolvedSchema::builder().build_array_with_resolver([schema_a], &mut resolver)?;
 
         // Both B and C should have been requested
         assert!(resolver.calls().contains(&"chain.B".to_string()));
@@ -1126,7 +1175,7 @@ mod tests {
         }"#;
 
         let mut resolver = MapResolver::new(Vec::<(&str, &str)>::new());
-        let result = ResolvedSchema::resolve().build_array_with_resolver([schema_a], &mut resolver);
+        let result = ResolvedSchema::builder().build_array_with_resolver([schema_a], &mut resolver);
 
         assert!(result.is_err(), "should fail when resolver cannot find the schema");
         let err_msg = result.unwrap_err().to_string();
@@ -1153,7 +1202,7 @@ mod tests {
         }"#;
 
         let mut resolver = MapResolver::new([("ns.Expected", wrong_schema)]);
-        let result = ResolvedSchema::resolve().build_array_with_resolver([schema_a], &mut resolver);
+        let result = ResolvedSchema::builder().build_array_with_resolver([schema_a], &mut resolver);
 
         assert!(result.is_err(), "should fail when resolver returns a schema that doesn't define the requested name");
 
@@ -1185,7 +1234,7 @@ mod tests {
         }"#;
 
         let mut resolver = MapResolver::new([("ext.Shared", shared)]);
-        let resolved = ResolvedSchema::resolve().build_list_with_resolver(
+        let resolved = ResolvedSchema::builder().build_list_with_resolver(
             vec![schema_a, schema_b],
             &mut resolver,
         )?;
@@ -1227,7 +1276,7 @@ mod tests {
         }"#;
 
         let mut resolver = MapResolver::new([("ext.C", schema_c)]);
-        let [rs] = ResolvedSchema::resolve().additional(vec![schema_b])?.build_array_with_resolver([schema_a], &mut resolver)?;
+        let [rs] = ResolvedSchema::builder().additional(vec![schema_b])?.build_array_with_resolver([schema_a], &mut resolver)?;
 
         // B resolved locally, C externally
         assert!(rs.get_names().contains_key(&Name::new("ns.A")?));
@@ -1266,7 +1315,7 @@ mod tests {
         }"#;
 
         let mut resolver = MapResolver::new([("ext.Inner", inner)]);
-        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([wrapper], &mut resolver)?;
+        let [rs] = ResolvedSchema::builder().build_array_with_resolver([wrapper], &mut resolver)?;
 
         // Walk the resolved schema tree
         let node = ResolvedNode::new(&rs);
@@ -1309,7 +1358,7 @@ mod tests {
         }"#;
 
         let mut resolver = MapResolver::new([("ext.Payload", payload)]);
-        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([record], &mut resolver)?;
+        let [rs] = ResolvedSchema::builder().build_array_with_resolver([record], &mut resolver)?;
 
         assert!(rs.get_names().contains_key(&Name::new("ext.Payload")?));
 
@@ -1354,7 +1403,7 @@ mod tests {
         }"#;
 
         let mut resolver = MapResolver::new([("ext.Item", item)]);
-        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([record], &mut resolver)?;
+        let [rs] = ResolvedSchema::builder().build_array_with_resolver([record], &mut resolver)?;
 
         assert!(rs.get_names().contains_key(&Name::new("ext.Item")?));
 
@@ -1396,7 +1445,7 @@ mod tests {
         }"#;
 
         let mut resolver = MapResolver::new([("ext.Entry", entry)]);
-        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([record], &mut resolver)?;
+        let [rs] = ResolvedSchema::builder().build_array_with_resolver([record], &mut resolver)?;
 
         assert!(rs.get_names().contains_key(&Name::new("ext.Entry")?));
 
@@ -1437,10 +1486,10 @@ mod tests {
 
         // Resolve via custom resolver
         let mut resolver = MapResolver::new([("ns.Dep", dep)]);
-        let [via_resolver] = ResolvedSchema::resolve().build_array_with_resolver([main], &mut resolver)?;
+        let [via_resolver] = ResolvedSchema::builder().build_array_with_resolver([main], &mut resolver)?;
 
         // Resolve by providing dep locally
-        let [via_local] = ResolvedSchema::resolve().additional(vec![dep])?.build_array([main])?;
+        let [via_local] = ResolvedSchema::builder().additional(vec![dep])?.build_array([main])?;
 
         assert_eq!(via_resolver, via_local);
 
@@ -1463,7 +1512,7 @@ mod tests {
         }"#;
 
         let mut resolver = MapResolver::new([("ns.Dep", dep)]);
-        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([main], &mut resolver)?;
+        let [rs] = ResolvedSchema::builder().build_array_with_resolver([main], &mut resolver)?;
 
         // Serialize and re-parse: the resulting schema should be self-contained.
         let json = serde_json::to_string(&rs)?;
@@ -1501,7 +1550,7 @@ mod tests {
         }"#;
 
         let mut resolver = MapResolver::new([("ext.Detail", detail)]);
-        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([main], &mut resolver)?;
+        let [rs] = ResolvedSchema::builder().build_array_with_resolver([main], &mut resolver)?;
 
         assert!(rs.get_names().contains_key(&Name::new("ns.Main")?));
         assert!(rs.get_names().contains_key(&Name::new("ext.Detail")?));
@@ -1536,7 +1585,7 @@ mod tests {
             ("deep.D", schema_d),
         ]);
 
-        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([schema_a], &mut resolver)?;
+        let [rs] = ResolvedSchema::builder().build_array_with_resolver([schema_a], &mut resolver)?;
 
         for name in ["deep.A", "deep.B", "deep.C", "deep.D"] {
             assert!(rs.get_names().contains_key(&Name::new(name)?), "missing {name}");
@@ -1573,7 +1622,7 @@ mod tests {
         let main_sws = SchemaWithSymbols::parse_str(main)?;
 
         let mut resolver = MapResolver::new([("ns.External", external)]);
-        let [rs] = ResolvedSchema::resolve().build_array_with_resolver(
+        let [rs] = ResolvedSchema::builder().build_array_with_resolver(
             [main_sws],
             &mut resolver,
         )?;
@@ -1612,7 +1661,7 @@ mod tests {
             ("ns.Tag", tag),
             ("ns.Meta", meta),
         ]);
-        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([main], &mut resolver)?;
+        let [rs] = ResolvedSchema::builder().build_array_with_resolver([main], &mut resolver)?;
 
         let unraveled = rs.unravel();
 
@@ -1660,7 +1709,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::resolve().build_array([schema])?;
+        let [rs] = ResolvedSchema::builder().build_array([schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.inner_record_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -1700,7 +1749,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
+        let [rs] = ResolvedSchema::builder().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.inner_record_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -1735,7 +1784,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
+        let [rs] = ResolvedSchema::builder().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.inner_enum_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -1770,7 +1819,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
+        let [rs] = ResolvedSchema::builder().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.inner_enum_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -1805,7 +1854,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
+        let [rs] = ResolvedSchema::builder().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.inner_fixed_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -1840,7 +1889,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
+        let [rs] = ResolvedSchema::builder().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.inner_fixed_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -1881,7 +1930,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
+        let [rs] = ResolvedSchema::builder().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "inner_space.inner_record_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -1917,7 +1966,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
+        let [rs] = ResolvedSchema::builder().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "inner_space.inner_enum_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -1953,7 +2002,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
+        let [rs] = ResolvedSchema::builder().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "inner_space.inner_fixed_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -2005,7 +2054,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
+        let [rs] = ResolvedSchema::builder().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 3);
         for s in [
             "space.record_name",
@@ -2062,7 +2111,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
+        let [rs] = ResolvedSchema::builder().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 3);
         for s in [
             "space.record_name",
@@ -2120,7 +2169,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
+        let [rs] = ResolvedSchema::builder().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 3);
         for s in [
             "space.record_name",
@@ -2164,7 +2213,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
+        let [rs] = ResolvedSchema::builder().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.in_array_record"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -2204,7 +2253,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
+        let [rs] = ResolvedSchema::builder().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.in_map_record"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -2241,7 +2290,7 @@ mod tests {
         }
         "#;
         let schema = Schema::parse_str(schema)?;
-        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
+        let [rs] = ResolvedSchema::builder().build_array([&schema])?;
 
         // confirm we have expected 2 full-names
         assert_eq!(rs.get_names().len(), 2);
@@ -2285,7 +2334,7 @@ mod tests {
         }
         "#;
         let schema = Schema::parse_str(schema)?;
-        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
+        let [rs] = ResolvedSchema::builder().build_array([&schema])?;
 
         // confirm we have expected 2 full-names
         assert_eq!(rs.get_names().len(), 2);
@@ -2322,7 +2371,7 @@ mod tests {
                 }
             ]
         }"#;
-        let _resolved = ResolvedSchema::resolve().build_array([&schema])?;
+        let _resolved = ResolvedSchema::builder().build_array([&schema])?;
 
         Ok(())
     }
@@ -2350,7 +2399,7 @@ mod tests {
                 }
             ]
         }"#;
-        let _resolved = ResolvedSchema::resolve().build_array([&schema])?;
+        let _resolved = ResolvedSchema::builder().build_array([&schema])?;
 
         Ok(())
     }
@@ -2397,7 +2446,7 @@ mod tests {
 
         let ambig_schema = r#""duplicated_name""#;
 
-        let result = ResolvedSchema::resolve().additional(vec![&schema, &other_schema])?.build_array([&ambig_schema])
+        let result = ResolvedSchema::builder().additional(vec![&schema, &other_schema])?.build_array([&ambig_schema])
             .unwrap_err();
 
         assert!(
@@ -2443,7 +2492,7 @@ mod tests {
         }
             "#;
 
-        let _resolved = ResolvedSchema::resolve().build_array([schema1, schema2])?;
+        let _resolved = ResolvedSchema::builder().build_array([schema1, schema2])?;
 
         Ok(())
     }
@@ -2486,9 +2535,9 @@ mod tests {
         }
             "#;
 
-        assert_eq!(
-            ResolvedSchema::resolve().additional([schema1, schema2])?.build_array([union]).is_err(),
-            true);
+        assert!(
+            ResolvedSchema::builder().additional([schema1, schema2])?.build_array([union]).is_err()
+            );
 
         Ok(())
 
@@ -2496,7 +2545,7 @@ mod tests {
 
     #[test]
     fn unravel_is_alias_aware() -> TestResult{
-        let complete = CompleteSchema::try_from(&ResolvedSchema::parse_str(
+        let complete = CompleteSchema::from(&ResolvedSchema::parse_str(
             r#"
             {
               "type": "record",
@@ -2508,7 +2557,7 @@ mod tests {
               ]
             }
         "#,
-        )?)?;
+        )?);
 
         let mut lookup = BTreeMap::new();
         lookup.insert("value".to_owned(), 0);
@@ -2638,7 +2687,7 @@ mod tests {
             "size": 4
         }"#;
 
-        let [rs] = ResolvedSchema::resolve().additional([schema2, schema3, schema4, schema5])?.build_array([schema1])?;
+        let [rs] = ResolvedSchema::builder().additional([schema2, schema3, schema4, schema5])?.build_array([schema1])?;
         let my_fixed = rs.context.0.get(&Name::try_from("myfixed")?);
 
         assert_eq!(
@@ -2668,7 +2717,7 @@ mod tests {
             "fields": [{"name": "myfield", "type": "long"}]
         }"#;
 
-        let _rs = ResolvedSchema::resolve().additional([&schema2, &schema3, &schema4, &schema4])?.build_array([&schema1])?;
+        let _rs = ResolvedSchema::builder().additional([&schema2, &schema3, &schema4, &schema4])?.build_array([&schema1])?;
 
         Ok(())
     }
@@ -2701,7 +2750,7 @@ mod tests {
             "symbols": ["F","W","D"]
         }"#;
 
-        let _rs = ResolvedSchema::resolve().additional([&schema1, &schema2])?.build_array([&union, &record])?;
+        let _rs = ResolvedSchema::builder().additional([&schema1, &schema2])?.build_array([&union, &record])?;
 
         Ok(())
     }
@@ -2724,7 +2773,7 @@ mod tests {
         "symbols": ["X", "Y"]
     }"#;
 
-    /// baz as a record instead of fixed — conflicts with BAZ_FIXED
+    /// baz as a record instead of fixed — conflicts with `BAZ_FIXED`
     const BAZ_RECORD: &str = r#"{
         "type": "record",
         "name": "baz",
@@ -2741,7 +2790,7 @@ mod tests {
 
     #[test]
     fn resolved_schema_only_includes_needed_definitions() {
-        let [resolved] = ResolvedSchema::resolve()
+        let [resolved] = ResolvedSchema::builder()
             .additional(vec![BAR_ENUM, BAZ_FIXED])
             .unwrap()
             .build_array([FOO_USES_BAR])
@@ -2761,14 +2810,14 @@ mod tests {
     #[test]
     fn equal_when_different_unused_definitions_in_pool() {
         // resolve foo with {bar, baz}
-        let [resolved_a] = ResolvedSchema::resolve()
+        let [resolved_a] = ResolvedSchema::builder()
             .additional(vec![BAR_ENUM, BAZ_FIXED])
             .unwrap()
             .build_array([FOO_USES_BAR])
             .unwrap();
 
         // resolve foo with {bar, qux}
-        let [resolved_b] = ResolvedSchema::resolve()
+        let [resolved_b] = ResolvedSchema::builder()
             .additional(vec![BAR_ENUM, QUX_ENUM])
             .unwrap()
             .build_array([FOO_USES_BAR])
@@ -2783,7 +2832,7 @@ mod tests {
     #[test]
     fn equal_despite_conflicting_unused_definitions_across_pools() {
         // pool A has baz as a fixed
-        let [resolved_a] = ResolvedSchema::resolve()
+        let [resolved_a] = ResolvedSchema::builder()
             .additional(vec![BAR_ENUM, BAZ_FIXED])
             .unwrap()
             .build_array([FOO_USES_BAR])
@@ -2791,7 +2840,7 @@ mod tests {
 
         // pool B has baz as a record — conflicts with pool A's baz,
         // but neither resolution actually needs baz
-        let [resolved_b] = ResolvedSchema::resolve()
+        let [resolved_b] = ResolvedSchema::builder()
             .additional(vec![BAR_ENUM, BAZ_RECORD])
             .unwrap()
             .build_array([FOO_USES_BAR])
@@ -2811,13 +2860,13 @@ mod tests {
             "symbols": ["D", "E", "F"]
         }"#;
 
-        let [resolved_a] = ResolvedSchema::resolve()
+        let [resolved_a] = ResolvedSchema::builder()
             .additional(vec![BAR_ENUM])
             .unwrap()
             .build_array([FOO_USES_BAR])
             .unwrap();
 
-        let [resolved_b] = ResolvedSchema::resolve()
+        let [resolved_b] = ResolvedSchema::builder()
             .additional(vec![bar_enum_alt])
             .unwrap()
             .build_array([FOO_USES_BAR])
@@ -2840,7 +2889,7 @@ mod tests {
             ]
         }"#;
 
-        let [resolved] = ResolvedSchema::resolve()
+        let [resolved] = ResolvedSchema::builder()
             .additional(vec![bar_uses_baz, BAZ_FIXED, QUX_ENUM])
             .unwrap()
             .build_array([FOO_USES_BAR])
@@ -2869,14 +2918,14 @@ mod tests {
         }"#;
 
         // pool has an extra unrelated schema
-        let [resolved_a] = ResolvedSchema::resolve()
+        let [resolved_a] = ResolvedSchema::builder()
             .additional(vec![bar_uses_baz, BAZ_FIXED, QUX_ENUM])
             .unwrap()
             .build_array([FOO_USES_BAR])
             .unwrap();
 
         // pool without the extra
-        let [resolved_b] = ResolvedSchema::resolve()
+        let [resolved_b] = ResolvedSchema::builder()
             .additional(vec![bar_uses_baz, BAZ_FIXED])
             .unwrap()
             .build_array([FOO_USES_BAR])

--- a/avro/src/schema/resolve.rs
+++ b/avro/src/schema/resolve.rs
@@ -15,226 +15,801 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::error::Details;
-use crate::schema::{
-    DecimalSchema, EnumSchema, FixedSchema, InnerDecimalSchema, NamesRef, NamespaceRef,
-    RecordSchema, UnionSchema, UuidSchema,
-};
-use crate::{AvroResult, Error, Schema};
-use std::collections::HashMap;
+// Items used for handling and/or providing named schema resolution.
 
-#[derive(Debug, Clone)]
-pub struct ResolvedSchema<'s> {
-    pub(super) names_ref: NamesRef<'s>,
-    schemata: Vec<&'s Schema>,
-}
+use serde::Serialize;
+use serde_json::Value as JsonValue;
+use strum::Display;
 
-impl<'s> ResolvedSchema<'s> {
-    pub fn get_schemata(&self) -> &[&'s Schema] {
-        &self.schemata
+use crate::schema::{Aliases, ArraySchema, DecimalSchema, Documentation, EnumSchema,
+            FixedSchema, MapSchema, Name, NameMap, NameSet, RecordField, RecordSchema, Schema,
+            SchemaKind, SchemaWithSymbols, UnionSchema, UuidSchema};
+use crate::{AvroResult, types};
+use crate::error::{Details,Error};
+use std::collections::BTreeMap;
+use std::{collections::{HashMap, HashSet}, sync::Arc, iter::once};
+
+/// a map of names and definitions that is consistent: that is, we have all named schemata refered
+/// by any of the component schemata has a unique definition in this context.
+#[derive(Debug,Clone)]
+pub struct ResolvedContext(NameMap);
+
+impl ResolvedContext{
+    /// gets the resolved context from a `ResolvedSchema`
+    pub fn from_resolved_schema(resolved_schema : &ResolvedSchema) -> ResolvedContext{
+        resolved_schema.context.clone()
     }
 
-    pub fn get_names(&self) -> &NamesRef<'s> {
-        &self.names_ref
+    pub fn from_str_array<const N : usize, S : AsRef<str>>(to_resolve: [S; N] , additional: impl IntoIterator<Item = S>) -> AvroResult<[ResolvedSchema; N]>{
+        todo!()
     }
 
-    /// Resolve all references in this schema.
-    ///
-    /// If some references are to other schemas, see [`ResolvedSchema::new_with_schemata`].
-    pub fn new(schema: &'s Schema) -> AvroResult<Self> {
-        Self::new_with_schemata(vec![schema])
+    pub fn from_str_array_with_resolver<const N : usize, S : AsRef<str>>(to_resolve: [S; N] , additional: impl IntoIterator<Item = S>) -> AvroResult<[ResolvedSchema; N]>{
+        todo!()
     }
 
-    /// Resolve all references in these schemas.
-    ///
-    // TODO: Support this
-    /// These schemas will be resolved in order, so references to schemas later in the
-    /// list is not supported.
-    pub fn new_with_schemata(schemata: Vec<&'s Schema>) -> AvroResult<Self> {
-        Self::new_with_known_schemata(schemata, None, &HashMap::new())
+    pub fn empty() -> ResolvedContext{
+        ResolvedContext(HashMap::new().into())
     }
 
-    /// Creates `ResolvedSchema` with some already known schemas.
-    ///
-    /// Those schemata would be used to resolve references if needed.
-    pub fn new_with_known_schemata<'n>(
-        schemata_to_resolve: Vec<&'s Schema>,
-        enclosing_namespace: NamespaceRef,
-        known_schemata: &'n NamesRef<'n>,
-    ) -> AvroResult<Self> {
-        let mut names = HashMap::new();
-        resolve_names_with_schemata(
-            schemata_to_resolve.iter().copied(),
-            &mut names,
-            enclosing_namespace,
-            known_schemata,
-        )?;
-        Ok(ResolvedSchema {
-            names_ref: names,
-            schemata: schemata_to_resolve,
-        })
-    }
-}
+    // convenience method for copying (pointer copy) ony the definitions we need for a given schema
+    // KTODO: bug with this, see notes, need to get to a stable testing environment to look at
+    // more...
+    //pub fn copy_needed_definitions(&self, schema_with_symbols: &SchemaWithSymbols) -> AvroResult<ResolvedContext> {
+    //    let needed_references = &schema_with_symbols.referenced_names;
+    //    let mut needed_defs : NameMap = HashMap::new();
+    //    for needed in needed_references{
+    //        if let Some(def) = self.0.get(needed){
+    //            needed_defs.insert(Arc::clone(needed), Arc::clone(def));
+    //        }else{
+    //            return Err(Details::SchemaLookupError(needed.as_ref().clone()).into());
+    //        }
+    //    };
 
-impl<'s> TryFrom<&'s Schema> for ResolvedSchema<'s> {
-    type Error = Error;
+    //    // *Why we can form another resolved*: since we provided a schema_with_symbols, we are
+    //    // guarenteed that we we have the complete set of definitions needed to descend through
+    //    // that schema, since part of our parsing is to track this.
+    //    Ok(ResolvedContext(needed_defs.into()))
+    //}
 
-    fn try_from(schema: &'s Schema) -> AvroResult<Self> {
-        Self::new(schema)
-    }
-}
-
-impl<'s> TryFrom<Vec<&'s Schema>> for ResolvedSchema<'s> {
-    type Error = Error;
-
-    fn try_from(schemata: Vec<&'s Schema>) -> AvroResult<Self> {
-        Self::new_with_schemata(schemata)
-    }
-}
-
-/// Implementation detail of [`ResolvedOwnedSchema`]
-///
-/// This struct is self-referencing. The references in `names` point to `root_schema`.
-/// This allows resolving an owned schema without having to clone all the named schemas.
-#[ouroboros::self_referencing]
-struct InnerResolvedOwnedSchema {
-    root_schema: Schema,
-    #[borrows(root_schema)]
-    #[covariant]
-    names: NamesRef<'this>,
-}
-
-/// A variant of [`ResolvedSchema`] that owns the schema
-pub struct ResolvedOwnedSchema {
-    inner: InnerResolvedOwnedSchema,
-}
-
-impl ResolvedOwnedSchema {
-    pub fn new(root_schema: Schema) -> AvroResult<Self> {
-        Ok(Self {
-            inner: InnerResolvedOwnedSchemaTryBuilder {
-                root_schema,
-                names_builder: |schema: &Schema| {
-                    let mut names = HashMap::new();
-                    resolve_names(schema, &mut names, None, &HashMap::new())?;
-                    Ok::<_, Error>(names)
-                },
+    // checks that the provided definition names do not conflict with existing definitions.
+    fn check_if_conflicts<'a>(defined_names: &NameMap, names: impl Iterator<Item = &'a Arc<Name> >) -> AvroResult<()>{
+        let mut conflicting_fullnames : Vec<String> = Vec::new();
+        for name in names{
+            if defined_names.contains_key(name){
+                conflicting_fullnames.push(name.fullname(Option::None));
             }
-            .try_build()?,
-        })
+        }
+
+        if conflicting_fullnames.len() == 0 {
+            Ok(())
+        }else{
+            Err(Details::MultipleNameCollision(conflicting_fullnames).into())
+        }
     }
 
-    pub fn get_root_schema(&self) -> &Schema {
-        self.inner.borrow_root_schema()
+    pub fn new_context(schemata: impl Iterator<Item = SchemaWithSymbols>) -> AvroResult<ResolvedContext>{
+        Self::new_context_with_resolver(schemata, &mut DefaultResolver::new())
     }
-    pub fn get_names(&self) -> &NamesRef<'_> {
-        self.inner.borrow_names()
+
+    pub fn new_context_with_resolver(schemata: impl Iterator<Item = SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<ResolvedContext>{
+        let mut context : NameMap = HashMap::new();
+        Self::add_to_context(&mut context, schemata, resolver)?;
+        Ok(ResolvedContext(context))
+    }
+
+    // add the with_symbols into the defined_names and check for naming conflicts.
+    // If we can't resolved from the local context, we will ask the resolved if it can find
+    // the schema we need.
+    fn add_to_context(defined_names: &mut NameMap, schemata: impl Iterator<Item = SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<()>{
+        let mut references : HashSet<Arc<Name>> = HashSet::new();
+
+        for schema_with_symbol in schemata{
+            Self::check_if_conflicts(&defined_names, schema_with_symbol.defined_names.keys())?;
+            defined_names.extend(schema_with_symbol.defined_names);
+            references.extend(schema_with_symbol.referenced_names);
+        }
+
+        for schema_ref in references{
+            Self::resolve_name(defined_names, &schema_ref, resolver)?;
+        }
+
+        Ok(())
+
+    }
+
+    // attempt to resolve the schema name, first from the known schema definitions, and if that
+    // fails, from the provided resolver.
+    fn resolve_name(defined_names: &mut NameMap, name: &Arc<Name>, resolver: &mut impl Resolver) -> AvroResult<()>{
+        // first, check if can resolve internally
+        if defined_names.contains_key(name) {
+            return Ok(());
+        }
+
+        // second, use provided resolver
+        match resolver.find_schema(name){
+            Ok(schema_with_symbols) => {
+
+                // check that what we got back from the resolver actually matches what we expect
+                if !schema_with_symbols.defined_names.contains_key(name) {
+                    return Err(Details::CustomSchemaResolverMismatch(name.as_ref().clone(),
+                            Vec::from_iter(schema_with_symbols.defined_names.keys().map(|key| {key.as_ref().clone()}))).into())
+                }
+                // matches, lets add this as a schemata that we should have, and recurse in
+                Self::add_to_context(defined_names, once(schema_with_symbols), resolver)?;
+                Ok(())
+            },
+            Err(msg) => {
+                return Err(Details::SchemaResolutionErrorWithMsg(name.as_ref().clone(), msg).into());
+            }
+        }
+    }
+}
+/// contians a schema with all of the schema
+/// definitions it needs to be completely resolved
+/// This type is a promise from the API that each named
+/// type in the schema has exactly one unique definition
+/// and every named reference in the schema can be uniquely
+/// resolved to one of these definitions.
+/// ResolvedSchema wraps Arc references and is therefore easy to clone.
+#[derive(Debug,Clone)]
+pub struct ResolvedSchema{
+    pub schema: Arc<Schema>, //KTODO maybe this should take a SchemaWithSymbols? Or a
+                                   //reference to SchemaWithSymbols?
+    context: ResolvedContext
+}
+
+impl ResolvedSchema{
+
+   // KTODO: do we want a function like this??
+   // pub fn new(schema: SchemaWithSymbols) -> AvroResult<ResolvedSchema>{
+   //     let [resolved_schema] = ResolvedSchema::from_schemata_array([schema], vec![])?;
+   //     return Ok(resolved_schema)
+   // }
+
+    pub fn new_empty() -> Self{
+       Schema::Null.try_into().unwrap()
+    }
+
+    // methods that take directly from a string
+
+    // convenience method since this is a common scenario
+    pub fn parse_str(string: impl AsRef<str>) -> AvroResult<ResolvedSchema>{
+        let [resolved] = Self::from_str_array_only([string])?;
+        return Ok(resolved)
+    }
+
+    // the rest!
+
+    pub fn from_str_array_only<const N : usize, S : AsRef<str>>(to_resolve: [S; N]) -> AvroResult<[ResolvedSchema; N]>{
+        let empt : Vec<&str> = Vec::new();
+        Self::from_str_array_with_resolver(to_resolve, empt, &mut DefaultResolver::new())
+    }
+
+    pub fn from_str_array<const N : usize, S : AsRef<str>>(to_resolve: [S; N] , additional: impl IntoIterator<Item = S>) -> AvroResult<[ResolvedSchema; N]>{
+        Self::from_str_array_with_resolver(to_resolve, additional, &mut DefaultResolver::new())
+    }
+
+    pub fn from_str_array_with_resolver<const N : usize>(to_resolve:  [impl AsRef<str>; N] , additional: impl IntoIterator<Item = impl AsRef<str>> , resolver: &mut impl Resolver) -> AvroResult<[ResolvedSchema; N]>{
+        let to_resolve = SchemaWithSymbols::parse_array(to_resolve)?;
+        let additional = SchemaWithSymbols::parse_list(additional)?;
+        let resolved = Self::from_with_symbols_array_with_resolver(to_resolve, additional.into_iter(), resolver)?;
+        Ok(resolved)
+    }
+
+    pub fn from_str_list<T : AsRef<str>>(to_resolve: Vec<T> , additional: Vec<T>) -> AvroResult<Vec<ResolvedSchema>>{
+        Self::from_str_list_with_resolver(to_resolve, additional, &mut DefaultResolver::new())
+    }
+
+    pub fn from_str_list_with_resolver<T : AsRef<str>>(to_resolve: Vec<T> , additional: Vec<T>, resolver: &mut impl Resolver) -> AvroResult<Vec<ResolvedSchema>>{
+        let to_resolve_len : usize = to_resolve.len();
+        let schemata_with_symbols = SchemaWithSymbols::parse_list(to_resolve.into_iter().chain(additional.into_iter()))?;
+        let mut resolved = Self::from_with_symbols_list_with_resolver(schemata_with_symbols, Vec::new(), resolver)?;
+        Ok(resolved.drain(0..to_resolve_len).collect())
+    }
+
+    // methods that take directly from schema
+    // this is not the recommended way of forming a ResolvedSchema
+
+    pub fn from_schema_array_only<'a,const N: usize>(to_resolve: [&Schema;N]) -> AvroResult<[ResolvedSchema; N]>{
+        Self::from_schema_array_with_resolver(to_resolve, Vec::new(), &mut DefaultResolver::new())
+    }
+
+    pub fn from_schema_array<'a,const N: usize>(to_resolve: [&Schema;N], schemata: impl IntoIterator<Item = &'a Schema>) -> AvroResult<[ResolvedSchema; N]>{
+        Self::from_schema_array_with_resolver(to_resolve, schemata, &mut DefaultResolver::new())
+    }
+
+    pub fn from_schema_array_with_resolver<'a,const N: usize>(to_resolve: [&Schema;N], schemata: impl IntoIterator<Item = &'a Schema>, resolver: &mut impl Resolver) -> AvroResult<[ResolvedSchema; N]>{
+        let to_resolve_with_symbols : [SchemaWithSymbols; N] = std::array::from_fn(|i|{
+            (*to_resolve.get(i).unwrap()).clone().into()
+        });
+        ResolvedSchema::from_with_symbols_array_with_resolver(to_resolve_with_symbols,
+            schemata.into_iter().map(|schema| schema.clone().into()), resolver)
+    }
+
+    pub fn from_schema_list<'a>(to_resolve: impl IntoIterator<Item = &'a Schema>, schemata: impl IntoIterator<Item = &'a Schema>) -> AvroResult<Vec<ResolvedSchema>>{
+        Self::from_schema_list_with_resolver(to_resolve, schemata, &mut DefaultResolver::new())
+    }
+    pub fn from_schema_list_with_resolver<'a>(to_resolve: impl IntoIterator<Item = &'a Schema>, schemata: impl IntoIterator<Item = &'a Schema>, resolver: &mut impl Resolver) -> AvroResult<Vec<ResolvedSchema>>{
+        let to_resolve_with_symbols : Vec<SchemaWithSymbols> = to_resolve.into_iter().cloned().map(|schema|{schema.into()}).collect();
+        ResolvedSchema::from_with_symbols_list_with_resolver(to_resolve_with_symbols,
+            schemata.into_iter().map(|schema| schema.clone().into()), resolver)
+    }
+
+    // methods that form a resolution context from `SchemaWithSymbols`
+    // this is the reccomended way of creating a `ResolvedSchema`
+    //
+    pub fn from_with_symbols_array_only<const N : usize>(to_resolve: [SchemaWithSymbols;N]) -> AvroResult<[ResolvedSchema; N]>{
+        Self::from_with_symbols_array_with_resolver(to_resolve, Vec::new(), &mut DefaultResolver::new())
+    }
+
+    pub fn from_with_symbols_array<const N : usize>(to_resolve: [SchemaWithSymbols;N], schemata_with_symbols: impl IntoIterator<Item = SchemaWithSymbols>) -> AvroResult<[ResolvedSchema; N]>{
+        Self::from_with_symbols_array_with_resolver(to_resolve, schemata_with_symbols, &mut DefaultResolver::new())
+    }
+
+    pub fn from_with_symbols_list(to_resolve: impl IntoIterator<Item = SchemaWithSymbols>, schemata_with_symbols: impl IntoIterator<Item = SchemaWithSymbols>) -> AvroResult<Vec<ResolvedSchema>>{
+        Self::from_with_symbols_list_with_resolver(to_resolve, schemata_with_symbols, &mut DefaultResolver::new())
+    }
+
+    /// Takes two vectors of schemata. Both of these vectors are checked that they form a complete
+    /// schema context in which there every named schema has a unique defition and every schema
+    /// reference can be uniquely resolved to one of these definitions. The first vector of
+    /// schemata are those in which we want the associated ResolvedSchema forms of the schema to be
+    /// returned. The second vector are schemata that are used for schema resolution, but do not
+    /// have their ResolvedSchema form returned.
+    pub fn from_with_symbols_array_with_resolver<const N : usize>(to_resolve: [SchemaWithSymbols; N], schemata_with_symbols: impl IntoIterator<Item = SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<[ResolvedSchema; N]> {
+
+        let context = ResolvedContext::new_context_with_resolver(to_resolve.clone().into_iter().chain(schemata_with_symbols), resolver)?;
+
+        // check defualts for each with_symbol
+        for with_symbol in to_resolve.iter(){
+            for (schema, value) in &with_symbol.field_defaults_to_resolve{
+               let avro_value = types::Value::try_from(value.clone())?;
+               avro_value.resolve_internal(ResolvedNode::new(&ResolvedSchema{
+                   schema: Arc::new(schema.clone()), // KTODO: this should be optimized away
+                   context: context.clone()
+               }))?;
+            }
+        }
+
+        let mut to_resolve_iter = to_resolve.into_iter();
+        Ok(std::array::from_fn(|_|{
+            let with_symbol = to_resolve_iter.next().unwrap();
+            ResolvedSchema{
+                schema: with_symbol.schema,
+                context: context.clone()
+            }
+        }))
+    }
+
+    pub fn from_with_symbols_list_with_resolver(to_resolve: impl IntoIterator<Item = SchemaWithSymbols>, schemata_with_symbols: impl IntoIterator<Item = SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<Vec<ResolvedSchema>> {
+
+        let to_resolve : Vec<SchemaWithSymbols> = Vec::from_iter(to_resolve.into_iter());
+
+        let context = ResolvedContext::new_context_with_resolver(to_resolve.iter().cloned().chain(schemata_with_symbols), resolver)?;
+
+        // check defualts for each with_symbol
+        for with_symbol in to_resolve.iter(){
+            for (schema, value) in &with_symbol.field_defaults_to_resolve{
+               let avro_value = types::Value::try_from(value.clone())?;
+               avro_value.resolve_internal(ResolvedNode::new(&ResolvedSchema{
+                   schema: Arc::new(schema.clone()), // TODO: this should be optimized away
+                   context: context.clone()
+               }))?;
+            }
+        }
+
+        Ok(to_resolve.into_iter().map(|schema_with_symbols|{ResolvedSchema{
+                schema: schema_with_symbols.schema,
+                context: context.clone()
+            }}).collect())
+    }
+
+
+
+    pub fn get_names<'b>(&'b self) -> &'b NameMap{
+        &self.context.0
+    }
+
+    pub fn get_schemata(&self) -> impl Iterator<Item = &Arc<Schema>>{
+        self.context.0.values()
     }
 }
 
-impl TryFrom<Schema> for ResolvedOwnedSchema {
+#[derive(Clone, Debug)]
+pub struct ResolvedArray<'a>{
+    pub attributes: &'a BTreeMap<String, JsonValue>,
+    items: &'a Schema,
+    root: &'a ResolvedSchema,
+
+    schema: &'a Schema,
+}
+
+#[derive(Clone, Debug)]
+pub struct ResolvedMap<'a>{
+    pub attributes: &'a BTreeMap<String, JsonValue>,
+    types: &'a Schema,
+    root: &'a ResolvedSchema,
+
+    schema: &'a Schema
+}
+
+#[derive(Clone, Debug)]
+pub struct ResolvedUnion<'a>{
+    pub variant_index: &'a BTreeMap<SchemaKind, usize>,
+
+    union_schema: &'a UnionSchema,
+    schemas: &'a Vec<Schema>,
+    root: &'a ResolvedSchema,
+
+    schema: &'a Schema
+}
+
+#[derive(Clone,Debug)]
+pub struct ResolvedRecord<'a>{
+    pub name: &'a Arc<Name>,
+    pub aliases: &'a Aliases,
+    pub doc: &'a Documentation,
+    pub lookup: &'a BTreeMap<String, usize>,
+    pub attributes: &'a BTreeMap<String, JsonValue>,
+    pub fields: Vec<ResolvedRecordField<'a>>,
+
+    root: &'a ResolvedSchema,
+
+    schema: &'a Schema,
+}
+
+#[derive(Clone,Debug)]
+pub struct ResolvedRecordField<'a>{
+    pub name: &'a String,
+    pub doc: &'a Documentation,
+    pub aliases: &'a Vec<String>,
+    pub default: Option<crate::types::Value>,
+    pub custom_attributes: &'a BTreeMap<String, JsonValue>,
+
+    record_field: &'a RecordField,
+    schema: &'a Schema,
+    root: &'a ResolvedSchema
+}
+
+#[derive(Clone,Debug, Display)]
+pub enum ResolvedNode<'a>{
+    Null,
+    Boolean,
+    Int,
+    Long,
+    Float,
+    Double,
+    Bytes,
+    String,
+    BigDecimal,
+    Date,
+    TimeMillis,
+    TimeMicros,
+    TimestampMillis,
+    TimestampMicros,
+    TimestampNanos,
+    LocalTimestampMillis,
+    LocalTimestampMicros,
+    LocalTimestampNanos,
+    Uuid(&'a UuidSchema),
+    Duration(&'a FixedSchema),
+    Enum(&'a EnumSchema),
+    Fixed(&'a FixedSchema),
+    Decimal(&'a DecimalSchema),
+    Array(ResolvedArray<'a>),
+    Map(ResolvedMap<'a>),
+    Union(ResolvedUnion<'a>),
+    Record(ResolvedRecord<'a>),
+}
+
+/// Represents a node inside a resolved schema.
+/// This is can be used when traversing down a resolved schema tree as it couples
+/// the root definintion information with a reference into the schema.
+impl<'a> ResolvedNode<'a> {
+   pub fn new(root: &'a ResolvedSchema)->ResolvedNode<'a>{
+       let schema = root.schema.as_ref();
+       Self::from_schema(schema, root)
+   }
+
+   fn from_schema(schema: &'a Schema, root: &'a ResolvedSchema) -> ResolvedNode<'a>{
+       match schema {
+        Schema::Map(MapSchema{attributes, types}) => ResolvedNode::Map(ResolvedMap{attributes, types, root, schema}),
+        Schema::Union(union_schema) => ResolvedNode::Union(ResolvedUnion{union_schema, schemas: &union_schema.schemas, variant_index: &union_schema.variant_index, root,schema}),
+        Schema::Array(ArraySchema { items, attributes }) => ResolvedNode::Array(ResolvedArray{items, attributes, root,schema}),
+        Schema::Record(RecordSchema { name, aliases, doc, fields, lookup, attributes }) => {
+            let fields = fields.iter()
+                .map(|field|{
+                    let RecordField {name, doc, aliases, default, schema, custom_attributes} = field;
+                    let default_value = default.as_ref().and_then(|json_value|{Some(crate::types::Value::try_from(json_value.clone()).expect("unable to resolve defualt json value into value. This is an internal error and should never be reached."))});
+                    ResolvedRecordField{name, doc, aliases, default: default_value, schema, custom_attributes, record_field: field, root}
+                }).collect();
+            ResolvedNode::Record(ResolvedRecord{ name, aliases, doc, fields, lookup, attributes, root, schema})
+        },
+        Schema::Ref{name} => Self::from_schema(root.context.0.get(name).unwrap().as_ref(), root),
+        Schema::Null => ResolvedNode::Null,
+        Schema::Boolean => ResolvedNode::Boolean,
+        Schema::Int => ResolvedNode::Int,
+        Schema::Long => ResolvedNode::Long,
+        Schema::Float => ResolvedNode::Float,
+        Schema::Double => ResolvedNode::Double,
+        Schema::Bytes => ResolvedNode::Bytes,
+        Schema::String => ResolvedNode::String,
+        Schema::BigDecimal => ResolvedNode::BigDecimal,
+        Schema::Uuid(uuid_schema) => ResolvedNode::Uuid(uuid_schema),
+        Schema::Date => ResolvedNode::Date,
+        Schema::TimeMillis => ResolvedNode::TimeMillis,
+        Schema::TimeMicros => ResolvedNode::TimeMicros,
+        Schema::TimestampMillis => ResolvedNode::TimestampMillis,
+        Schema::TimestampMicros => ResolvedNode::TimestampMicros,
+        Schema::TimestampNanos => ResolvedNode::TimestampNanos,
+        Schema::LocalTimestampMillis => ResolvedNode::LocalTimestampMillis,
+        Schema::LocalTimestampMicros => ResolvedNode::LocalTimestampMicros,
+        Schema::LocalTimestampNanos => ResolvedNode::LocalTimestampNanos,
+        Schema::Duration(fixed_schema) => ResolvedNode::Duration(fixed_schema),
+        Schema::Enum(enum_schema) => ResolvedNode::Enum(enum_schema),
+        Schema::Fixed(fixed_schema) => ResolvedNode::Fixed(fixed_schema),
+        Schema::Decimal(decimal_schema) => ResolvedNode::Decimal(decimal_schema)
+       }
+   }
+
+   /// For a given resolved node, recreates the ResolvedSchema context. KTODO, need better
+   /// documentation
+   pub fn get_resolved(&self) -> ResolvedSchema{
+       match self {
+        ResolvedNode::Map(resolved_map) => ResolvedSchema{schema: resolved_map.schema.clone().into(), context: resolved_map.root.context.clone()},
+        ResolvedNode::Union(resolved_union) => ResolvedSchema{schema: resolved_union.schema.clone().into(), context: resolved_union.root.context.clone()},
+        ResolvedNode::Array(resolved_array) => ResolvedSchema{schema: resolved_array.schema.clone().into(), context: resolved_array.root.context.clone()},
+        ResolvedNode::Record(resolved_record) => ResolvedSchema{schema: resolved_record.schema.clone().into(), context: resolved_record.root.context.clone()},
+        ResolvedNode::Uuid(uuid_schema) => ResolvedSchema{schema: Schema::Uuid((*uuid_schema).clone()).into(), context: ResolvedContext::empty()},
+        ResolvedNode::Duration(fixed_schema) => ResolvedSchema{schema: Schema::Duration((*fixed_schema).clone()).into(), context: ResolvedContext::empty()},
+        ResolvedNode::Enum(enum_schema) => ResolvedSchema{schema: Schema::Enum((*enum_schema).clone()).into(), context: ResolvedContext::empty()},
+        ResolvedNode::Fixed(fixed_schema) => ResolvedSchema{schema: Schema::Fixed((*fixed_schema).clone()).into(), context: ResolvedContext::empty()},
+        ResolvedNode::Decimal(decimal_schema) => ResolvedSchema{schema: Schema::Decimal((*decimal_schema).clone()).into(), context: ResolvedContext::empty()},
+        ResolvedNode::Null => ResolvedSchema{schema: Schema::Null.into(), context: ResolvedContext::empty()},
+        ResolvedNode::Boolean => ResolvedSchema{schema: Schema::Boolean.into(), context: ResolvedContext::empty()},
+        ResolvedNode::Int => ResolvedSchema{schema: Schema::Int.into(), context: ResolvedContext::empty()},
+        ResolvedNode::Long => ResolvedSchema{schema: Schema::Long.into(), context: ResolvedContext::empty()},
+        ResolvedNode::Float => ResolvedSchema{schema: Schema::Float.into(), context: ResolvedContext::empty()},
+        ResolvedNode::Double => ResolvedSchema{schema: Schema::Double.into(), context: ResolvedContext::empty()},
+        ResolvedNode::Bytes => ResolvedSchema{schema: Schema::Bytes.into(), context: ResolvedContext::empty()},
+        ResolvedNode::String => ResolvedSchema{schema: Schema::String.into(), context: ResolvedContext::empty()},
+        ResolvedNode::BigDecimal => ResolvedSchema{schema: Schema::BigDecimal.into(), context: ResolvedContext::empty()},
+        ResolvedNode::Date => ResolvedSchema{schema: Schema::Date.into(), context: ResolvedContext::empty()},
+        ResolvedNode::TimeMillis => ResolvedSchema{schema: Schema::TimeMillis.into(), context: ResolvedContext::empty()},
+        ResolvedNode::TimeMicros => ResolvedSchema{schema: Schema::TimeMicros.into(), context: ResolvedContext::empty()},
+        ResolvedNode::TimestampMillis => ResolvedSchema{schema: Schema::TimestampMillis.into(), context: ResolvedContext::empty()},
+        ResolvedNode::TimestampMicros => ResolvedSchema{schema: Schema::TimestampMicros.into(), context: ResolvedContext::empty()},
+        ResolvedNode::TimestampNanos => ResolvedSchema{schema: Schema::TimestampNanos.into(), context: ResolvedContext::empty()},
+        ResolvedNode::LocalTimestampMillis => ResolvedSchema{schema: Schema::LocalTimestampMillis.into(), context: ResolvedContext::empty()},
+        ResolvedNode::LocalTimestampMicros => ResolvedSchema{schema: Schema::LocalTimestampMicros.into(), context: ResolvedContext::empty()},
+        ResolvedNode::LocalTimestampNanos => ResolvedSchema{schema: Schema::LocalTimestampNanos.into(), context: ResolvedContext::empty()},
+       }
+   }
+
+   pub(crate) fn get_schema(&self) -> Schema{ // KTODO, maybe get rid of this for the future!!
+       self.get_resolved().schema.as_ref().clone()
+   }
+}
+
+impl From<&ResolvedNode<'_>> for SchemaKind {
+    fn from(value: &ResolvedNode) -> Self {
+        match value {
+            ResolvedNode::Null => Self::Null,
+            ResolvedNode::Boolean => Self::Boolean,
+            ResolvedNode::Int => Self::Int,
+            ResolvedNode::Long => Self::Long,
+            ResolvedNode::Float => Self::Float,
+            ResolvedNode::Double => Self::Double,
+            ResolvedNode::Bytes => Self::Bytes,
+            ResolvedNode::String => Self::String,
+            ResolvedNode::Array(_) => Self::Array,
+            ResolvedNode::Map(_) => Self::Map,
+            ResolvedNode::Union(_) => Self::Union,
+            ResolvedNode::Record(_) => Self::Record,
+            ResolvedNode::Enum(_) => Self::Enum,
+            ResolvedNode::Fixed(_) => Self::Fixed,
+            ResolvedNode::Decimal { .. } => Self::Decimal,
+            ResolvedNode::BigDecimal => Self::BigDecimal,
+            ResolvedNode::Uuid(_) => Self::Uuid,
+            ResolvedNode::Date => Self::Date,
+            ResolvedNode::TimeMillis => Self::TimeMillis,
+            ResolvedNode::TimeMicros => Self::TimeMicros,
+            ResolvedNode::TimestampMillis => Self::TimestampMillis,
+            ResolvedNode::TimestampMicros => Self::TimestampMicros,
+            ResolvedNode::TimestampNanos => Self::TimestampNanos,
+            ResolvedNode::LocalTimestampMillis => Self::LocalTimestampMillis,
+            ResolvedNode::LocalTimestampMicros => Self::LocalTimestampMicros,
+            ResolvedNode::LocalTimestampNanos => Self::LocalTimestampNanos,
+            ResolvedNode::Duration { .. } => Self::Duration,
+        }
+    }
+}
+
+impl<'a> ResolvedMap<'a>{
+    pub fn resolve_types(&'a self)->ResolvedNode<'a>{
+       ResolvedNode::from_schema(&self.types, self.root)
+    }
+}
+
+impl<'a> ResolvedUnion<'a>{
+    pub fn resolve_schemas(&self)->Vec<ResolvedNode<'a>>{
+        self.schemas.iter().map(|schema|{
+            ResolvedNode::from_schema(schema, self.root)
+        }).collect()
+    }
+
+    /// For getting the original schema for nice error printing
+    /// Other than that, use should be avoided.
+    pub(crate) fn get_union_schema(&self) -> &'a UnionSchema{
+        self.union_schema
+    }
+
+    pub fn structural_match_on_schema(&'a self, value: &types::Value) -> Option<(usize,ResolvedNode<'a>)>{
+        let value_schema_kind = SchemaKind::from(value);
+        let resolved_nodes = self.resolve_schemas();
+        if let Some(i) = self.get_variant_index(&value_schema_kind) {
+            // fast path
+            Some((i, resolved_nodes.get(i).unwrap().clone()))
+        } else {
+            // slow path (required for matching logical or named types)
+            self.resolve_schemas().into_iter().enumerate().find(|(_, resolved_node)| {
+                value
+                    .clone()
+                    .resolve_internal(resolved_node.clone())
+                    .is_ok()
+            })
+        }
+    }
+
+    pub fn get_variant_index(&self, schema_kind: &SchemaKind) -> Option<usize>{
+       self.variant_index.get(schema_kind).copied()
+    }
+}
+
+impl<'a> ResolvedArray<'a>{
+    pub fn resolve_items(&self)->ResolvedNode<'a>{
+        ResolvedNode::from_schema(&self.items, self.root)
+    }
+}
+
+impl<'a> ResolvedRecordField<'a>{
+    pub fn resolve_field(&self)->ResolvedNode<'a>{
+        ResolvedNode::from_schema(&self.schema, self.root)
+    }
+
+    // delegate to implementation on Schema
+    pub fn is_nullable(&self) -> bool {
+        self.record_field.is_nullable()
+    }
+}
+
+/// this is a schema object that is "self contained" in that it contains all named definitions
+/// needed to encode/decode form this schema.
+pub struct CompleteSchema(Schema);
+
+impl CompleteSchema{
+    /// Returns the [Parsing Canonical Form] of `self` that is self contained (not dependent on
+    /// any definitions in `schemata`)
+    ///
+    /// [Parsing Canonical Form]:
+    /// https://avro.apache.org/docs/current/specification/#parsing-canonical-form-for-schemas
+    pub fn independent_canonical_form(&self) -> Result<String, Error> { // TODO: I think this will
+                                                                        // never panic..
+        Ok(self.0.canonical_form())
+    }
+}
+
+impl From<&ResolvedSchema> for CompleteSchema{
+    fn from(value: &ResolvedSchema) -> Self {
+
+        fn unravel(schema: &mut Schema, defined_schemata: &NameMap, placed_schemata: &mut NameSet){
+            match schema {
+                Schema::Ref{name}=> {
+                    if !placed_schemata.contains(name) {
+                        let mut definition = defined_schemata.get(name).unwrap().as_ref().clone();
+                        unravel(&mut definition, defined_schemata, placed_schemata);
+                        *schema = definition;
+                    }
+                },
+                Schema::Record(record_schema) => {
+                    if !placed_schemata.insert(Arc::clone(&record_schema.name)) {
+                        panic!("When converting to complete schema, attempted to double define a schema when unraveling");
+                    }
+                    for field in &mut record_schema.fields {
+                       unravel(&mut field.schema, defined_schemata, placed_schemata);
+                    }
+                }
+                Schema::Array(array_schema) => {
+                    unravel(&mut array_schema.items, defined_schemata, placed_schemata);
+                }
+                Schema::Map(map_schema) => {
+                    unravel(map_schema.types.as_mut(), defined_schemata, placed_schemata);
+                }
+                Schema::Union(union_schema) => {
+                    for mut el_schema in &mut union_schema.schemas {
+                        unravel(&mut el_schema, defined_schemata, placed_schemata);
+                    }
+                },
+                Schema::Fixed(fixed_schema) => {
+                    if !placed_schemata.insert(Arc::clone(&fixed_schema.name)) {
+                        panic!("When converting to complete schema, attempted to double define a schema when unraveling");
+                    }
+                },
+                Schema::Enum(enum_schema) => {
+                    if !placed_schemata.insert(Arc::clone(&enum_schema.name)) {
+                        panic!("When converting to complete schema, attempted to double define a schema when unraveling");
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let mut schema = value.schema.as_ref().clone();
+        unravel(&mut schema, &value.context.0, &mut HashSet::new());
+        CompleteSchema(schema)
+    }
+}
+
+impl TryFrom<Schema> for CompleteSchema{
+    type Error = Error;
+
+    fn try_from(value: Schema) -> Result<Self, Error> {
+        let resolved : ResolvedSchema = value.try_into()?;
+        return Ok((&resolved).into())
+    }
+}
+
+impl Serialize for CompleteSchema{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer {
+                self.0.serialize(serializer)
+    }
+}
+
+impl PartialEq<CompleteSchema> for CompleteSchema{
+   fn eq(&self, other: &CompleteSchema) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Serialize for ResolvedSchema{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer {
+       let complete_schema = CompleteSchema::from(self);
+       complete_schema.serialize(serializer)
+    }
+}
+
+impl PartialEq for ResolvedSchema{
+    fn eq(&self, other: &Self) -> bool {
+        compare_schema_with_context(&self.schema, &other.schema, &self.context.0, &other.context.0, &HashSet::new(), &HashSet::new())
+    }
+}
+
+/// technically this is a tighter bound that we need, as we may have
+/// iterated far enough down that we don't need to check the entire conext definitions.
+impl PartialEq for ResolvedNode<'_>{
+    fn eq(&self, other: &Self) -> bool {
+        let resolved_self = self.get_resolved();
+        let resolved_other = other.get_resolved();
+        return resolved_other == resolved_self
+    }
+}
+
+impl PartialEq for SchemaWithSymbols{
+    fn eq(&self, other: &Self) -> bool {
+        compare_schema_with_context(&self.schema, &other.schema, &self.defined_names, &other.defined_names, &self.referenced_names, &other.referenced_names)
+    }
+}
+
+impl TryFrom<SchemaWithSymbols> for ResolvedSchema{
+    type Error = Error;
+
+    fn try_from(schema: SchemaWithSymbols) -> AvroResult<Self> {
+        let [resolved_schema] = ResolvedSchema::from_with_symbols_array([schema], Vec::new())?;
+        Ok(resolved_schema)
+    }
+}
+
+impl TryFrom<&SchemaWithSymbols> for ResolvedSchema{
+    type Error = Error;
+
+    fn try_from(schema: &SchemaWithSymbols) -> AvroResult<Self> {
+        let [resolved_schema] = ResolvedSchema::from_with_symbols_array([schema.clone()], Vec::new())?;
+        Ok(resolved_schema)
+    }
+}
+
+impl TryFrom<Schema> for ResolvedSchema{
     type Error = Error;
 
     fn try_from(schema: Schema) -> AvroResult<Self> {
-        Self::new(schema)
+        let with_symbols : SchemaWithSymbols = schema.into();
+        let [resolved_schema] = ResolvedSchema::from_with_symbols_array([with_symbols], Vec::new())?;
+        Ok(resolved_schema)
     }
 }
 
-/// Resolve all references in the schema, saving any named type found in `names`
-///
-/// `known_schemata` will be used to resolve references but they won't be added to `names`.
-pub fn resolve_names<'s, 'n>(
-    schema: &'s Schema,
-    names: &mut NamesRef<'s>,
-    enclosing_namespace: NamespaceRef,
-    known_schemata: &NamesRef<'n>,
-) -> AvroResult<()> {
-    match schema {
-        Schema::Array(schema) => {
-            resolve_names(&schema.items, names, enclosing_namespace, known_schemata)
-        }
-        Schema::Map(schema) => {
-            resolve_names(&schema.types, names, enclosing_namespace, known_schemata)
-        }
-        Schema::Union(UnionSchema { schemas, .. }) => {
-            for schema in schemas {
-                resolve_names(schema, names, enclosing_namespace, known_schemata)?
-            }
-            Ok(())
-        }
-        Schema::Enum(EnumSchema { name, .. })
-        | Schema::Fixed(FixedSchema { name, .. })
-        | Schema::Uuid(UuidSchema::Fixed(FixedSchema { name, .. }))
-        | Schema::Decimal(DecimalSchema {
-            inner: InnerDecimalSchema::Fixed(FixedSchema { name, .. }),
-            ..
-        })
-        | Schema::Duration(FixedSchema { name, .. }) => {
-            let fully_qualified_name = name.fully_qualified_name(enclosing_namespace).into_owned();
-            if names.contains_key(&fully_qualified_name)
-                || known_schemata.contains_key(&fully_qualified_name)
-            {
-                Err(Details::AmbiguousSchemaDefinition(fully_qualified_name).into())
-            } else {
-                names.insert(fully_qualified_name, schema);
-                Ok(())
-            }
-        }
-        Schema::Record(RecordSchema { name, fields, .. }) => {
-            let fully_qualified_name = name.fully_qualified_name(enclosing_namespace).into_owned();
-            if names.contains_key(&fully_qualified_name)
-                || known_schemata.contains_key(&fully_qualified_name)
-            {
-                Err(Details::AmbiguousSchemaDefinition(fully_qualified_name).into())
-            } else {
-                let record_namespace = fully_qualified_name.namespace().map(ToString::to_string);
-                names.insert(fully_qualified_name, schema);
-                for field in fields {
-                    resolve_names(
-                        &field.schema,
-                        names,
-                        record_namespace.as_deref(),
-                        known_schemata,
-                    )?
-                }
-                Ok(())
-            }
-        }
-        Schema::Ref { name } => {
-            let fully_qualified_name = name.fully_qualified_name(enclosing_namespace);
-            if names.contains_key(&fully_qualified_name)
-                || known_schemata.contains_key(&fully_qualified_name)
-            {
-                Ok(())
-            } else {
-                Err(Details::SchemaResolutionError(fully_qualified_name.into_owned()).into())
-            }
-        }
-        _ => Ok(()),
+/// NOTE: this will copy the schema, and is therefore not the most performant option
+impl TryFrom<&Schema> for ResolvedSchema{
+    type Error = Error;
+
+    fn try_from(schema: &Schema) -> AvroResult<Self> {
+        let schema = schema.clone();
+        let with_symbols : SchemaWithSymbols = schema.into();
+        let [resolved_schema] = ResolvedSchema::from_with_symbols_array([with_symbols], Vec::new())?;
+        Ok(resolved_schema)
     }
 }
 
-pub fn resolve_names_with_schemata<'s, 'n>(
-    schemata: impl IntoIterator<Item = &'s Schema>,
-    names: &mut NamesRef<'s>,
-    enclosing_namespace: NamespaceRef,
-    known_schemata: &NamesRef<'n>,
-) -> AvroResult<()> {
-    for schema in schemata {
-        resolve_names(schema, names, enclosing_namespace, known_schemata)?;
+//impl<'a> TryFrom<UnionSchema> for ResolvedUnion<'a>{ // KTODO: is this something I should do??
+//    type Error = Error;
+//
+//    fn try_from(value: UnionSchema) -> Result<Self, Self::Error> {
+//        let [resolved] = ResolvedSchema::from_raw_schema_array([&Schema::Union(value)], vec![])?;
+//        let node = ResolvedNode::new(&resolved);
+//        match node {
+//            ResolvedNode::Union(resolved_union) => {resolved_union},
+//            _ => unreachable!()
+//        }
+//    }
+//}
+
+/// trait for implementing a custom schema name resolver. For instance this
+/// could be used to create resolvers that lookup schema names
+/// from a shcema registry.
+pub trait Resolver{
+    fn find_schema(&mut self, name: &Arc<Name>) -> Result<SchemaWithSymbols, String>;
+}
+
+pub struct DefaultResolver{}
+impl Resolver for DefaultResolver{
+    fn find_schema(&mut self, _name: &Arc<Name>) -> Result<SchemaWithSymbols, String> {
+       Err(String::from("Definition not found, no custom resolver was given for ResolutionContext"))
     }
-    Ok(())
+}
+
+impl DefaultResolver{
+    pub fn new()->Self{
+        DefaultResolver{}
+    }
+}
+
+fn compare_schema_with_context(schema_one: &Schema, schema_two: &Schema, context_one: &NameMap, context_two: &NameMap, dangling_one: &NameSet, dangling_two: &NameSet) -> bool{
+    if dangling_one != dangling_two{
+        return false;
+    }
+
+    // verify the provided definitions are the same:
+    let one_contains_two = context_one.keys().fold(true, |acc, val|{acc && context_two.contains_key(val)});
+    let two_contains_one = context_two.keys().fold(true, |acc, val|{acc && context_one.contains_key(val)});
+
+    if !(one_contains_two && two_contains_one){
+        return false
+    }
+
+    // we now know that the two contexts claim to define the same set of names, lets verify
+
+    if context_one.iter().fold(true, |acc, (name, schema)|{acc &&
+        schema.as_ref() == context_two.get(name).unwrap().as_ref()}) {
+        return false
+    }
+
+    schema_one == schema_two
+
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ResolvedOwnedSchema, ResolvedSchema};
+    use super::{ResolvedSchema};
     use crate::{
         Schema,
-        schema::{Name, NamesRef},
+        schema::{Name},
     };
     use apache_avro_test_helper::TestResult;
-    use std::collections::HashMap;
 
     #[test]
     fn avro_3448_test_proper_resolution_inner_record_inherited_namespace() -> TestResult {
@@ -267,8 +842,7 @@ mod tests {
           ]
         }
         "#;
-        let schema = Schema::parse_str(schema)?;
-        let rs = ResolvedSchema::new(&schema)?;
+        let [rs] = ResolvedSchema::from_str_array_only([schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.inner_record_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -308,8 +882,7 @@ mod tests {
           ]
         }
         "#;
-        let schema = Schema::parse_str(schema)?;
-        let rs = ResolvedSchema::new(&schema)?;
+        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.inner_record_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -344,8 +917,7 @@ mod tests {
           ]
         }
         "#;
-        let schema = Schema::parse_str(schema)?;
-        let rs = ResolvedSchema::new(&schema)?;
+        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.inner_enum_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -380,8 +952,7 @@ mod tests {
           ]
         }
         "#;
-        let schema = Schema::parse_str(schema)?;
-        let rs = ResolvedSchema::new(&schema)?;
+        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.inner_enum_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -416,8 +987,7 @@ mod tests {
           ]
         }
         "#;
-        let schema = Schema::parse_str(schema)?;
-        let rs = ResolvedSchema::new(&schema)?;
+        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.inner_fixed_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -452,8 +1022,7 @@ mod tests {
           ]
         }
         "#;
-        let schema = Schema::parse_str(schema)?;
-        let rs = ResolvedSchema::new(&schema)?;
+        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.inner_fixed_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -494,8 +1063,7 @@ mod tests {
           ]
         }
         "#;
-        let schema = Schema::parse_str(schema)?;
-        let rs = ResolvedSchema::new(&schema)?;
+        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "inner_space.inner_record_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -531,8 +1099,7 @@ mod tests {
           ]
         }
         "#;
-        let schema = Schema::parse_str(schema)?;
-        let rs = ResolvedSchema::new(&schema)?;
+        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "inner_space.inner_enum_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -568,8 +1135,7 @@ mod tests {
           ]
         }
         "#;
-        let schema = Schema::parse_str(schema)?;
-        let rs = ResolvedSchema::new(&schema)?;
+        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "inner_space.inner_fixed_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -621,8 +1187,7 @@ mod tests {
           ]
         }
         "#;
-        let schema = Schema::parse_str(schema)?;
-        let rs = ResolvedSchema::new(&schema)?;
+        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
         assert_eq!(rs.get_names().len(), 3);
         for s in [
             "space.record_name",
@@ -679,8 +1244,7 @@ mod tests {
           ]
         }
         "#;
-        let schema = Schema::parse_str(schema)?;
-        let rs = ResolvedSchema::new(&schema)?;
+        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
         assert_eq!(rs.get_names().len(), 3);
         for s in [
             "space.record_name",
@@ -738,8 +1302,7 @@ mod tests {
           ]
         }
         "#;
-        let schema = Schema::parse_str(schema)?;
-        let rs = ResolvedSchema::new(&schema)?;
+        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
         assert_eq!(rs.get_names().len(), 3);
         for s in [
             "space.record_name",
@@ -783,8 +1346,7 @@ mod tests {
           ]
         }
         "#;
-        let schema = Schema::parse_str(schema)?;
-        let rs = ResolvedSchema::new(&schema)?;
+        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.in_array_record"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -824,8 +1386,7 @@ mod tests {
           ]
         }
         "#;
-        let schema = Schema::parse_str(schema)?;
-        let rs = ResolvedSchema::new(&schema)?;
+        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.in_map_record"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -862,7 +1423,7 @@ mod tests {
         }
         "#;
         let schema = Schema::parse_str(schema)?;
-        let rs = ResolvedSchema::new(&schema)?;
+        let [rs] = ResolvedSchema::from_schema_array_only([&schema])?;
 
         // confirm we have expected 2 full-names
         assert_eq!(rs.get_names().len(), 2);
@@ -906,7 +1467,7 @@ mod tests {
         }
         "#;
         let schema = Schema::parse_str(schema)?;
-        let rs = ResolvedSchema::new(&schema)?;
+        let [rs] = ResolvedSchema::from_schema_array_only([&schema])?;
 
         // confirm we have expected 2 full-names
         assert_eq!(rs.get_names().len(), 2);
@@ -924,8 +1485,7 @@ mod tests {
 
     #[test]
     fn avro_rs_339_schema_ref_uuid() -> TestResult {
-        let schema = Schema::parse_str(
-            r#"{
+        let schema = r#"{
             "name": "foo",
             "type": "record",
             "fields": [
@@ -943,18 +1503,15 @@ mod tests {
                     "type": "bar"
                 }
             ]
-        }"#,
-        )?;
-        let _resolved = ResolvedSchema::new(&schema)?;
-        let _resolved_owned = ResolvedOwnedSchema::try_from(schema)?;
+        }"#;
+        let _resolved = ResolvedSchema::from_str_array_only([&schema])?;
 
         Ok(())
     }
 
     #[test]
     fn avro_rs_339_schema_ref_decimal() -> TestResult {
-        let schema = Schema::parse_str(
-            r#"{
+        let schema = r#"{
             "name": "foo",
             "type": "record",
             "fields": [
@@ -974,18 +1531,15 @@ mod tests {
                     "type": "bar"
                 }
             ]
-        }"#,
-        )?;
-        let _resolved = ResolvedSchema::new(&schema)?;
-        let _resolved_owned = ResolvedOwnedSchema::try_from(schema)?;
+        }"#;
+        let _resolved = ResolvedSchema::from_str_array_only([&schema])?;
 
         Ok(())
     }
 
     #[test]
     fn avro_rs_444_do_not_allow_duplicate_names_in_known_schemata() -> TestResult {
-        let schema = Schema::parse_str(
-            r#"{
+        let schema = r#"{
             "name": "foo",
             "type": "record",
             "fields": [
@@ -1014,13 +1568,16 @@ mod tests {
                     }
                 }
             ]
-        }"#,
-        )?;
+        }"#;
 
-        let mut known_schemata: NamesRef = HashMap::default();
-        known_schemata.insert("duplicated_name".try_into()?, &Schema::Boolean);
+        let other_schema = r#"{
+                "name": "duplicated_name",
+                "type": "enum",
+                "symbols": ["A", "B", "C"]
 
-        let result = ResolvedSchema::new_with_known_schemata(vec![&schema], None, &known_schemata)
+        }"#;
+
+        let result = ResolvedSchema::from_str_array([&schema],vec![&other_schema])
             .unwrap_err();
 
         assert_eq!(

--- a/avro/src/schema/resolve.rs
+++ b/avro/src/schema/resolve.rs
@@ -21,12 +21,11 @@ use serde::Serialize;
 use serde_json::Value as JsonValue;
 use strum::Display;
 
-use crate::schema::{Aliases, ArraySchema, DecimalSchema, Documentation, EnumSchema,
-            FixedSchema, MapSchema, Name, NameMap, NameSet, RecordField, RecordSchema, Schema,
-            SchemaKind, SchemaWithSymbols, UnionSchema, UuidSchema};
+use crate::schema::{Aliases, ArraySchema, DecimalSchema, DefaultToResolve, Documentation, EnumSchema, FixedSchema, MapSchema, Name, NameMap, NameSet, RecordField, RecordSchema, Schema, SchemaKind, SchemaWithSymbols, UnionSchema, UuidSchema, unravel_inner};
 use crate::{AvroResult, types};
 use crate::error::{Details,Error};
 use std::collections::BTreeMap;
+use std::fmt::Debug;
 use std::{collections::{HashMap, HashSet}, sync::Arc, iter::once};
 
 /// a map of names and definitions that is consistent: that is, we have all named schemata refered
@@ -38,14 +37,6 @@ impl ResolvedContext{
     /// gets the resolved context from a `ResolvedSchema`
     pub fn from_resolved_schema(resolved_schema : &ResolvedSchema) -> ResolvedContext{
         resolved_schema.context.clone()
-    }
-
-    pub fn from_str_array<const N : usize, S : AsRef<str>>(to_resolve: [S; N] , additional: impl IntoIterator<Item = S>) -> AvroResult<[ResolvedSchema; N]>{
-        todo!()
-    }
-
-    pub fn from_str_array_with_resolver<const N : usize, S : AsRef<str>>(to_resolve: [S; N] , additional: impl IntoIterator<Item = S>) -> AvroResult<[ResolvedSchema; N]>{
-        todo!()
     }
 
     pub fn empty() -> ResolvedContext{
@@ -73,10 +64,10 @@ impl ResolvedContext{
     //}
 
     // checks that the provided definition names do not conflict with existing definitions.
-    fn check_if_conflicts<'a>(defined_names: &NameMap, names: impl Iterator<Item = &'a Arc<Name> >) -> AvroResult<()>{
+    fn check_if_conflicts<'a>(defined_names: &NameMap, added: &NameMap) -> AvroResult<()>{
         let mut conflicting_fullnames : Vec<String> = Vec::new();
-        for name in names{
-            if defined_names.contains_key(name){
+        for (name, schema) in added{
+            if defined_names.contains_key(name) && Some(schema) != defined_names.get(name){
                 conflicting_fullnames.push(name.fullname(Option::None));
             }
         }
@@ -88,39 +79,108 @@ impl ResolvedContext{
         }
     }
 
-    pub fn new_context(schemata: impl Iterator<Item = SchemaWithSymbols>) -> AvroResult<ResolvedContext>{
-        Self::new_context_with_resolver(schemata, &mut DefaultResolver::new())
+    //pub fn new_context(schemata: impl Iterator<Item = SchemaWithSymbols>) -> AvroResult<ResolvedContext>{
+    //    Self::new_context_with_resolver(schemata, &mut DefaultResolver::new())
+    //}
+
+    /// KTODO: docs
+    pub fn new_context_with_resolver<'s>(schemata: &Vec<SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<ResolvedContext>{
+        let mut context : NameMap = HashMap::new();
+        let mut defaults : Vec<Arc<Vec<DefaultToResolve>>> = Vec::new();
+        Self::add_to_context(&mut context, &mut defaults, schemata, resolver)?;
+        let context = ResolvedContext(context);
+        Self::check_defaults(&defaults, &context)?;
+        Ok(context)
     }
 
-    pub fn new_context_with_resolver(schemata: impl Iterator<Item = SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<ResolvedContext>{
+    /// KTODO: docs
+    pub fn needed_context_with_resolver<'s>(schema: &'s SchemaWithSymbols, schemata: &Vec<SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<ResolvedContext>{
         let mut context : NameMap = HashMap::new();
-        Self::add_to_context(&mut context, schemata, resolver)?;
-        Ok(ResolvedContext(context))
+        let mut defaults : Vec<Arc<Vec<DefaultToResolve>>> = Vec::new();
+        Self::check_if_schemata_redefine_names(schemata.iter())?;
+        Self::add_needed_to_context(schema, &mut context, &mut defaults ,schemata, resolver)?;
+        let context = ResolvedContext(context);
+        Self::check_defaults(&defaults, &context)?;
+        Ok(context)
     }
 
     // add the with_symbols into the defined_names and check for naming conflicts.
     // If we can't resolved from the local context, we will ask the resolved if it can find
     // the schema we need.
-    fn add_to_context(defined_names: &mut NameMap, schemata: impl Iterator<Item = SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<()>{
+    fn add_to_context(defined_names: &mut NameMap, defaults: &mut Vec<Arc<Vec<DefaultToResolve>>>, schemata: &Vec<SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<()>{
         let mut references : HashSet<Arc<Name>> = HashSet::new();
 
         for schema_with_symbol in schemata{
-            Self::check_if_conflicts(&defined_names, schema_with_symbol.defined_names.keys())?;
-            defined_names.extend(schema_with_symbol.defined_names);
-            references.extend(schema_with_symbol.referenced_names);
+            defaults.push(Arc::clone(&schema_with_symbol.field_defaults_to_resolve));
+            Self::check_if_conflicts(&defined_names, &schema_with_symbol.defined_names)?;
+            defined_names.extend(schema_with_symbol.defined_names.clone());
+            references.extend(schema_with_symbol.referenced_names.clone());
         }
 
         for schema_ref in references{
-            Self::resolve_name(defined_names, &schema_ref, resolver)?;
+            Self::resolve_name(defined_names, defaults, &schema_ref, resolver)?;
         }
 
         Ok(())
 
     }
 
+    /// KTODO: docs
+    fn add_needed_to_context(schema: &SchemaWithSymbols, defined_names: &mut NameMap, defaults: &mut Vec<Arc<Vec<DefaultToResolve>>>, schemata: &Vec<SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<()>{
+        defined_names.extend(schema.defined_names.clone());
+        defaults.push(Arc::clone(&schema.field_defaults_to_resolve));
+        let mut worklist: HashSet<Arc<Name>> = schema.referenced_names.clone();
+
+        while let Some(needed) = Self::take_one(&mut worklist) {
+            if defined_names.contains_key(&needed) {
+                continue;
+            }
+
+            if let Some(provider) = schemata.iter().find(|s| s.defined_names.contains_key(&needed)) {
+                Self::check_if_conflicts(defined_names, &provider.defined_names)?;
+                defined_names.extend(provider.defined_names.clone());
+                defaults.push(Arc::clone(&provider.field_defaults_to_resolve));
+                worklist.extend(provider.referenced_names.clone());
+            } else {
+                Self::resolve_name(defined_names, defaults, &needed, resolver)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn take_one(set: &mut HashSet<Arc<Name>>) -> Option<Arc<Name>> {
+        let name = set.iter().next()?.clone();
+        set.remove(&name);
+        Some(name)
+    }
+
+    // checks if the list we have provided locally has duplicate definitions for
+    // a given name.
+    fn check_if_schemata_redefine_names<'s>(schemata: impl IntoIterator<Item = &'s SchemaWithSymbols>)-> AvroResult<()>{
+        let mut defined_names : HashMap<&Arc<Name>, &Arc<Schema>> = HashMap::new();
+
+        let mut conflicting_fullnames : Vec<String> = Vec::new();
+
+        for schema in schemata{
+            for (name, schema) in &schema.defined_names{
+                if defined_names.contains_key(name) && Some(schema) != defined_names.get(name).map(|v| &**v){
+                    conflicting_fullnames.push(name.fullname(Option::None));
+                }
+            }
+            defined_names.extend(&schema.defined_names);
+        }
+
+        if conflicting_fullnames.len() == 0 {
+            Ok(())
+        }else{
+            Err(Details::MultipleNameCollision(conflicting_fullnames).into())
+        }
+    }
+
     // attempt to resolve the schema name, first from the known schema definitions, and if that
     // fails, from the provided resolver.
-    fn resolve_name(defined_names: &mut NameMap, name: &Arc<Name>, resolver: &mut impl Resolver) -> AvroResult<()>{
+    fn resolve_name(defined_names: &mut NameMap, defaults: &mut Vec<Arc<Vec<DefaultToResolve>>>, name: &Arc<Name>, resolver: &mut impl Resolver) -> AvroResult<()>{
         // first, check if can resolve internally
         if defined_names.contains_key(name) {
             return Ok(());
@@ -136,7 +196,7 @@ impl ResolvedContext{
                             Vec::from_iter(schema_with_symbols.defined_names.keys().map(|key| {key.as_ref().clone()}))).into())
                 }
                 // matches, lets add this as a schemata that we should have, and recurse in
-                Self::add_to_context(defined_names, once(schema_with_symbols), resolver)?;
+                Self::add_to_context(defined_names, defaults, &vec![schema_with_symbols], resolver)?;
                 Ok(())
             },
             Err(msg) => {
@@ -144,164 +204,242 @@ impl ResolvedContext{
             }
         }
     }
+
+    fn check_defaults(default_vecs: &Vec<Arc<Vec<DefaultToResolve>>>, context: &ResolvedContext) -> AvroResult<()>{
+        for default_vec in default_vecs{
+            for default in default_vec.as_ref(){
+                let avro_value = types::Value::try_from(default.json.clone())?;
+                       avro_value.resolve_internal(ResolvedNode::new(&ResolvedSchema{
+                           stub: Arc::new(default.schema.clone()), // TODO: would be nice to get rid of clones here!
+                           context: context.clone()
+                       })).or_else(|error| {
+                           Err(Details::DefaultValidationWithReason {
+                               record_name: default.record_name.clone(),
+                               field_name: default.field_name.clone(),
+                               value: default.json.clone() ,
+                               schema: default.schema.clone(),
+                               reason: error.to_string() })}
+                           )?;
+            }
+        }
+
+        Ok(())
+    }
 }
-/// contians a schema with all of the schema
-/// definitions it needs to be completely resolved
-/// This type is a promise from the API that each named
-/// type in the schema has exactly one unique definition
-/// and every named reference in the schema can be uniquely
-/// resolved to one of these definitions.
-/// ResolvedSchema wraps Arc references and is therefore easy to clone.
+/// Trait for types that can be converted into a [`SchemaWithSymbols`] for schema resolution.
+///
+/// Implemented for:
+/// - `&str`, `String`, `&String` (parses JSON schema string)
+/// - `&Schema` (clones and converts)
+/// - `SchemaWithSymbols` (identity)
+pub trait IntoSchemaWithSymbols {
+    fn into_schema_with_symbols(self) -> AvroResult<SchemaWithSymbols>;
+}
+
+impl<S: AsRef<str>> IntoSchemaWithSymbols for S {
+    fn into_schema_with_symbols(self) -> AvroResult<SchemaWithSymbols> {
+        SchemaWithSymbols::parse_str(self.as_ref())
+    }
+}
+
+impl IntoSchemaWithSymbols for &Schema {
+    fn into_schema_with_symbols(self) -> AvroResult<SchemaWithSymbols> {
+        Ok(self.clone().into())
+    }
+}
+
+impl IntoSchemaWithSymbols for SchemaWithSymbols {
+    fn into_schema_with_symbols(self) -> AvroResult<SchemaWithSymbols> {
+        Ok(self)
+    }
+}
+
+/// Builder for resolving one or more schemas into [`ResolvedSchema`] values.
+///
+/// Created via [`ResolvedSchema::resolve()`]. Accepts schema strings, `&Schema` references,
+/// or [`SchemaWithSymbols`] values as input — all via the [`IntoSchemaWithSymbols`] trait.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// // Resolve a single schema:
+/// let resolved = ResolvedSchema::resolve().build_one(schema_str)?;
+///
+/// // Resolve with additional context schemas:
+/// let [resolved] = ResolvedSchema::resolve()
+///     .additional(vec![context_schema])?
+///     .build_array([main_schema])?;
+///
+/// // With a custom resolver (e.g. schema registry):
+/// let [resolved] = ResolvedSchema::resolve()
+///     .build_array_with_resolver([schema], &mut my_resolver)?;
+/// ```
+pub struct ResolvedSchemaBuilder {
+    additional: Vec<SchemaWithSymbols>,
+}
+
+impl ResolvedSchemaBuilder {
+    fn new() -> Self {
+        ResolvedSchemaBuilder {
+            additional: Vec::new(),
+        }
+    }
+
+    /// Provide additional schemas that participate in name resolution but are not themselves
+    /// returned. Accepts anything that implements [`IntoSchemaWithSymbols`]: JSON strings,
+    /// `&Schema` references, or `SchemaWithSymbols` values.
+    pub fn additional(mut self, additional: impl IntoIterator<Item = impl IntoSchemaWithSymbols>) -> AvroResult<Self> {
+        self.additional = additional
+            .into_iter()
+            .map(|s| s.into_schema_with_symbols())
+            .collect::<AvroResult<Vec<_>>>()?;
+        Ok(self)
+    }
+
+    /// Resolve a single schema. This is the simplest entry point.
+    pub fn build_one(self, to_resolve: impl IntoSchemaWithSymbols) -> AvroResult<ResolvedSchema> {
+        let [result] = self.build_array([to_resolve])?;
+        Ok(result)
+    }
+
+    /// Resolve a single schema with a custom [`Resolver`] for external name lookup.
+    pub fn build_one_with_resolver(self, to_resolve: impl IntoSchemaWithSymbols, resolver: &mut impl Resolver) -> AvroResult<ResolvedSchema> {
+        let [result] = self.build_array_with_resolver([to_resolve], resolver)?;
+        Ok(result)
+    }
+
+    /// Resolve a fixed-size array of schemas, preserving the count at compile time.
+    /// All elements must be the same type (e.g. all `&str` or all `&Schema`).
+    pub fn build_array<const N: usize>(self, to_resolve: [impl IntoSchemaWithSymbols; N]) -> AvroResult<[ResolvedSchema; N]> {
+        self.build_array_with_resolver(to_resolve, &mut DefaultResolver::new())
+    }
+
+    /// Resolve a fixed-size array of schemas with a custom [`Resolver`].
+    pub fn build_array_with_resolver<const N: usize>(self, to_resolve: [impl IntoSchemaWithSymbols; N], resolver: &mut impl Resolver) -> AvroResult<[ResolvedSchema; N]> {
+        let converted: AvroResult<Vec<SchemaWithSymbols>> = to_resolve
+            .into_iter()
+            .map(|s| s.into_schema_with_symbols())
+            .collect();
+        let converted = converted?;
+        let mut iter = converted.into_iter();
+        let to_resolve_array: [SchemaWithSymbols; N] = std::array::from_fn(|_| iter.next().unwrap());
+        ResolvedSchema::resolve_symbols_array(to_resolve_array, self.additional, resolver)
+    }
+
+    /// Resolve a dynamic list of schemas.
+    pub fn build_list(self, to_resolve: impl IntoIterator<Item = impl IntoSchemaWithSymbols>) -> AvroResult<Vec<ResolvedSchema>> {
+        self.build_list_with_resolver(to_resolve, &mut DefaultResolver::new())
+    }
+
+    /// Resolve a dynamic list of schemas with a custom [`Resolver`].
+    pub fn build_list_with_resolver(self, to_resolve: impl IntoIterator<Item = impl IntoSchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<Vec<ResolvedSchema>> {
+        let converted: AvroResult<Vec<SchemaWithSymbols>> = to_resolve
+            .into_iter()
+            .map(|s| s.into_schema_with_symbols())
+            .collect();
+        ResolvedSchema::resolve_symbols_list(converted?, self.additional, resolver)
+    }
+}
+
+/// Contains a schema with all of the schema definitions it needs to be completely resolved.
+///
+/// This type is a promise from the API that each named type in the schema has exactly one
+/// unique definition and every named reference in the schema can be uniquely resolved to
+/// one of these definitions.
+///
+/// `ResolvedSchema` wraps `Arc` references and is therefore cheap to clone.
+///
+/// # Construction
+///
+/// Use [`ResolvedSchema::resolve()`] to get a [`ResolvedSchemaBuilder`], or
+/// [`ResolvedSchema::parse_str()`] for the single-schema convenience method.
+///
+/// ```rust,ignore
+/// // Single schema:
+/// let resolved = ResolvedSchema::parse_str(r#"{"type":"record", ...}"#)?;
+///
+/// // Multiple schemas with context:
+/// let [a, b] = ResolvedSchema::resolve()
+///     .additional(vec![context])?
+///     .build_array([schema_a, schema_b])?;
+/// ```
 #[derive(Debug,Clone)]
 pub struct ResolvedSchema{
-    pub schema: Arc<Schema>, //KTODO maybe this should take a SchemaWithSymbols? Or a
-                                   //reference to SchemaWithSymbols?
+    pub stub: Arc<Schema>,
     context: ResolvedContext
 }
 
 impl ResolvedSchema{
 
-   // KTODO: do we want a function like this??
-   // pub fn new(schema: SchemaWithSymbols) -> AvroResult<ResolvedSchema>{
-   //     let [resolved_schema] = ResolvedSchema::from_schemata_array([schema], vec![])?;
-   //     return Ok(resolved_schema)
-   // }
+    /// Start building a schema resolution. Returns a [`ResolvedSchemaBuilder`].
+    pub fn resolve() -> ResolvedSchemaBuilder {
+        ResolvedSchemaBuilder::new()
+    }
+
+    pub fn unravel(&self) -> Schema{
+        let complete : CompleteSchema = self.into();
+        complete.0
+    }
 
     pub fn new_empty() -> Self{
        Schema::Null.try_into().unwrap()
     }
 
-    // methods that take directly from a string
-
-    // convenience method since this is a common scenario
+    /// Parse and resolve a single JSON schema string. Convenience for
+    /// `ResolvedSchema::resolve().build_one(string)`.
     pub fn parse_str(string: impl AsRef<str>) -> AvroResult<ResolvedSchema>{
-        let [resolved] = Self::from_str_array_only([string])?;
-        return Ok(resolved)
+        Self::resolve().build_one(string)
     }
 
-    // the rest!
+    // ----- internal implementation methods -----
 
-    pub fn from_str_array_only<const N : usize, S : AsRef<str>>(to_resolve: [S; N]) -> AvroResult<[ResolvedSchema; N]>{
-        let empt : Vec<&str> = Vec::new();
-        Self::from_str_array_with_resolver(to_resolve, empt, &mut DefaultResolver::new())
-    }
+    fn resolve_symbols_array<const N : usize>(to_resolve: [SchemaWithSymbols; N], additional: Vec<SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<[ResolvedSchema; N]> {
 
-    pub fn from_str_array<const N : usize, S : AsRef<str>>(to_resolve: [S; N] , additional: impl IntoIterator<Item = S>) -> AvroResult<[ResolvedSchema; N]>{
-        Self::from_str_array_with_resolver(to_resolve, additional, &mut DefaultResolver::new())
-    }
+        let mut all_schemata : Vec<SchemaWithSymbols> = to_resolve.clone().into();
+        all_schemata.extend(additional);
 
-    pub fn from_str_array_with_resolver<const N : usize>(to_resolve:  [impl AsRef<str>; N] , additional: impl IntoIterator<Item = impl AsRef<str>> , resolver: &mut impl Resolver) -> AvroResult<[ResolvedSchema; N]>{
-        let to_resolve = SchemaWithSymbols::parse_array(to_resolve)?;
-        let additional = SchemaWithSymbols::parse_list(additional)?;
-        let resolved = Self::from_with_symbols_array_with_resolver(to_resolve, additional.into_iter(), resolver)?;
-        Ok(resolved)
-    }
+        let contexts : Vec<AvroResult<ResolvedContext>> = to_resolve.iter().map(|schema|{
+            ResolvedContext::needed_context_with_resolver(schema , &all_schemata, resolver)
+        }).collect();
 
-    pub fn from_str_list<T : AsRef<str>>(to_resolve: Vec<T> , additional: Vec<T>) -> AvroResult<Vec<ResolvedSchema>>{
-        Self::from_str_list_with_resolver(to_resolve, additional, &mut DefaultResolver::new())
-    }
+        let context_errs : Vec<_> = contexts.iter().filter_map(|context|{context.as_ref().err()}).collect();
 
-    pub fn from_str_list_with_resolver<T : AsRef<str>>(to_resolve: Vec<T> , additional: Vec<T>, resolver: &mut impl Resolver) -> AvroResult<Vec<ResolvedSchema>>{
-        let to_resolve_len : usize = to_resolve.len();
-        let schemata_with_symbols = SchemaWithSymbols::parse_list(to_resolve.into_iter().chain(additional.into_iter()))?;
-        let mut resolved = Self::from_with_symbols_list_with_resolver(schemata_with_symbols, Vec::new(), resolver)?;
-        Ok(resolved.drain(0..to_resolve_len).collect())
-    }
-
-    // methods that take directly from schema
-    // this is not the recommended way of forming a ResolvedSchema
-
-    pub fn from_schema_array_only<'a,const N: usize>(to_resolve: [&Schema;N]) -> AvroResult<[ResolvedSchema; N]>{
-        Self::from_schema_array_with_resolver(to_resolve, Vec::new(), &mut DefaultResolver::new())
-    }
-
-    pub fn from_schema_array<'a,const N: usize>(to_resolve: [&Schema;N], schemata: impl IntoIterator<Item = &'a Schema>) -> AvroResult<[ResolvedSchema; N]>{
-        Self::from_schema_array_with_resolver(to_resolve, schemata, &mut DefaultResolver::new())
-    }
-
-    pub fn from_schema_array_with_resolver<'a,const N: usize>(to_resolve: [&Schema;N], schemata: impl IntoIterator<Item = &'a Schema>, resolver: &mut impl Resolver) -> AvroResult<[ResolvedSchema; N]>{
-        let to_resolve_with_symbols : [SchemaWithSymbols; N] = std::array::from_fn(|i|{
-            (*to_resolve.get(i).unwrap()).clone().into()
-        });
-        ResolvedSchema::from_with_symbols_array_with_resolver(to_resolve_with_symbols,
-            schemata.into_iter().map(|schema| schema.clone().into()), resolver)
-    }
-
-    pub fn from_schema_list<'a>(to_resolve: impl IntoIterator<Item = &'a Schema>, schemata: impl IntoIterator<Item = &'a Schema>) -> AvroResult<Vec<ResolvedSchema>>{
-        Self::from_schema_list_with_resolver(to_resolve, schemata, &mut DefaultResolver::new())
-    }
-    pub fn from_schema_list_with_resolver<'a>(to_resolve: impl IntoIterator<Item = &'a Schema>, schemata: impl IntoIterator<Item = &'a Schema>, resolver: &mut impl Resolver) -> AvroResult<Vec<ResolvedSchema>>{
-        let to_resolve_with_symbols : Vec<SchemaWithSymbols> = to_resolve.into_iter().cloned().map(|schema|{schema.into()}).collect();
-        ResolvedSchema::from_with_symbols_list_with_resolver(to_resolve_with_symbols,
-            schemata.into_iter().map(|schema| schema.clone().into()), resolver)
-    }
-
-    // methods that form a resolution context from `SchemaWithSymbols`
-    // this is the reccomended way of creating a `ResolvedSchema`
-    //
-    pub fn from_with_symbols_array_only<const N : usize>(to_resolve: [SchemaWithSymbols;N]) -> AvroResult<[ResolvedSchema; N]>{
-        Self::from_with_symbols_array_with_resolver(to_resolve, Vec::new(), &mut DefaultResolver::new())
-    }
-
-    pub fn from_with_symbols_array<const N : usize>(to_resolve: [SchemaWithSymbols;N], schemata_with_symbols: impl IntoIterator<Item = SchemaWithSymbols>) -> AvroResult<[ResolvedSchema; N]>{
-        Self::from_with_symbols_array_with_resolver(to_resolve, schemata_with_symbols, &mut DefaultResolver::new())
-    }
-
-    pub fn from_with_symbols_list(to_resolve: impl IntoIterator<Item = SchemaWithSymbols>, schemata_with_symbols: impl IntoIterator<Item = SchemaWithSymbols>) -> AvroResult<Vec<ResolvedSchema>>{
-        Self::from_with_symbols_list_with_resolver(to_resolve, schemata_with_symbols, &mut DefaultResolver::new())
-    }
-
-    /// Takes two vectors of schemata. Both of these vectors are checked that they form a complete
-    /// schema context in which there every named schema has a unique defition and every schema
-    /// reference can be uniquely resolved to one of these definitions. The first vector of
-    /// schemata are those in which we want the associated ResolvedSchema forms of the schema to be
-    /// returned. The second vector are schemata that are used for schema resolution, but do not
-    /// have their ResolvedSchema form returned.
-    pub fn from_with_symbols_array_with_resolver<const N : usize>(to_resolve: [SchemaWithSymbols; N], schemata_with_symbols: impl IntoIterator<Item = SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<[ResolvedSchema; N]> {
-
-        let context = ResolvedContext::new_context_with_resolver(to_resolve.clone().into_iter().chain(schemata_with_symbols), resolver)?;
-
-        // check defualts for each with_symbol
-        for with_symbol in to_resolve.iter(){
-            for (schema, value) in &with_symbol.field_defaults_to_resolve{
-               let avro_value = types::Value::try_from(value.clone())?;
-               avro_value.resolve_internal(ResolvedNode::new(&ResolvedSchema{
-                   schema: Arc::new(schema.clone()), // KTODO: this should be optimized away
-                   context: context.clone()
-               }))?;
-            }
+        if !context_errs.is_empty(){
+            let context_errs : Vec<_> = contexts.into_iter().filter_map(|context|{context.err()}).collect();
+            return Err(Details::ResolvedSchemaCreationError(context_errs).into())
         }
 
         let mut to_resolve_iter = to_resolve.into_iter();
+        let mut context_iter = contexts.into_iter().map(AvroResult::unwrap);
         Ok(std::array::from_fn(|_|{
             let with_symbol = to_resolve_iter.next().unwrap();
+            let context = context_iter.next().unwrap();
             ResolvedSchema{
-                schema: with_symbol.schema,
-                context: context.clone()
+                stub: with_symbol.stub,
+                context
             }
         }))
     }
 
-    pub fn from_with_symbols_list_with_resolver(to_resolve: impl IntoIterator<Item = SchemaWithSymbols>, schemata_with_symbols: impl IntoIterator<Item = SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<Vec<ResolvedSchema>> {
+    fn resolve_symbols_list(to_resolve: Vec<SchemaWithSymbols>, additional: Vec<SchemaWithSymbols>, resolver: &mut impl Resolver) -> AvroResult<Vec<ResolvedSchema>> {
 
-        let to_resolve : Vec<SchemaWithSymbols> = Vec::from_iter(to_resolve.into_iter());
+        let mut all_schemata = to_resolve.clone();
+        all_schemata.extend(additional);
+        let contexts : Vec<AvroResult<ResolvedContext>> = to_resolve.iter().map(|schema|{
+            ResolvedContext::needed_context_with_resolver(schema , &all_schemata, resolver)
+        }).collect();
 
-        let context = ResolvedContext::new_context_with_resolver(to_resolve.iter().cloned().chain(schemata_with_symbols), resolver)?;
+        let context_errs : Vec<_> = contexts.iter().filter_map(|context|{context.as_ref().err()}).collect();
 
-        // check defualts for each with_symbol
-        for with_symbol in to_resolve.iter(){
-            for (schema, value) in &with_symbol.field_defaults_to_resolve{
-               let avro_value = types::Value::try_from(value.clone())?;
-               avro_value.resolve_internal(ResolvedNode::new(&ResolvedSchema{
-                   schema: Arc::new(schema.clone()), // TODO: this should be optimized away
-                   context: context.clone()
-               }))?;
-            }
+        if !context_errs.is_empty(){
+            let context_errs : Vec<_> = contexts.into_iter().filter_map(|context|{context.err()}).collect();
+            return Err(Details::ResolvedSchemaCreationError(context_errs).into())
         }
 
-        Ok(to_resolve.into_iter().map(|schema_with_symbols|{ResolvedSchema{
-                schema: schema_with_symbols.schema,
-                context: context.clone()
+        let schema_and_context = to_resolve.into_iter().zip(contexts.into_iter());
+        Ok(schema_and_context.into_iter().map(|(schema_with_symbols, context)|{ResolvedSchema{
+                stub: schema_with_symbols.stub,
+                context: context.unwrap()
             }}).collect())
     }
 
@@ -408,7 +546,7 @@ pub enum ResolvedNode<'a>{
 /// the root definintion information with a reference into the schema.
 impl<'a> ResolvedNode<'a> {
    pub fn new(root: &'a ResolvedSchema)->ResolvedNode<'a>{
-       let schema = root.schema.as_ref();
+       let schema = root.stub.as_ref();
        Self::from_schema(schema, root)
    }
 
@@ -457,38 +595,34 @@ impl<'a> ResolvedNode<'a> {
    /// documentation
    pub fn get_resolved(&self) -> ResolvedSchema{
        match self {
-        ResolvedNode::Map(resolved_map) => ResolvedSchema{schema: resolved_map.schema.clone().into(), context: resolved_map.root.context.clone()},
-        ResolvedNode::Union(resolved_union) => ResolvedSchema{schema: resolved_union.schema.clone().into(), context: resolved_union.root.context.clone()},
-        ResolvedNode::Array(resolved_array) => ResolvedSchema{schema: resolved_array.schema.clone().into(), context: resolved_array.root.context.clone()},
-        ResolvedNode::Record(resolved_record) => ResolvedSchema{schema: resolved_record.schema.clone().into(), context: resolved_record.root.context.clone()},
-        ResolvedNode::Uuid(uuid_schema) => ResolvedSchema{schema: Schema::Uuid((*uuid_schema).clone()).into(), context: ResolvedContext::empty()},
-        ResolvedNode::Duration(fixed_schema) => ResolvedSchema{schema: Schema::Duration((*fixed_schema).clone()).into(), context: ResolvedContext::empty()},
-        ResolvedNode::Enum(enum_schema) => ResolvedSchema{schema: Schema::Enum((*enum_schema).clone()).into(), context: ResolvedContext::empty()},
-        ResolvedNode::Fixed(fixed_schema) => ResolvedSchema{schema: Schema::Fixed((*fixed_schema).clone()).into(), context: ResolvedContext::empty()},
-        ResolvedNode::Decimal(decimal_schema) => ResolvedSchema{schema: Schema::Decimal((*decimal_schema).clone()).into(), context: ResolvedContext::empty()},
-        ResolvedNode::Null => ResolvedSchema{schema: Schema::Null.into(), context: ResolvedContext::empty()},
-        ResolvedNode::Boolean => ResolvedSchema{schema: Schema::Boolean.into(), context: ResolvedContext::empty()},
-        ResolvedNode::Int => ResolvedSchema{schema: Schema::Int.into(), context: ResolvedContext::empty()},
-        ResolvedNode::Long => ResolvedSchema{schema: Schema::Long.into(), context: ResolvedContext::empty()},
-        ResolvedNode::Float => ResolvedSchema{schema: Schema::Float.into(), context: ResolvedContext::empty()},
-        ResolvedNode::Double => ResolvedSchema{schema: Schema::Double.into(), context: ResolvedContext::empty()},
-        ResolvedNode::Bytes => ResolvedSchema{schema: Schema::Bytes.into(), context: ResolvedContext::empty()},
-        ResolvedNode::String => ResolvedSchema{schema: Schema::String.into(), context: ResolvedContext::empty()},
-        ResolvedNode::BigDecimal => ResolvedSchema{schema: Schema::BigDecimal.into(), context: ResolvedContext::empty()},
-        ResolvedNode::Date => ResolvedSchema{schema: Schema::Date.into(), context: ResolvedContext::empty()},
-        ResolvedNode::TimeMillis => ResolvedSchema{schema: Schema::TimeMillis.into(), context: ResolvedContext::empty()},
-        ResolvedNode::TimeMicros => ResolvedSchema{schema: Schema::TimeMicros.into(), context: ResolvedContext::empty()},
-        ResolvedNode::TimestampMillis => ResolvedSchema{schema: Schema::TimestampMillis.into(), context: ResolvedContext::empty()},
-        ResolvedNode::TimestampMicros => ResolvedSchema{schema: Schema::TimestampMicros.into(), context: ResolvedContext::empty()},
-        ResolvedNode::TimestampNanos => ResolvedSchema{schema: Schema::TimestampNanos.into(), context: ResolvedContext::empty()},
-        ResolvedNode::LocalTimestampMillis => ResolvedSchema{schema: Schema::LocalTimestampMillis.into(), context: ResolvedContext::empty()},
-        ResolvedNode::LocalTimestampMicros => ResolvedSchema{schema: Schema::LocalTimestampMicros.into(), context: ResolvedContext::empty()},
-        ResolvedNode::LocalTimestampNanos => ResolvedSchema{schema: Schema::LocalTimestampNanos.into(), context: ResolvedContext::empty()},
+        ResolvedNode::Map(resolved_map) => ResolvedSchema{stub: resolved_map.schema.clone().into(), context: resolved_map.root.context.clone()},
+        ResolvedNode::Union(resolved_union) => ResolvedSchema{stub: resolved_union.schema.clone().into(), context: resolved_union.root.context.clone()},
+        ResolvedNode::Array(resolved_array) => ResolvedSchema{stub: resolved_array.schema.clone().into(), context: resolved_array.root.context.clone()},
+        ResolvedNode::Record(resolved_record) => ResolvedSchema{stub: resolved_record.schema.clone().into(), context: resolved_record.root.context.clone()},
+        ResolvedNode::Uuid(uuid_schema) => ResolvedSchema{stub: Schema::Uuid((*uuid_schema).clone()).into(), context: ResolvedContext::empty()},
+        ResolvedNode::Duration(fixed_schema) => ResolvedSchema{stub: Schema::Duration((*fixed_schema).clone()).into(), context: ResolvedContext::empty()},
+        ResolvedNode::Enum(enum_schema) => ResolvedSchema{stub: Schema::Enum((*enum_schema).clone()).into(), context: ResolvedContext::empty()},
+        ResolvedNode::Fixed(fixed_schema) => ResolvedSchema{stub: Schema::Fixed((*fixed_schema).clone()).into(), context: ResolvedContext::empty()},
+        ResolvedNode::Decimal(decimal_schema) => ResolvedSchema{stub: Schema::Decimal((*decimal_schema).clone()).into(), context: ResolvedContext::empty()},
+        ResolvedNode::Null => ResolvedSchema{stub: Schema::Null.into(), context: ResolvedContext::empty()},
+        ResolvedNode::Boolean => ResolvedSchema{stub: Schema::Boolean.into(), context: ResolvedContext::empty()},
+        ResolvedNode::Int => ResolvedSchema{stub: Schema::Int.into(), context: ResolvedContext::empty()},
+        ResolvedNode::Long => ResolvedSchema{stub: Schema::Long.into(), context: ResolvedContext::empty()},
+        ResolvedNode::Float => ResolvedSchema{stub: Schema::Float.into(), context: ResolvedContext::empty()},
+        ResolvedNode::Double => ResolvedSchema{stub: Schema::Double.into(), context: ResolvedContext::empty()},
+        ResolvedNode::Bytes => ResolvedSchema{stub: Schema::Bytes.into(), context: ResolvedContext::empty()},
+        ResolvedNode::String => ResolvedSchema{stub: Schema::String.into(), context: ResolvedContext::empty()},
+        ResolvedNode::BigDecimal => ResolvedSchema{stub: Schema::BigDecimal.into(), context: ResolvedContext::empty()},
+        ResolvedNode::Date => ResolvedSchema{stub: Schema::Date.into(), context: ResolvedContext::empty()},
+        ResolvedNode::TimeMillis => ResolvedSchema{stub: Schema::TimeMillis.into(), context: ResolvedContext::empty()},
+        ResolvedNode::TimeMicros => ResolvedSchema{stub: Schema::TimeMicros.into(), context: ResolvedContext::empty()},
+        ResolvedNode::TimestampMillis => ResolvedSchema{stub: Schema::TimestampMillis.into(), context: ResolvedContext::empty()},
+        ResolvedNode::TimestampMicros => ResolvedSchema{stub: Schema::TimestampMicros.into(), context: ResolvedContext::empty()},
+        ResolvedNode::TimestampNanos => ResolvedSchema{stub: Schema::TimestampNanos.into(), context: ResolvedContext::empty()},
+        ResolvedNode::LocalTimestampMillis => ResolvedSchema{stub: Schema::LocalTimestampMillis.into(), context: ResolvedContext::empty()},
+        ResolvedNode::LocalTimestampMicros => ResolvedSchema{stub: Schema::LocalTimestampMicros.into(), context: ResolvedContext::empty()},
+        ResolvedNode::LocalTimestampNanos => ResolvedSchema{stub: Schema::LocalTimestampNanos.into(), context: ResolvedContext::empty()},
        }
-   }
-
-   pub(crate) fn get_schema(&self) -> Schema{ // KTODO, maybe get rid of this for the future!!
-       self.get_resolved().schema.as_ref().clone()
    }
 }
 
@@ -549,8 +683,15 @@ impl<'a> ResolvedUnion<'a>{
         let value_schema_kind = SchemaKind::from(value);
         let resolved_nodes = self.resolve_schemas();
         if let Some(i) = self.get_variant_index(&value_schema_kind) {
-            // fast path
-            Some((i, resolved_nodes.get(i).unwrap().clone()))
+            // fast path KTODO double check this!
+            let variant_clone = resolved_nodes.get(i).unwrap().clone();
+            if let Ok(_) = value
+                .clone()
+                .resolve_internal(variant_clone.clone()){
+                Some((i, variant_clone))
+            }else{
+                None
+            }
         } else {
             // slow path (required for matching logical or named types)
             self.resolve_schemas().into_iter().enumerate().find(|(_, resolved_node)| {
@@ -586,6 +727,7 @@ impl<'a> ResolvedRecordField<'a>{
 
 /// this is a schema object that is "self contained" in that it contains all named definitions
 /// needed to encode/decode form this schema.
+#[derive(Debug)]
 pub struct CompleteSchema(Schema);
 
 impl CompleteSchema{
@@ -602,52 +744,9 @@ impl CompleteSchema{
 
 impl From<&ResolvedSchema> for CompleteSchema{
     fn from(value: &ResolvedSchema) -> Self {
-
-        fn unravel(schema: &mut Schema, defined_schemata: &NameMap, placed_schemata: &mut NameSet){
-            match schema {
-                Schema::Ref{name}=> {
-                    if !placed_schemata.contains(name) {
-                        let mut definition = defined_schemata.get(name).unwrap().as_ref().clone();
-                        unravel(&mut definition, defined_schemata, placed_schemata);
-                        *schema = definition;
-                    }
-                },
-                Schema::Record(record_schema) => {
-                    if !placed_schemata.insert(Arc::clone(&record_schema.name)) {
-                        panic!("When converting to complete schema, attempted to double define a schema when unraveling");
-                    }
-                    for field in &mut record_schema.fields {
-                       unravel(&mut field.schema, defined_schemata, placed_schemata);
-                    }
-                }
-                Schema::Array(array_schema) => {
-                    unravel(&mut array_schema.items, defined_schemata, placed_schemata);
-                }
-                Schema::Map(map_schema) => {
-                    unravel(map_schema.types.as_mut(), defined_schemata, placed_schemata);
-                }
-                Schema::Union(union_schema) => {
-                    for mut el_schema in &mut union_schema.schemas {
-                        unravel(&mut el_schema, defined_schemata, placed_schemata);
-                    }
-                },
-                Schema::Fixed(fixed_schema) => {
-                    if !placed_schemata.insert(Arc::clone(&fixed_schema.name)) {
-                        panic!("When converting to complete schema, attempted to double define a schema when unraveling");
-                    }
-                },
-                Schema::Enum(enum_schema) => {
-                    if !placed_schemata.insert(Arc::clone(&enum_schema.name)) {
-                        panic!("When converting to complete schema, attempted to double define a schema when unraveling");
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        let mut schema = value.schema.as_ref().clone();
-        unravel(&mut schema, &value.context.0, &mut HashSet::new());
-        CompleteSchema(schema)
+        let mut stub = value.stub.as_ref().clone();
+        unravel_inner(&mut stub, &value.context.0, &mut HashSet::new(),  &mut HashMap::new());
+        CompleteSchema(stub)
     }
 }
 
@@ -685,7 +784,7 @@ impl Serialize for ResolvedSchema{
 
 impl PartialEq for ResolvedSchema{
     fn eq(&self, other: &Self) -> bool {
-        compare_schema_with_context(&self.schema, &other.schema, &self.context.0, &other.context.0, &HashSet::new(), &HashSet::new())
+        compare_schema_and_context(&self.stub, &other.stub, &self.context.0, &other.context.0, &HashSet::new(), &HashSet::new())
     }
 }
 
@@ -695,13 +794,13 @@ impl PartialEq for ResolvedNode<'_>{
     fn eq(&self, other: &Self) -> bool {
         let resolved_self = self.get_resolved();
         let resolved_other = other.get_resolved();
-        return resolved_other == resolved_self
+        return resolved_other.unravel() == resolved_self.unravel()
     }
 }
 
 impl PartialEq for SchemaWithSymbols{
     fn eq(&self, other: &Self) -> bool {
-        compare_schema_with_context(&self.schema, &other.schema, &self.defined_names, &other.defined_names, &self.referenced_names, &other.referenced_names)
+        compare_schema_and_context(&self.stub, &other.stub, &self.defined_names, &other.defined_names, &self.referenced_names, &other.referenced_names)
     }
 }
 
@@ -709,8 +808,7 @@ impl TryFrom<SchemaWithSymbols> for ResolvedSchema{
     type Error = Error;
 
     fn try_from(schema: SchemaWithSymbols) -> AvroResult<Self> {
-        let [resolved_schema] = ResolvedSchema::from_with_symbols_array([schema], Vec::new())?;
-        Ok(resolved_schema)
+        ResolvedSchema::resolve().build_one(schema)
     }
 }
 
@@ -718,8 +816,7 @@ impl TryFrom<&SchemaWithSymbols> for ResolvedSchema{
     type Error = Error;
 
     fn try_from(schema: &SchemaWithSymbols) -> AvroResult<Self> {
-        let [resolved_schema] = ResolvedSchema::from_with_symbols_array([schema.clone()], Vec::new())?;
-        Ok(resolved_schema)
+        ResolvedSchema::resolve().build_one(schema.clone())
     }
 }
 
@@ -727,9 +824,8 @@ impl TryFrom<Schema> for ResolvedSchema{
     type Error = Error;
 
     fn try_from(schema: Schema) -> AvroResult<Self> {
-        let with_symbols : SchemaWithSymbols = schema.into();
-        let [resolved_schema] = ResolvedSchema::from_with_symbols_array([with_symbols], Vec::new())?;
-        Ok(resolved_schema)
+        let with_symbols: SchemaWithSymbols = schema.into();
+        ResolvedSchema::resolve().build_one(with_symbols)
     }
 }
 
@@ -738,10 +834,7 @@ impl TryFrom<&Schema> for ResolvedSchema{
     type Error = Error;
 
     fn try_from(schema: &Schema) -> AvroResult<Self> {
-        let schema = schema.clone();
-        let with_symbols : SchemaWithSymbols = schema.into();
-        let [resolved_schema] = ResolvedSchema::from_with_symbols_array([with_symbols], Vec::new())?;
-        Ok(resolved_schema)
+        ResolvedSchema::resolve().build_one(schema)
     }
 }
 
@@ -778,7 +871,9 @@ impl DefaultResolver{
     }
 }
 
-fn compare_schema_with_context(schema_one: &Schema, schema_two: &Schema, context_one: &NameMap, context_two: &NameMap, dangling_one: &NameSet, dangling_two: &NameSet) -> bool{
+/// compares the given two schema inside the context AND ALSO compares the contexts themselves. That
+/// is, ensures the two contexts are identical
+fn compare_schema_and_context(schema_one: &Schema, schema_two: &Schema, context_one: &NameMap, context_two: &NameMap, dangling_one: &NameSet, dangling_two: &NameSet) -> bool{
     if dangling_one != dangling_two{
         return false;
     }
@@ -793,7 +888,7 @@ fn compare_schema_with_context(schema_one: &Schema, schema_two: &Schema, context
 
     // we now know that the two contexts claim to define the same set of names, lets verify
 
-    if context_one.iter().fold(true, |acc, (name, schema)|{acc &&
+    if !context_one.iter().fold(true, |acc, (name, schema)|{acc &&
         schema.as_ref() == context_two.get(name).unwrap().as_ref()}) {
         return false
     }
@@ -804,12 +899,735 @@ fn compare_schema_with_context(schema_one: &Schema, schema_two: &Schema, context
 
 #[cfg(test)]
 mod tests {
-    use super::{ResolvedSchema};
+    use std::collections::{BTreeMap, HashMap, HashSet};
+    use std::sync::Arc;
+
+    use super::{Resolver, ResolvedSchema};
     use crate::{
         Schema,
-        schema::{Name},
+        schema::{Alias, CompleteSchema, Name, RecordField, RecordSchema, ResolvedNode, SchemaWithSymbols, UnionSchema},
     };
     use apache_avro_test_helper::TestResult;
+    use log::RecordBuilder;
+
+    // ---------- custom resolver infrastructure for tests ----------
+
+    /// A simple resolver backed by a HashMap of JSON schema strings keyed by fullname.
+    struct MapResolver {
+        registry: HashMap<String, String>,
+        call_log: Vec<String>,
+    }
+
+    impl MapResolver {
+        fn new(entries: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>) -> Self {
+            MapResolver {
+                registry: entries.into_iter().map(|(k, v)| (k.into(), v.into())).collect(),
+                call_log: Vec::new(),
+            }
+        }
+
+        fn calls(&self) -> &[String] {
+            &self.call_log
+        }
+    }
+
+    impl Resolver for MapResolver {
+        fn find_schema(&mut self, name: &Arc<Name>) -> Result<SchemaWithSymbols, String> {
+            let fullname = name.fullname(None);
+            self.call_log.push(fullname.clone());
+            match self.registry.get(&fullname) {
+                Some(json) => SchemaWithSymbols::parse_str(json)
+                    .map_err(|e| format!("parse error: {e}")),
+                None => Err(format!("not found: {fullname}")),
+            }
+        }
+    }
+
+    // ---------- custom resolver tests ----------
+
+    #[test]
+    fn custom_resolver_resolves_missing_record() -> TestResult {
+        // A record that references "ext.Address" which is not provided locally.
+        let person = r#"{
+            "type": "record",
+            "name": "Person",
+            "namespace": "app",
+            "fields": [
+                {"name": "name", "type": "string"},
+                {"name": "address", "type": "ext.Address"}
+            ]
+        }"#;
+
+        let address = r#"{
+            "type": "record",
+            "name": "Address",
+            "namespace": "ext",
+            "fields": [
+                {"name": "street", "type": "string"},
+                {"name": "city", "type": "string"}
+            ]
+        }"#;
+
+        let mut resolver = MapResolver::new([("ext.Address", address)]);
+        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([person], &mut resolver)?;
+
+        // The resolver was called for ext.Address
+        assert!(resolver.calls().contains(&"ext.Address".to_string()));
+
+        // The context should contain both Person and Address
+        assert!(rs.get_names().contains_key(&Name::new("app.Person")?));
+        assert!(rs.get_names().contains_key(&Name::new("ext.Address")?));
+        assert_eq!(rs.get_names().len(), 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_resolver_resolves_missing_enum() -> TestResult {
+        let order = r#"{
+            "type": "record",
+            "name": "Order",
+            "namespace": "shop",
+            "fields": [
+                {"name": "id", "type": "long"},
+                {"name": "status", "type": "shop.OrderStatus"}
+            ]
+        }"#;
+
+        let status_enum = r#"{
+            "type": "enum",
+            "name": "OrderStatus",
+            "namespace": "shop",
+            "symbols": ["PENDING", "SHIPPED", "DELIVERED"]
+        }"#;
+
+        let mut resolver = MapResolver::new([("shop.OrderStatus", status_enum)]);
+        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([order], &mut resolver)?;
+
+        assert!(resolver.calls().contains(&"shop.OrderStatus".to_string()));
+        assert!(rs.get_names().contains_key(&Name::new("shop.Order")?));
+        assert!(rs.get_names().contains_key(&Name::new("shop.OrderStatus")?));
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_resolver_resolves_missing_fixed() -> TestResult {
+        let msg = r#"{
+            "type": "record",
+            "name": "Message",
+            "namespace": "proto",
+            "fields": [
+                {"name": "payload", "type": "string"},
+                {"name": "checksum", "type": "proto.Checksum"}
+            ]
+        }"#;
+
+        let checksum_fixed = r#"{
+            "type": "fixed",
+            "name": "Checksum",
+            "namespace": "proto",
+            "size": 16
+        }"#;
+
+        let mut resolver = MapResolver::new([("proto.Checksum", checksum_fixed)]);
+        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([msg], &mut resolver)?;
+
+        assert!(resolver.calls().contains(&"proto.Checksum".to_string()));
+        assert!(rs.get_names().contains_key(&Name::new("proto.Message")?));
+        assert!(rs.get_names().contains_key(&Name::new("proto.Checksum")?));
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_resolver_not_called_when_locally_resolved() -> TestResult {
+        // Both schemas provided locally — resolver should never be called.
+        let person = r#"{
+            "type": "record",
+            "name": "Person",
+            "namespace": "app",
+            "fields": [
+                {"name": "name", "type": "string"},
+                {"name": "address", "type": "app.Address"}
+            ]
+        }"#;
+
+        let address = r#"{
+            "type": "record",
+            "name": "Address",
+            "namespace": "app",
+            "fields": [
+                {"name": "street", "type": "string"}
+            ]
+        }"#;
+
+        let mut resolver = MapResolver::new(Vec::<(&str, &str)>::new());
+        let [rs] = ResolvedSchema::resolve().additional(vec![address])?.build_array_with_resolver([person], &mut resolver)?;
+
+        assert!(resolver.calls().is_empty(), "resolver should not be called when all names resolve locally");
+        assert_eq!(rs.get_names().len(), 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_resolver_transitive_resolution() -> TestResult {
+        // A references B, B references C. Only A is provided; B and C come from the resolver.
+        let schema_a = r#"{
+            "type": "record",
+            "name": "A",
+            "namespace": "chain",
+            "fields": [{"name": "b", "type": "chain.B"}]
+        }"#;
+
+        let schema_b = r#"{
+            "type": "record",
+            "name": "B",
+            "namespace": "chain",
+            "fields": [{"name": "c", "type": "chain.C"}]
+        }"#;
+
+        let schema_c = r#"{
+            "type": "record",
+            "name": "C",
+            "namespace": "chain",
+            "fields": [{"name": "value", "type": "int"}]
+        }"#;
+
+        let mut resolver = MapResolver::new([
+            ("chain.B", schema_b),
+            ("chain.C", schema_c),
+        ]);
+
+        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([schema_a], &mut resolver)?;
+
+        // Both B and C should have been requested
+        assert!(resolver.calls().contains(&"chain.B".to_string()));
+        assert!(resolver.calls().contains(&"chain.C".to_string()));
+
+        // All three should be in the context
+        assert!(rs.get_names().contains_key(&Name::new("chain.A")?));
+        assert!(rs.get_names().contains_key(&Name::new("chain.B")?));
+        assert!(rs.get_names().contains_key(&Name::new("chain.C")?));
+        assert_eq!(rs.get_names().len(), 3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_resolver_error_propagates() -> TestResult {
+        // A references a name that the resolver cannot provide.
+        let schema_a = r#"{
+            "type": "record",
+            "name": "A",
+            "namespace": "ns",
+            "fields": [{"name": "x", "type": "ns.Missing"}]
+        }"#;
+
+        let mut resolver = MapResolver::new(Vec::<(&str, &str)>::new());
+        let result = ResolvedSchema::resolve().build_array_with_resolver([schema_a], &mut resolver);
+
+        assert!(result.is_err(), "should fail when resolver cannot find the schema");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("ns.Missing"), "error should mention the missing name, got: {err_msg}");
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_resolver_mismatch_error() -> TestResult {
+        // The resolver returns a schema that defines "wrong.Name" when asked for "ns.Expected".
+        let schema_a = r#"{
+            "type": "record",
+            "name": "A",
+            "namespace": "ns",
+            "fields": [{"name": "x", "type": "ns.Expected"}]
+        }"#;
+
+        let wrong_schema = r#"{
+            "type": "record",
+            "name": "WrongName",
+            "namespace": "wrong",
+            "fields": [{"name": "y", "type": "int"}]
+        }"#;
+
+        let mut resolver = MapResolver::new([("ns.Expected", wrong_schema)]);
+        let result = ResolvedSchema::resolve().build_array_with_resolver([schema_a], &mut resolver);
+
+        assert!(result.is_err(), "should fail when resolver returns a schema that doesn't define the requested name");
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_resolver_with_multiple_schemas_to_resolve() -> TestResult {
+        // Two schemas that each reference an external type.
+        let schema_a = r#"{
+            "type": "record",
+            "name": "A",
+            "namespace": "ns",
+            "fields": [{"name": "shared", "type": "ext.Shared"}]
+        }"#;
+
+        let schema_b = r#"{
+            "type": "record",
+            "name": "B",
+            "namespace": "ns",
+            "fields": [{"name": "shared", "type": "ext.Shared"}]
+        }"#;
+
+        let shared = r#"{
+            "type": "record",
+            "name": "Shared",
+            "namespace": "ext",
+            "fields": [{"name": "value", "type": "string"}]
+        }"#;
+
+        let mut resolver = MapResolver::new([("ext.Shared", shared)]);
+        let resolved = ResolvedSchema::resolve().build_list_with_resolver(
+            vec![schema_a, schema_b],
+            &mut resolver,
+        )?;
+
+        assert_eq!(resolved.len(), 2);
+        // Both resolved schemas should have ext.Shared in their context
+        for rs in &resolved {
+            assert!(rs.get_names().contains_key(&Name::new("ext.Shared")?));
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_resolver_mixed_local_and_external() -> TestResult {
+        // A references B (provided locally) and C (provided by resolver).
+        let schema_a = r#"{
+            "type": "record",
+            "name": "A",
+            "namespace": "ns",
+            "fields": [
+                {"name": "b", "type": "ns.B"},
+                {"name": "c", "type": "ext.C"}
+            ]
+        }"#;
+
+        let schema_b = r#"{
+            "type": "record",
+            "name": "B",
+            "namespace": "ns",
+            "fields": [{"name": "val", "type": "int"}]
+        }"#;
+
+        let schema_c = r#"{
+            "type": "record",
+            "name": "C",
+            "namespace": "ext",
+            "fields": [{"name": "val", "type": "long"}]
+        }"#;
+
+        let mut resolver = MapResolver::new([("ext.C", schema_c)]);
+        let [rs] = ResolvedSchema::resolve().additional(vec![schema_b])?.build_array_with_resolver([schema_a], &mut resolver)?;
+
+        // B resolved locally, C externally
+        assert!(rs.get_names().contains_key(&Name::new("ns.A")?));
+        assert!(rs.get_names().contains_key(&Name::new("ns.B")?));
+        assert!(rs.get_names().contains_key(&Name::new("ext.C")?));
+        assert_eq!(rs.get_names().len(), 3);
+
+        // Only C should have triggered a resolver call
+        assert_eq!(resolver.calls().len(), 1);
+        assert_eq!(resolver.calls()[0], "ext.C");
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_resolver_resolved_schema_resolves_node_correctly() -> TestResult {
+        // Verify that a schema resolved via custom resolver actually works for
+        // navigating the schema tree through ResolvedNode.
+        let wrapper = r#"{
+            "type": "record",
+            "name": "Wrapper",
+            "namespace": "ns",
+            "fields": [
+                {"name": "inner", "type": "ext.Inner"}
+            ]
+        }"#;
+
+        let inner = r#"{
+            "type": "record",
+            "name": "Inner",
+            "namespace": "ext",
+            "fields": [
+                {"name": "x", "type": "int"},
+                {"name": "y", "type": "string"}
+            ]
+        }"#;
+
+        let mut resolver = MapResolver::new([("ext.Inner", inner)]);
+        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([wrapper], &mut resolver)?;
+
+        // Walk the resolved schema tree
+        let node = ResolvedNode::new(&rs);
+        match node {
+            ResolvedNode::Record(record) => {
+                assert_eq!(record.fields.len(), 1);
+                let inner_node = record.fields[0].resolve_field();
+                match inner_node {
+                    ResolvedNode::Record(inner_record) => {
+                        assert_eq!(inner_record.fields.len(), 2);
+                        assert_eq!(inner_record.fields[0].name, "x");
+                        assert_eq!(inner_record.fields[1].name, "y");
+                    },
+                    other => panic!("expected Record for inner, got {other}"),
+                }
+            },
+            other => panic!("expected Record for wrapper, got {other}"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_resolver_in_union_field() -> TestResult {
+        // A field has a union type where one variant comes from the resolver.
+        let record = r#"{
+            "type": "record",
+            "name": "Event",
+            "namespace": "ns",
+            "fields": [
+                {"name": "payload", "type": ["null", "ext.Payload"]}
+            ]
+        }"#;
+
+        let payload = r#"{
+            "type": "record",
+            "name": "Payload",
+            "namespace": "ext",
+            "fields": [{"name": "data", "type": "bytes"}]
+        }"#;
+
+        let mut resolver = MapResolver::new([("ext.Payload", payload)]);
+        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([record], &mut resolver)?;
+
+        assert!(rs.get_names().contains_key(&Name::new("ext.Payload")?));
+
+        // Walk the tree: Event -> payload field -> union -> second variant should be Record
+        let node = ResolvedNode::new(&rs);
+        match node {
+            ResolvedNode::Record(rec) => {
+                let field_node = rec.fields[0].resolve_field();
+                match field_node {
+                    ResolvedNode::Union(union) => {
+                        let variants = union.resolve_schemas();
+                        assert_eq!(variants.len(), 2);
+                        assert!(matches!(variants[0], ResolvedNode::Null));
+                        assert!(matches!(variants[1], ResolvedNode::Record(_)));
+                    },
+                    other => panic!("expected Union, got {other}"),
+                }
+            },
+            other => panic!("expected Record, got {other}"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_resolver_in_array_items() -> TestResult {
+        // An array whose items type comes from the resolver.
+        let record = r#"{
+            "type": "record",
+            "name": "Container",
+            "namespace": "ns",
+            "fields": [
+                {"name": "items", "type": {"type": "array", "items": "ext.Item"}}
+            ]
+        }"#;
+
+        let item = r#"{
+            "type": "record",
+            "name": "Item",
+            "namespace": "ext",
+            "fields": [{"name": "label", "type": "string"}]
+        }"#;
+
+        let mut resolver = MapResolver::new([("ext.Item", item)]);
+        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([record], &mut resolver)?;
+
+        assert!(rs.get_names().contains_key(&Name::new("ext.Item")?));
+
+        let node = ResolvedNode::new(&rs);
+        match node {
+            ResolvedNode::Record(rec) => {
+                let field_node = rec.fields[0].resolve_field();
+                match field_node {
+                    ResolvedNode::Array(arr) => {
+                        let items_node = arr.resolve_items();
+                        assert!(matches!(items_node, ResolvedNode::Record(_)));
+                    },
+                    other => panic!("expected Array, got {other}"),
+                }
+            },
+            other => panic!("expected Record, got {other}"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_resolver_in_map_values() -> TestResult {
+        // A map whose value type comes from the resolver.
+        let record = r#"{
+            "type": "record",
+            "name": "Registry",
+            "namespace": "ns",
+            "fields": [
+                {"name": "entries", "type": {"type": "map", "values": "ext.Entry"}}
+            ]
+        }"#;
+
+        let entry = r#"{
+            "type": "record",
+            "name": "Entry",
+            "namespace": "ext",
+            "fields": [{"name": "value", "type": "double"}]
+        }"#;
+
+        let mut resolver = MapResolver::new([("ext.Entry", entry)]);
+        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([record], &mut resolver)?;
+
+        assert!(rs.get_names().contains_key(&Name::new("ext.Entry")?));
+
+        let node = ResolvedNode::new(&rs);
+        match node {
+            ResolvedNode::Record(rec) => {
+                let field_node = rec.fields[0].resolve_field();
+                match field_node {
+                    ResolvedNode::Map(map) => {
+                        let values_node = map.resolve_types();
+                        assert!(matches!(values_node, ResolvedNode::Record(_)));
+                    },
+                    other => panic!("expected Map, got {other}"),
+                }
+            },
+            other => panic!("expected Record, got {other}"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_resolver_resolved_schema_equality() -> TestResult {
+        // A schema resolved via custom resolver should equal the same schema resolved locally.
+        let main = r#"{
+            "type": "record",
+            "name": "Main",
+            "namespace": "ns",
+            "fields": [{"name": "dep", "type": "ns.Dep"}]
+        }"#;
+
+        let dep = r#"{
+            "type": "record",
+            "name": "Dep",
+            "namespace": "ns",
+            "fields": [{"name": "v", "type": "int"}]
+        }"#;
+
+        // Resolve via custom resolver
+        let mut resolver = MapResolver::new([("ns.Dep", dep)]);
+        let [via_resolver] = ResolvedSchema::resolve().build_array_with_resolver([main], &mut resolver)?;
+
+        // Resolve by providing dep locally
+        let [via_local] = ResolvedSchema::resolve().additional(vec![dep])?.build_array([main])?;
+
+        assert_eq!(via_resolver, via_local);
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_resolver_serialization_roundtrip() -> TestResult {
+        // A schema resolved via custom resolver should serialize correctly.
+        let main = r#"{
+            "type": "record",
+            "name": "ns.Main",
+            "fields": [{"name": "dep", "type": "ns.Dep"}]
+        }"#;
+
+        let dep = r#"{
+            "type": "record",
+            "name": "ns.Dep",
+            "fields": [{"name": "x", "type": "int"}]
+        }"#;
+
+        let mut resolver = MapResolver::new([("ns.Dep", dep)]);
+        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([main], &mut resolver)?;
+
+        // Serialize and re-parse: the resulting schema should be self-contained.
+        let json = serde_json::to_string(&rs)?;
+        let reparsed = ResolvedSchema::parse_str(&json)?;
+        assert_eq!(rs, reparsed);
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_resolver_resolver_returns_schema_with_extra_definitions() -> TestResult {
+        // The resolver returns a schema that defines the requested name plus additional
+        // names (e.g. a record with an inline enum). Those extra names should also be
+        // available in the context.
+        let main = r#"{
+            "type": "record",
+            "name": "Main",
+            "namespace": "ns",
+            "fields": [{"name": "detail", "type": "ext.Detail"}]
+        }"#;
+
+        // Detail defines an inline enum ext.Status
+        let detail = r#"{
+            "type": "record",
+            "name": "Detail",
+            "namespace": "ext",
+            "fields": [
+                {"name": "status", "type": {
+                    "type": "enum",
+                    "name": "Status",
+                    "namespace": "ext",
+                    "symbols": ["OK", "FAIL"]
+                }}
+            ]
+        }"#;
+
+        let mut resolver = MapResolver::new([("ext.Detail", detail)]);
+        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([main], &mut resolver)?;
+
+        assert!(rs.get_names().contains_key(&Name::new("ns.Main")?));
+        assert!(rs.get_names().contains_key(&Name::new("ext.Detail")?));
+        assert!(rs.get_names().contains_key(&Name::new("ext.Status")?));
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_resolver_deep_transitive_chain() -> TestResult {
+        // A -> B -> C -> D, all resolved externally.
+        let schema_a = r#"{
+            "type": "record", "name": "deep.A",
+            "fields": [{"name": "b", "type": "deep.B"}]
+        }"#;
+        let schema_b = r#"{
+            "type": "record", "name": "deep.B",
+            "fields": [{"name": "c", "type": "deep.C"}]
+        }"#;
+        let schema_c = r#"{
+            "type": "record", "name": "deep.C",
+            "fields": [{"name": "d", "type": "deep.D"}]
+        }"#;
+        let schema_d = r#"{
+            "type": "record", "name": "deep.D",
+            "fields": [{"name": "val", "type": "int"}]
+        }"#;
+
+        let mut resolver = MapResolver::new([
+            ("deep.B", schema_b),
+            ("deep.C", schema_c),
+            ("deep.D", schema_d),
+        ]);
+
+        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([schema_a], &mut resolver)?;
+
+        for name in ["deep.A", "deep.B", "deep.C", "deep.D"] {
+            assert!(rs.get_names().contains_key(&Name::new(name)?), "missing {name}");
+        }
+        assert_eq!(rs.get_names().len(), 4);
+
+        // Walk all the way down
+        let node = ResolvedNode::new(&rs);
+        let ResolvedNode::Record(a) = node else { panic!("expected Record") };
+        let ResolvedNode::Record(b) = a.fields[0].resolve_field() else { panic!("expected Record") };
+        let ResolvedNode::Record(c) = b.fields[0].resolve_field() else { panic!("expected Record") };
+        let ResolvedNode::Record(d) = c.fields[0].resolve_field() else { panic!("expected Record") };
+        let val = d.fields[0].resolve_field();
+        assert!(matches!(val, ResolvedNode::Int));
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_resolver_with_schema_with_symbols_api() -> TestResult {
+        // Test using the SchemaWithSymbols-level API with a custom resolver.
+        let main = r#"{
+            "type": "record",
+            "name": "ns.Main",
+            "fields": [{"name": "ref_field", "type": "ns.External"}]
+        }"#;
+
+        let external = r#"{
+            "type": "enum",
+            "name": "ns.External",
+            "symbols": ["X", "Y", "Z"]
+        }"#;
+
+        let main_sws = SchemaWithSymbols::parse_str(main)?;
+
+        let mut resolver = MapResolver::new([("ns.External", external)]);
+        let [rs] = ResolvedSchema::resolve().build_array_with_resolver(
+            [main_sws],
+            &mut resolver,
+        )?;
+
+        assert!(rs.get_names().contains_key(&Name::new("ns.Main")?));
+        assert!(rs.get_names().contains_key(&Name::new("ns.External")?));
+
+        // Verify the field resolves to an Enum
+        let ResolvedNode::Record(rec) = ResolvedNode::new(&rs) else { panic!("expected Record") };
+        assert!(matches!(rec.fields[0].resolve_field(), ResolvedNode::Enum(_)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_resolver_unravel_produces_self_contained_schema() -> TestResult {
+        // After resolving via custom resolver, unravel() should produce a fully
+        // self-contained schema with no Schema::Ref nodes.
+        let main = r#"{
+            "type": "record",
+            "name": "ns.Root",
+            "fields": [
+                {"name": "tag", "type": "ns.Tag"},
+                {"name": "meta", "type": "ns.Meta"}
+            ]
+        }"#;
+        let tag = r#"{
+            "type": "enum", "name": "ns.Tag",
+            "symbols": ["ALPHA", "BETA"]
+        }"#;
+        let meta = r#"{
+            "type": "fixed", "name": "ns.Meta", "size": 8
+        }"#;
+
+        let mut resolver = MapResolver::new([
+            ("ns.Tag", tag),
+            ("ns.Meta", meta),
+        ]);
+        let [rs] = ResolvedSchema::resolve().build_array_with_resolver([main], &mut resolver)?;
+
+        let unraveled = rs.unravel();
+
+        // The unraveled schema should be a Record with inline definitions, no Ref nodes
+        match &unraveled {
+            Schema::Record(rec) => {
+                assert_eq!(rec.fields.len(), 2);
+                assert!(matches!(&rec.fields[0].schema, Schema::Enum(_)));
+                assert!(matches!(&rec.fields[1].schema, Schema::Fixed(_)));
+            },
+            other => panic!("expected Record, got {other:?}"),
+        }
+
+        Ok(())
+    }
 
     #[test]
     fn avro_3448_test_proper_resolution_inner_record_inherited_namespace() -> TestResult {
@@ -842,7 +1660,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::from_str_array_only([schema])?;
+        let [rs] = ResolvedSchema::resolve().build_array([schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.inner_record_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -882,7 +1700,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
+        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.inner_record_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -917,7 +1735,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
+        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.inner_enum_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -952,7 +1770,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
+        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.inner_enum_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -987,7 +1805,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
+        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.inner_fixed_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -1022,7 +1840,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
+        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.inner_fixed_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -1063,7 +1881,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
+        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "inner_space.inner_record_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -1099,7 +1917,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
+        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "inner_space.inner_enum_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -1135,7 +1953,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
+        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "inner_space.inner_fixed_name"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -1187,7 +2005,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
+        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 3);
         for s in [
             "space.record_name",
@@ -1244,7 +2062,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
+        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 3);
         for s in [
             "space.record_name",
@@ -1302,7 +2120,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
+        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 3);
         for s in [
             "space.record_name",
@@ -1346,7 +2164,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
+        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.in_array_record"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -1386,7 +2204,7 @@ mod tests {
           ]
         }
         "#;
-        let [rs] = ResolvedSchema::from_str_array_only([&schema])?;
+        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
         assert_eq!(rs.get_names().len(), 2);
         for s in ["space.record_name", "space.in_map_record"] {
             assert!(rs.get_names().contains_key(&Name::new(s)?));
@@ -1423,7 +2241,7 @@ mod tests {
         }
         "#;
         let schema = Schema::parse_str(schema)?;
-        let [rs] = ResolvedSchema::from_schema_array_only([&schema])?;
+        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
 
         // confirm we have expected 2 full-names
         assert_eq!(rs.get_names().len(), 2);
@@ -1467,7 +2285,7 @@ mod tests {
         }
         "#;
         let schema = Schema::parse_str(schema)?;
-        let [rs] = ResolvedSchema::from_schema_array_only([&schema])?;
+        let [rs] = ResolvedSchema::resolve().build_array([&schema])?;
 
         // confirm we have expected 2 full-names
         assert_eq!(rs.get_names().len(), 2);
@@ -1504,7 +2322,7 @@ mod tests {
                 }
             ]
         }"#;
-        let _resolved = ResolvedSchema::from_str_array_only([&schema])?;
+        let _resolved = ResolvedSchema::resolve().build_array([&schema])?;
 
         Ok(())
     }
@@ -1532,7 +2350,7 @@ mod tests {
                 }
             ]
         }"#;
-        let _resolved = ResolvedSchema::from_str_array_only([&schema])?;
+        let _resolved = ResolvedSchema::resolve().build_array([&schema])?;
 
         Ok(())
     }
@@ -1577,14 +2395,497 @@ mod tests {
 
         }"#;
 
-        let result = ResolvedSchema::from_str_array([&schema],vec![&other_schema])
+        let ambig_schema = r#""duplicated_name""#;
+
+        let result = ResolvedSchema::resolve().additional(vec![&schema, &other_schema])?.build_array([&ambig_schema])
             .unwrap_err();
 
-        assert_eq!(
-            result.to_string(),
-            "Two named schema defined for same fullname: duplicated_name."
+        assert!(
+            result.to_string().contains("Schamata with fullnames: [\"duplicated_name\"], already have definitions in this context.")
         );
 
         Ok(())
     }
+
+    #[test]
+    fn allow_identical_definitions() -> TestResult{
+        let schema1 = r#"
+        {
+            "name": "someRecord",
+            "type": "record",
+            "fields": [
+            {
+                "name": "field1",
+                "type": {
+                    "name": "duplicateEnum",
+                    "type": "enum",
+                    "symbols":["A","B","C"]
+                }
+            }
+            ]
+        }
+            "#;
+
+        let schema2 = r#"
+        {
+            "name": "someOtherRecord",
+            "type": "record",
+            "fields": [
+            {
+                "name": "otherField1",
+                "type": {
+                    "name": "duplicateEnum",
+                    "type": "enum",
+                    "symbols":["A","B","C"]
+                }
+            }
+            ]
+        }
+            "#;
+
+        let _resolved = ResolvedSchema::resolve().build_array([schema1, schema2])?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn dont_allow_close_but_not_identical_definitions() -> TestResult{
+        let union = r#"[someRecord, someOtherRecord]"#;
+
+        let schema1 = r#"
+        {
+            "name": "someRecord",
+            "type": "record",
+            "fields": [
+            {
+                "name": "field1",
+                "type": {
+                    "name": "duplicateEnum",
+                    "type": "enum",
+                    "symbols":["A","B","C"]
+                }
+            }
+            ]
+        }
+            "#;
+
+        let schema2 = r#"
+        {
+            "name": "someOtherRecord",
+            "type": "record",
+            "fields": [
+            {
+                "name": "otherField1",
+                "type": {
+                    "name": "duplicateEnum",
+                    "type": "enum",
+                    "symbols":["A","B"]
+                }
+            }
+            ]
+        }
+            "#;
+
+        assert_eq!(
+            ResolvedSchema::resolve().additional([schema1, schema2])?.build_array([union]).is_err(),
+            true);
+
+        Ok(())
+
+    }
+
+    #[test]
+    fn unravel_is_alias_aware() -> TestResult{
+        let complete = CompleteSchema::try_from(&ResolvedSchema::parse_str(
+            r#"
+            {
+              "type": "record",
+              "name": "LongList",
+              "aliases": ["LinkedLongs"],
+              "fields" : [
+                {"name": "value", "type": "long"},
+                {"name": "next", "type": ["null", "LinkedLongs"]}
+              ]
+            }
+        "#,
+        )?)?;
+
+        let mut lookup = BTreeMap::new();
+        lookup.insert("value".to_owned(), 0);
+        lookup.insert("next".to_owned(), 1);
+
+        let expected = Schema::Record(RecordSchema {
+            name: Name::new("LongList")?.into(),
+            aliases: Some(vec![Alias::new("LinkedLongs").unwrap()]),
+            doc: None,
+            fields: vec![
+                RecordField::builder()
+                    .name("value".to_string())
+                    .schema(Schema::Long)
+                    .build(),
+                RecordField::builder()
+                    .name("next".to_string())
+                    .schema(Schema::Union(UnionSchema::new(vec![
+                        Schema::Null,
+                        Schema::Ref {
+                            name: Name::new("LongList")?.into(),
+                        },
+                    ])?))
+                    .build(),
+            ],
+            lookup,
+            attributes: Default::default(),
+        });
+
+        assert_eq!(
+                complete.0,
+                expected
+            );
+
+        Ok(())
+    }
+
+    #[test]
+    fn correct_comparison_after_resolved_node_traversal() -> TestResult{
+        let schema1 = r#"{
+            "name": "someRecord",
+            "type": "record",
+            "fields": [
+                {
+                    "name": "matchingInner",
+                    "type": {
+                        "name": "matchingInner",
+                        "type": "record",
+                        "fields": [{"name": "f1", "type": "long"}]
+                    }
+                },
+                {
+                    "name": "someLongField",
+                    "type": "long"
+                }
+            ]
+        }"#;
+
+        let schema2 = r#"{
+            "name": "someOtherRecord",
+            "type": "record",
+            "fields": [
+                {
+                    "name": "matchingInner",
+                    "type": {
+                        "name": "matchingInner",
+                        "type": "record",
+                        "fields": [{"name": "f1", "type": "long"}]
+                    }
+                },
+                {
+                    "name": "someStringField",
+                    "type": "string"
+                }
+            ]
+        }"#;
+
+        let resolved1 = ResolvedSchema::parse_str(schema1)?;
+        let resolved2 = ResolvedSchema::parse_str(schema2)?;
+
+        let node1 = ResolvedNode::new(&resolved1);
+        let node2 = ResolvedNode::new(&resolved2);
+
+        let matching_inner1 = match node1 {
+            ResolvedNode::Record(resolved_record) => {
+                Some(resolved_record.fields.iter().find(|field| field.name == "matchingInner").unwrap().resolve_field())
+            }
+            _ => None
+        };
+
+        let matching_inner2 = match node2 {
+            ResolvedNode::Record(resolved_record) => {
+                Some(resolved_record.fields.iter().find(|field| field.name == "matchingInner").unwrap().resolve_field())
+            }
+            _ => None
+        };
+
+        assert_eq!(
+            matching_inner1,
+            matching_inner2
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn schema_not_needed_are_ignored() -> TestResult{
+        let schema1 = r#"["enum1", "enum2", "myrecord"]"#;
+        let schema2 = r#"{
+            "name": "enum1",
+            "type": "enum",
+            "symbols": ["A","B","C"]
+        }"#;
+        let schema3 = r#"{
+            "name": "enum2",
+            "type": "enum",
+            "symbols": ["F","W","D"]
+        }"#;
+        let schema4 = r#"{
+            "name": "myrecord",
+            "type": "record",
+            "fields": [{"name": "myfield", "type": "long"}]
+        }"#;
+
+        let schema5 = r#"{
+            "name": "myfixed",
+            "type": "fixed",
+            "size": 4
+        }"#;
+
+        let [rs] = ResolvedSchema::resolve().additional([schema2, schema3, schema4, schema5])?.build_array([schema1])?;
+        let my_fixed = rs.context.0.get(&Name::try_from("myfixed")?);
+
+        assert_eq!(
+            my_fixed,
+            None
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn duplicate_in_provided_definitions_is_okay_if_equal() -> TestResult{
+        let schema1 = r#"["enum1", "enum2", "myrecord"]"#;
+        let schema2 = r#"{
+            "name": "enum1",
+            "type": "enum",
+            "symbols": ["A","B","C"]
+        }"#;
+        let schema3 = r#"{
+            "name": "enum2",
+            "type": "enum",
+            "symbols": ["F","W","D"]
+        }"#;
+        let schema4 = r#"{
+            "name": "myrecord",
+            "type": "record",
+            "fields": [{"name": "myfield", "type": "long"}]
+        }"#;
+
+        let _rs = ResolvedSchema::resolve().additional([&schema2, &schema3, &schema4, &schema4])?.build_array([&schema1])?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_multiple_resolved_schema_at_once() -> TestResult{
+        let union = r#"["enum1", "enum2"]"#;
+        let record = r#"{
+            "name": "myRecord",
+            "type": "record",
+            "fields": [
+                {
+                    "name": "f1",
+                    "type": "enum1"
+                },
+                {
+                    "name": "f2",
+                    "type": "enum2"
+                }
+            ]
+        }"#;
+        let schema1 = r#"{
+            "name": "enum1",
+            "type": "enum",
+            "symbols": ["A","B","C"]
+        }"#;
+        let schema2 = r#"{
+            "name": "enum2",
+            "type": "enum",
+            "symbols": ["F","W","D"]
+        }"#;
+
+        let _rs = ResolvedSchema::resolve().additional([&schema1, &schema2])?.build_array([&union, &record])?;
+
+        Ok(())
+    }
+
+    const BAR_ENUM: &str = r#"{
+        "type": "enum",
+        "name": "bar",
+        "symbols": ["A", "B", "C"]
+    }"#;
+
+    const BAZ_FIXED: &str = r#"{
+        "type": "fixed",
+        "name": "baz",
+        "size": 16
+    }"#;
+
+    const QUX_ENUM: &str = r#"{
+        "type": "enum",
+        "name": "qux",
+        "symbols": ["X", "Y"]
+    }"#;
+
+    /// baz as a record instead of fixed — conflicts with BAZ_FIXED
+    const BAZ_RECORD: &str = r#"{
+        "type": "record",
+        "name": "baz",
+        "fields": [{"name": "x", "type": "int"}]
+    }"#;
+
+    const FOO_USES_BAR: &str = r#"{
+        "type": "record",
+        "name": "foo",
+        "fields": [
+            {"name": "a", "type": "bar"}
+        ]
+    }"#;
+
+    #[test]
+    fn resolved_schema_only_includes_needed_definitions() {
+        let [resolved] = ResolvedSchema::resolve()
+            .additional(vec![BAR_ENUM, BAZ_FIXED])
+            .unwrap()
+            .build_array([FOO_USES_BAR])
+            .unwrap();
+
+        let names: HashSet<String> = resolved
+            .get_names()
+            .keys()
+            .map(|n| n.fullname(None))
+            .collect();
+
+        assert!(names.contains("foo"), "should contain root definition 'foo'");
+        assert!(names.contains("bar"), "should contain referenced definition 'bar'");
+        assert!(!names.contains("baz"), "should NOT contain unreferenced definition 'baz'");
+    }
+
+    #[test]
+    fn equal_when_different_unused_definitions_in_pool() {
+        // resolve foo with {bar, baz}
+        let [resolved_a] = ResolvedSchema::resolve()
+            .additional(vec![BAR_ENUM, BAZ_FIXED])
+            .unwrap()
+            .build_array([FOO_USES_BAR])
+            .unwrap();
+
+        // resolve foo with {bar, qux}
+        let [resolved_b] = ResolvedSchema::resolve()
+            .additional(vec![BAR_ENUM, QUX_ENUM])
+            .unwrap()
+            .build_array([FOO_USES_BAR])
+            .unwrap();
+
+        assert_eq!(
+            resolved_a, resolved_b,
+            "resolved schemas should be equal when only the unused pool members differ"
+        );
+    }
+
+    #[test]
+    fn equal_despite_conflicting_unused_definitions_across_pools() {
+        // pool A has baz as a fixed
+        let [resolved_a] = ResolvedSchema::resolve()
+            .additional(vec![BAR_ENUM, BAZ_FIXED])
+            .unwrap()
+            .build_array([FOO_USES_BAR])
+            .unwrap();
+
+        // pool B has baz as a record — conflicts with pool A's baz,
+        // but neither resolution actually needs baz
+        let [resolved_b] = ResolvedSchema::resolve()
+            .additional(vec![BAR_ENUM, BAZ_RECORD])
+            .unwrap()
+            .build_array([FOO_USES_BAR])
+            .unwrap();
+
+        assert_eq!(
+            resolved_a, resolved_b,
+            "conflicting definitions of 'baz' shouldn't matter since neither schema uses it"
+        );
+    }
+
+    #[test]
+    fn not_equal_when_shared_definition_differs() {
+        let bar_enum_alt: &str = r#"{
+            "type": "enum",
+            "name": "bar",
+            "symbols": ["D", "E", "F"]
+        }"#;
+
+        let [resolved_a] = ResolvedSchema::resolve()
+            .additional(vec![BAR_ENUM])
+            .unwrap()
+            .build_array([FOO_USES_BAR])
+            .unwrap();
+
+        let [resolved_b] = ResolvedSchema::resolve()
+            .additional(vec![bar_enum_alt])
+            .unwrap()
+            .build_array([FOO_USES_BAR])
+            .unwrap();
+
+        assert_ne!(
+            resolved_a, resolved_b,
+            "resolved schemas should differ when a used definition differs"
+        );
+    }
+
+    #[test]
+    fn transitive_dependencies_included_but_not_unrelated() {
+        // bar references baz, so resolving foo -> bar -> baz should pull in both
+        let bar_uses_baz: &str = r#"{
+            "type": "record",
+            "name": "bar",
+            "fields": [
+                {"name": "b", "type": "baz"}
+            ]
+        }"#;
+
+        let [resolved] = ResolvedSchema::resolve()
+            .additional(vec![bar_uses_baz, BAZ_FIXED, QUX_ENUM])
+            .unwrap()
+            .build_array([FOO_USES_BAR])
+            .unwrap();
+
+        let names: HashSet<String> = resolved
+            .get_names()
+            .keys()
+            .map(|n| n.fullname(None))
+            .collect();
+
+        assert!(names.contains("foo"), "root should be present");
+        assert!(names.contains("bar"), "direct dependency should be present");
+        assert!(names.contains("baz"), "transitive dependency should be present");
+        assert!(!names.contains("qux"), "unrelated definition should NOT be present");
+    }
+
+    #[test]
+    fn equal_with_transitive_deps_from_different_pools() {
+        let bar_uses_baz: &str = r#"{
+            "type": "record",
+            "name": "bar",
+            "fields": [
+                {"name": "b", "type": "baz"}
+            ]
+        }"#;
+
+        // pool has an extra unrelated schema
+        let [resolved_a] = ResolvedSchema::resolve()
+            .additional(vec![bar_uses_baz, BAZ_FIXED, QUX_ENUM])
+            .unwrap()
+            .build_array([FOO_USES_BAR])
+            .unwrap();
+
+        // pool without the extra
+        let [resolved_b] = ResolvedSchema::resolve()
+            .additional(vec![bar_uses_baz, BAZ_FIXED])
+            .unwrap()
+            .build_array([FOO_USES_BAR])
+            .unwrap();
+
+        assert_eq!(
+            resolved_a, resolved_b,
+            "transitive resolution should produce equal schemas regardless of extra pool members"
+        );
+    }
+
 }

--- a/avro/src/schema/union.rs
+++ b/avro/src/schema/union.rs
@@ -486,7 +486,7 @@ mod tests {
         );
 
         // KTODO, this test does not refactor in a nice way like the others...
-        let [rs] = ResolvedSchema::from_schema_array_only([&Schema::Union(union)])?;
+        let [rs] = ResolvedSchema::resolve().build_array([&Schema::Union(union)])?;
         let rn = ResolvedNode::new(&rs);
         let resolved_union = match rn {
             ResolvedNode::Union(res) => res,
@@ -507,7 +507,7 @@ mod tests {
         let value = Value::Int(42);
 
         // KTODO, this test does not refactor in a nice way like the others...
-        let [rs] = ResolvedSchema::from_schema_array_only([&Schema::Union(union)])?;
+        let [rs] = ResolvedSchema::resolve().build_array([&Schema::Union(union)])?;
         let rn = ResolvedNode::new(&rs);
         let resolved_union = match rn {
             ResolvedNode::Union(res) => res,
@@ -538,7 +538,7 @@ mod tests {
         let union = UnionSchema::new(vec![uuid.clone(), Schema::Null])?;
         let value = Value::Fixed(16, vec![0; 16]);
 
-        let [union_rs] = ResolvedSchema::from_schema_array_only([&Schema::Union(union)])?;
+        let [union_rs] = ResolvedSchema::resolve().build_array([&Schema::Union(union)])?;
         let union_rs = ResolvedNode::new(&union_rs);
 
         let resolved_union = match union_rs {

--- a/avro/src/schema/union.rs
+++ b/avro/src/schema/union.rs
@@ -17,7 +17,7 @@
 
 use crate::error::Details;
 use crate::schema::{
-    DecimalSchema, InnerDecimalSchema, Name, NamespaceRef, Schema, SchemaKind, UuidSchema,
+    DecimalSchema, InnerDecimalSchema, Name, Schema, SchemaKind, UuidSchema,
 };
 use crate::types;
 use crate::{AvroResult, Error};
@@ -485,8 +485,7 @@ mod tests {
                 .collect(),
         );
 
-        // KTODO, this test does not refactor in a nice way like the others...
-        let [rs] = ResolvedSchema::resolve().build_array([&Schema::Union(union)])?;
+        let [rs] = ResolvedSchema::builder().build_array([&Schema::Union(union)])?;
         let rn = ResolvedNode::new(&rs);
         let resolved_union = match rn {
             ResolvedNode::Union(res) => res,
@@ -506,8 +505,7 @@ mod tests {
         let union = UnionSchema::new(vec![Schema::Long, Schema::Null])?;
         let value = Value::Int(42);
 
-        // KTODO, this test does not refactor in a nice way like the others...
-        let [rs] = ResolvedSchema::resolve().build_array([&Schema::Union(union)])?;
+        let [rs] = ResolvedSchema::builder().build_array([&Schema::Union(union)])?;
         let rn = ResolvedNode::new(&rs);
         let resolved_union = match rn {
             ResolvedNode::Union(res) => res,
@@ -524,7 +522,6 @@ mod tests {
         Ok(())
     }
 
-    // KTODO: this refactors horribly....
     #[test]
     fn avro_rs_489_find_schema_with_known_schemata_uuid_vs_fixed() -> TestResult {
         let uuid = Schema::parse_str(
@@ -538,7 +535,7 @@ mod tests {
         let union = UnionSchema::new(vec![uuid.clone(), Schema::Null])?;
         let value = Value::Fixed(16, vec![0; 16]);
 
-        let [union_rs] = ResolvedSchema::resolve().build_array([&Schema::Union(union)])?;
+        let [union_rs] = ResolvedSchema::builder().build_array([&Schema::Union(union)])?;
         let union_rs = ResolvedNode::new(&union_rs);
 
         let resolved_union = match union_rs {

--- a/avro/src/schema/union.rs
+++ b/avro/src/schema/union.rs
@@ -21,7 +21,7 @@ use crate::schema::{
 };
 use crate::types;
 use crate::{AvroResult, Error};
-use std::borrow::Borrow;
+use std::sync::Arc;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Debug, Formatter};
 use strum::IntoDiscriminant;
@@ -34,7 +34,7 @@ pub struct UnionSchema {
     /// The indexes of unnamed types.
     ///
     /// Logical types have been reduced to their inner type.
-    variant_index: BTreeMap<SchemaKind, usize>,
+    pub(crate) variant_index: BTreeMap<SchemaKind, usize>,
     /// The indexes of named types.
     ///
     /// The names themselves aren't saved as they aren't used.
@@ -77,82 +77,6 @@ impl UnionSchema {
     /// Returns true if the any of the variants of this `UnionSchema` is `Null`.
     pub fn is_nullable(&self) -> bool {
         self.variant_index.contains_key(&SchemaKind::Null)
-    }
-
-    /// Optionally returns a reference to the schema matched by this value, as well as its position
-    /// within this union.
-    ///
-    /// Extra arguments:
-    /// - `known_schemata` - mapping between `Name` and `Schema` - if passed, additional external schemas would be used to resolve references.
-    pub fn find_schema_with_known_schemata<S: Borrow<Schema> + Debug>(
-        &self,
-        value: &types::Value,
-        known_schemata: Option<&HashMap<Name, S>>,
-        enclosing_namespace: NamespaceRef,
-    ) -> Option<(usize, &Schema)> {
-        let known_schemata_if_none = HashMap::new();
-        let known_schemata = known_schemata.unwrap_or(&known_schemata_if_none);
-        let ValueSchemaKind { unnamed, named } = Self::value_to_base_schemakind(value);
-        // Unnamed schema types can be looked up directly using the variant_index
-        let unnamed = unnamed
-            .and_then(|kind| self.variant_index.get(&kind).copied())
-            .map(|index| (index, &self.schemas[index]))
-            .and_then(|(index, schema)| {
-                let kind = schema.discriminant();
-                // Maps and arrays need to be checked if they actually match the value
-                if kind == SchemaKind::Map || kind == SchemaKind::Array {
-                    let namespace = schema.namespace().or(enclosing_namespace);
-
-                    // TODO: Do this without the clone
-                    value
-                        .clone()
-                        .resolve_internal(schema, known_schemata, namespace, &None)
-                        .ok()
-                        .map(|_| (index, schema))
-                } else {
-                    Some((index, schema))
-                }
-            });
-        let named = named.and_then(|kind| {
-            // Every named type needs to be checked against a value until one matches
-
-            self.named_index
-                .iter()
-                .copied()
-                .map(|i| (i, &self.schemas[i]))
-                .filter(|(_i, s)| {
-                    let s_kind = schema_to_base_schemakind(s);
-                    s_kind == kind || s_kind == SchemaKind::Ref
-                })
-                .find(|(_i, schema)| {
-                    let namespace = schema.namespace().or(enclosing_namespace);
-
-                    // TODO: Do this without the clone
-                    value
-                        .clone()
-                        .resolve_internal(schema, known_schemata, namespace, &None)
-                        .is_ok()
-                })
-        });
-
-        match (unnamed, named) {
-            (Some((u_i, _)), Some((n_i, _))) if u_i < n_i => unnamed,
-            (Some(_), Some(_)) => named,
-            (Some(_), None) => unnamed,
-            (None, Some(_)) => named,
-            (None, None) => {
-                // Slow path, check if value can be promoted to any of the types in the union
-                self.schemas.iter().enumerate().find(|(_i, schema)| {
-                    let namespace = schema.namespace().or(enclosing_namespace);
-
-                    // TODO: Do this without the clone
-                    value
-                        .clone()
-                        .resolve_internal(schema, known_schemata, namespace, &None)
-                        .is_ok()
-                })
-            }
-        }
     }
 
     /// Convert a value to a [`SchemaKind`] stripping logical types to their base type.
@@ -224,7 +148,7 @@ impl PartialEq for UnionSchema {
 #[derive(Default, Debug)]
 pub struct UnionSchemaBuilder {
     schemas: Vec<Schema>,
-    names: HashMap<Name, usize>,
+    names: HashMap<Arc<Name>, usize>,
     variant_index: BTreeMap<SchemaKind, usize>,
 }
 
@@ -390,7 +314,7 @@ fn schema_to_base_schemakind(schema: &Schema) -> SchemaKind {
 mod tests {
     use super::*;
     use crate::error::{Details, Error};
-    use crate::schema::RecordSchema;
+    use crate::schema::{RecordSchema, ResolvedNode, ResolvedSchema};
     use crate::types::Value;
     use apache_avro_test_helper::TestResult;
 
@@ -561,9 +485,16 @@ mod tests {
                 .collect(),
         );
 
+        // KTODO, this test does not refactor in a nice way like the others...
+        let [rs] = ResolvedSchema::from_schema_array_only([&Schema::Union(union)])?;
+        let rn = ResolvedNode::new(&rs);
+        let resolved_union = match rn {
+            ResolvedNode::Union(res) => res,
+            _ => unreachable!()
+        };
+
         assert!(
-            union
-                .find_schema_with_known_schemata(&value, None::<&HashMap<Name, Schema>>, None)
+           resolved_union.structural_match_on_schema(&value)
                 .is_none()
         );
 
@@ -575,14 +506,25 @@ mod tests {
         let union = UnionSchema::new(vec![Schema::Long, Schema::Null])?;
         let value = Value::Int(42);
 
+        // KTODO, this test does not refactor in a nice way like the others...
+        let [rs] = ResolvedSchema::from_schema_array_only([&Schema::Union(union)])?;
+        let rn = ResolvedNode::new(&rs);
+        let resolved_union = match rn {
+            ResolvedNode::Union(res) => res,
+            _ => unreachable!()
+        };
+
+        let matched_union_branch = resolved_union.structural_match_on_schema(&value);
+
         assert_eq!(
-            union.find_schema_with_known_schemata(&value, None::<&HashMap<Name, Schema>>, None),
-            Some((0, &Schema::Long))
+            matched_union_branch,
+            Some((0, ResolvedNode::Long))
         );
 
         Ok(())
     }
 
+    // KTODO: this refactors horribly....
     #[test]
     fn avro_rs_489_find_schema_with_known_schemata_uuid_vs_fixed() -> TestResult {
         let uuid = Schema::parse_str(
@@ -596,9 +538,24 @@ mod tests {
         let union = UnionSchema::new(vec![uuid.clone(), Schema::Null])?;
         let value = Value::Fixed(16, vec![0; 16]);
 
+        let [union_rs] = ResolvedSchema::from_schema_array_only([&Schema::Union(union)])?;
+        let union_rs = ResolvedNode::new(&union_rs);
+
+        let resolved_union = match union_rs {
+            ResolvedNode::Union(res) => res,
+            _ => unreachable!()
+        };
+
+        let matched_union_branch = resolved_union.structural_match_on_schema(&value);
+
+        let uuid = match uuid {
+            Schema::Uuid(uuid) => uuid,
+            _ => unreachable!()
+        };
+
         assert_eq!(
-            union.find_schema_with_known_schemata(&value, None::<&HashMap<Name, Schema>>, None),
-            Some((0, &uuid))
+            matched_union_branch,
+            Some((0, ResolvedNode::Uuid(&uuid)))
         );
 
         Ok(())

--- a/avro/src/schema_compatibility.rs
+++ b/avro/src/schema_compatibility.rs
@@ -853,7 +853,7 @@ mod tests {
     #[test]
     fn test_compatible_reader_writer_pairs() {
         let uuid_fixed = FixedSchema {
-            name: Name::new("uuid_fixed").unwrap(),
+            name: Name::new("uuid_fixed").unwrap().into(),
             aliases: None,
             doc: None,
             size: 16,
@@ -1699,7 +1699,7 @@ mod tests {
             precision: 20,
             scale: 0,
             inner: InnerDecimalSchema::Fixed(FixedSchema {
-                name: Name::new("DecimalFixed")?,
+                name: Name::new("DecimalFixed")?.into(),
                 aliases: None,
                 doc: None,
                 size: 20,

--- a/avro/src/schema_equality.rs
+++ b/avro/src/schema_equality.rs
@@ -311,14 +311,14 @@ mod tests {
     #[test]
     fn avro_rs_382_compare_schemata_duration_equal() {
         let schema_one = Schema::Duration(FixedSchema {
-            name: Name::try_from("name1").expect("Name is valid"),
+            name: Name::try_from("name1").expect("Name is valid").into(),
             size: 12,
             aliases: None,
             doc: None,
             attributes: BTreeMap::new(),
         });
         let schema_two = Schema::Duration(FixedSchema {
-            name: Name::try_from("name1").expect("Name is valid"),
+            name: Name::try_from("name1").expect("Name is valid").into(),
             size: 12,
             aliases: None,
             doc: None,
@@ -332,14 +332,14 @@ mod tests {
     #[test]
     fn avro_rs_382_compare_schemata_duration_different_names() {
         let schema_one = Schema::Duration(FixedSchema {
-            name: Name::try_from("name1").expect("Name is valid"),
+            name: Name::try_from("name1").expect("Name is valid").into(),
             size: 12,
             aliases: None,
             doc: None,
             attributes: BTreeMap::new(),
         });
         let schema_two = Schema::Duration(FixedSchema {
-            name: Name::try_from("name2").expect("Name is valid"),
+            name: Name::try_from("name2").expect("Name is valid").into(),
             size: 12,
             aliases: None,
             doc: None,
@@ -355,7 +355,7 @@ mod tests {
     #[test]
     fn avro_rs_382_compare_schemata_duration_different_attributes() {
         let schema_one = Schema::Duration(FixedSchema {
-            name: Name::try_from("name1").expect("Name is valid"),
+            name: Name::try_from("name1").expect("Name is valid").into(),
             size: 12,
             aliases: None,
             doc: None,
@@ -364,7 +364,7 @@ mod tests {
                 .collect(),
         });
         let schema_two = Schema::Duration(FixedSchema {
-            name: Name::try_from("name1").expect("Name is valid"),
+            name: Name::try_from("name1").expect("Name is valid").into(),
             size: 12,
             aliases: None,
             doc: None,
@@ -384,14 +384,14 @@ mod tests {
     #[test]
     fn avro_rs_382_compare_schemata_duration_different_sizes() {
         let schema_one = Schema::Duration(FixedSchema {
-            name: Name::try_from("name1").expect("Name is valid"),
+            name: Name::try_from("name1").expect("Name is valid").into(),
             size: 8,
             aliases: None,
             doc: None,
             attributes: BTreeMap::new(),
         });
         let schema_two = Schema::Duration(FixedSchema {
-            name: Name::try_from("name1").expect("Name is valid"),
+            name: Name::try_from("name1").expect("Name is valid").into(),
             size: 12,
             aliases: None,
             doc: None,
@@ -407,11 +407,11 @@ mod tests {
     #[test]
     fn test_avro_3939_compare_named_schemata_with_different_names() {
         let schema_one = Schema::Ref {
-            name: Name::try_from("name1").expect("Name is valid"),
+            name: Name::try_from("name1").expect("Name is valid").into(),
         };
 
         let schema_two = Schema::Ref {
-            name: Name::try_from("name2").expect("Name is valid"),
+            name: Name::try_from("name2").expect("Name is valid").into(),
         };
 
         let specification_eq_res = SPECIFICATION_EQ.compare(&schema_one, &schema_two);
@@ -534,7 +534,7 @@ mod tests {
     #[test]
     fn test_avro_3939_compare_fixed_schemata() {
         let schema_one = Schema::Fixed(FixedSchema {
-            name: Name::try_from("fixed").expect("Name is valid"),
+            name: Name::try_from("fixed").expect("Name is valid").into(),
             doc: None,
             size: 10,
             aliases: None,
@@ -544,7 +544,7 @@ mod tests {
         assert!(!STRUCT_FIELD_EQ.compare(&schema_one, &Schema::Boolean));
 
         let schema_two = Schema::Fixed(FixedSchema {
-            name: Name::try_from("fixed").expect("Name is valid"),
+            name: Name::try_from("fixed").expect("Name is valid").into(),
             doc: None,
             size: 10,
             aliases: None,
@@ -567,7 +567,7 @@ mod tests {
     #[test]
     fn test_avro_3939_compare_enum_schemata() {
         let schema_one = Schema::Enum(EnumSchema {
-            name: Name::try_from("enum").expect("Name is valid"),
+            name: Name::try_from("enum").expect("Name is valid").into(),
             doc: None,
             symbols: vec!["A".to_string(), "B".to_string()],
             default: None,
@@ -578,7 +578,7 @@ mod tests {
         assert!(!STRUCT_FIELD_EQ.compare(&schema_one, &Schema::Boolean));
 
         let schema_two = Schema::Enum(EnumSchema {
-            name: Name::try_from("enum").expect("Name is valid"),
+            name: Name::try_from("enum").expect("Name is valid").into(),
             doc: None,
             symbols: vec!["A".to_string(), "B".to_string()],
             default: None,
@@ -602,13 +602,13 @@ mod tests {
     #[test]
     fn test_avro_3939_compare_ref_schemata() {
         let schema_one = Schema::Ref {
-            name: Name::try_from("ref").expect("Name is valid"),
+            name: Name::try_from("ref").expect("Name is valid").into(),
         };
         assert!(!SPECIFICATION_EQ.compare(&schema_one, &Schema::Boolean));
         assert!(!STRUCT_FIELD_EQ.compare(&schema_one, &Schema::Boolean));
 
         let schema_two = Schema::Ref {
-            name: Name::try_from("ref").expect("Name is valid"),
+            name: Name::try_from("ref").expect("Name is valid").into(),
         };
 
         let specification_eq_res = SPECIFICATION_EQ.compare(&schema_one, &schema_two);
@@ -627,7 +627,7 @@ mod tests {
     #[test]
     fn test_avro_3939_compare_record_schemata() {
         let schema_one = Schema::Record(RecordSchema {
-            name: Name::try_from("record").expect("Name is valid"),
+            name: Name::try_from("record").expect("Name is valid").into(),
             doc: None,
             fields: vec![
                 RecordField::builder()
@@ -643,7 +643,7 @@ mod tests {
         assert!(!STRUCT_FIELD_EQ.compare(&schema_one, &Schema::Boolean));
 
         let schema_two = Schema::Record(RecordSchema {
-            name: Name::try_from("record").expect("Name is valid"),
+            name: Name::try_from("record").expect("Name is valid").into(),
             doc: None,
             fields: vec![
                 RecordField::builder()
@@ -696,7 +696,7 @@ mod tests {
         let string = Schema::Uuid(UuidSchema::String);
         let bytes = Schema::Uuid(UuidSchema::Bytes);
         let mut fixed_schema = FixedSchema {
-            name: Name::new("some_name")?,
+            name: Name::new("some_name")?.into(),
             aliases: None,
             doc: None,
             size: 16,

--- a/avro/src/serde/derive.rs
+++ b/avro/src/serde/derive.rs
@@ -385,7 +385,7 @@ pub fn get_record_fields_in_ctxt(
             // Get the schema
             let schema = schema_fn(named_schemas, enclosing_namespace);
             // Reinsert the old value
-            named_schemas.insert(name);
+            named_schemas.insert(name.as_ref().clone());
 
             // Now check if we actually got a record and return the fields if that is the case
             let Schema::Record(record) = schema else {
@@ -401,7 +401,7 @@ pub fn get_record_fields_in_ctxt(
     // Find the first Schema::Ref that has the target name
     fn find_first_ref<'a>(schema: &'a mut Schema, target: &Name) -> Option<&'a mut Schema> {
         match schema {
-            Schema::Ref { name } if name == target => Some(schema),
+            Schema::Ref { name } if name.as_ref() == target => Some(schema),
             Schema::Array(array) => find_first_ref(&mut array.items, target),
             Schema::Map(map) => find_first_ref(&mut map.types, target),
             Schema::Union(union) => {
@@ -414,7 +414,7 @@ pub fn get_record_fields_in_ctxt(
             }
             Schema::Record(record) => {
                 assert_ne!(
-                    &record.name, target,
+                    record.name.as_ref(), target,
                     "Only expecting a Ref named {target:?}"
                 );
                 for field in &mut record.fields {
@@ -471,7 +471,7 @@ pub fn get_record_fields_in_ctxt(
             };
 
             // The schema is used, so reinsert it
-            named_schemas.insert(name.clone());
+            named_schemas.insert(name.as_ref().clone());
 
             break;
         }
@@ -640,10 +640,10 @@ impl AvroSchemaComponent for core::time::Duration {
         let name = Name::new_with_enclosing_namespace("duration", enclosing_namespace)
             .expect("Name is valid");
         if named_schemas.contains(&name) {
-            Schema::Ref { name }
+            Schema::Ref { name: name.into() }
         } else {
             let schema = Schema::Duration(FixedSchema {
-                name: name.clone(),
+                name: name.clone().into(),
                 aliases: None,
                 doc: None,
                 size: 12,
@@ -673,10 +673,10 @@ impl AvroSchemaComponent for uuid::Uuid {
         let name =
             Name::new_with_enclosing_namespace("uuid", enclosing_namespace).expect("Name is valid");
         if named_schemas.contains(&name) {
-            Schema::Ref { name }
+            Schema::Ref { name: name.into() }
         } else {
             let schema = Schema::Uuid(UuidSchema::Fixed(FixedSchema {
-                name: name.clone(),
+                name: name.clone().into(),
                 aliases: None,
                 doc: None,
                 size: 16,
@@ -704,10 +704,10 @@ impl AvroSchemaComponent for u64 {
         let name =
             Name::new_with_enclosing_namespace("u64", enclosing_namespace).expect("Name is valid");
         if named_schemas.contains(&name) {
-            Schema::Ref { name }
+            Schema::Ref { name: name.into() }
         } else {
             let schema = Schema::Fixed(FixedSchema {
-                name: name.clone(),
+                name: name.clone().into(),
                 aliases: None,
                 doc: None,
                 size: 8,
@@ -735,10 +735,10 @@ impl AvroSchemaComponent for u128 {
         let name =
             Name::new_with_enclosing_namespace("u128", enclosing_namespace).expect("Name is valid");
         if named_schemas.contains(&name) {
-            Schema::Ref { name }
+            Schema::Ref { name: name.into() }
         } else {
             let schema = Schema::Fixed(FixedSchema {
-                name: name.clone(),
+                name: name.clone().into(),
                 aliases: None,
                 doc: None,
                 size: 16,
@@ -766,10 +766,10 @@ impl AvroSchemaComponent for i128 {
         let name =
             Name::new_with_enclosing_namespace("i128", enclosing_namespace).expect("Name is valid");
         if named_schemas.contains(&name) {
-            Schema::Ref { name }
+            Schema::Ref { name: name.into() }
         } else {
             let schema = Schema::Fixed(FixedSchema {
-                name: name.clone(),
+                name: name.clone().into(),
                 aliases: None,
                 doc: None,
                 size: 16,
@@ -859,7 +859,7 @@ mod tests {
         assert_eq!(
             schema,
             Schema::Fixed(FixedSchema {
-                name: Name::new("u64")?,
+                name: Name::new("u64")?.into(),
                 aliases: None,
                 doc: None,
                 size: 8,
@@ -876,7 +876,7 @@ mod tests {
         assert_eq!(
             schema,
             Schema::Fixed(FixedSchema {
-                name: Name::new("i128")?,
+                name: Name::new("i128")?.into(),
                 aliases: None,
                 doc: None,
                 size: 16,
@@ -893,7 +893,7 @@ mod tests {
         assert_eq!(
             schema,
             Schema::Fixed(FixedSchema {
-                name: Name::new("u128")?,
+                name: Name::new("u128")?.into(),
                 aliases: None,
                 doc: None,
                 size: 16,

--- a/avro/src/serde/derive.rs
+++ b/avro/src/serde/derive.rs
@@ -297,13 +297,13 @@ pub trait AvroSchema {
 ///         // Create the fully qualified name for your type given the enclosing namespace
 ///         let name = Name::new_with_enclosing_namespace("Foo", enclosing_namespace).expect("Name is valid");
 ///         if named_schemas.contains(&name) {
-///             Schema::Ref { name }
+///             Schema::Ref { name: name.into() }
 ///         } else {
 ///             let enclosing_namespace = name.namespace();
 ///             // Do this before you start creating the schema, as otherwise recursive types will cause infinite recursion.
 ///             named_schemas.insert(name.clone());
 ///             let schema = Schema::Record(RecordSchema::builder()
-///                 .name(name.clone())
+///                 .name(name.clone().into())
 ///                 .fields(Self::get_record_fields_in_ctxt(named_schemas, enclosing_namespace).expect("Impossible!"))
 ///                 .build()
 ///             );

--- a/avro/src/serde/ser_schema/mod.rs
+++ b/avro/src/serde/ser_schema/mod.rs
@@ -2458,9 +2458,7 @@ mod tests {
     #[test]
     fn test_serialize_nullable_union() -> TestResult {
         let schema = Schema::parse_str(
-            r#"{
-            "type": ["null", "long"]
-        }"#,
+            r#"["null", "long"]"#,
         )?;
 
         #[derive(Serialize)]
@@ -2505,9 +2503,7 @@ mod tests {
     #[test]
     fn test_serialize_union() -> TestResult {
         let schema = Schema::parse_str(
-            r#"{
-            "type": ["null", "long", "string"]
-        }"#,
+            r#"["null", "long", "string"]"#,
         )?;
 
         #[derive(Serialize)]

--- a/avro/src/serde/ser_schema/mod.rs
+++ b/avro/src/serde/ser_schema/mod.rs
@@ -17,7 +17,7 @@
 
 //! Logic for serde-compatible schema-aware serialization which writes directly to a writer.
 
-use crate::schema::{DecimalSchema, InnerDecimalSchema, UuidSchema};
+use crate::schema::{DecimalSchema, InnerDecimalSchema, NameMap, UuidSchema};
 use crate::{
     bigdecimal::big_decimal_as_bytes,
     encode::{encode_int, encode_long},
@@ -604,7 +604,7 @@ impl<W: Write> ser::SerializeTupleVariant for SchemaAwareWriteSerializeTupleStru
 pub struct SchemaAwareWriteSerializer<'s, W: Write> {
     writer: &'s mut W,
     root_schema: &'s Schema,
-    names: &'s NamesRef<'s>,
+    names: &'s NameMap,
     enclosing_namespace: Namespace,
 }
 
@@ -621,7 +621,7 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
     pub fn new(
         writer: &'s mut W,
         schema: &'s Schema,
-        names: &'s NamesRef<'s>,
+        names: &'s NameMap,
         enclosing_namespace: Namespace,
     ) -> SchemaAwareWriteSerializer<'s, W> {
         SchemaAwareWriteSerializer {
@@ -635,7 +635,7 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
     fn get_ref_schema(&self, name: &'s Name) -> Result<&'s Schema, Error> {
         let full_name = name.fully_qualified_name(self.enclosing_namespace.as_deref());
 
-        let ref_schema = self.names.get(full_name.as_ref()).copied();
+        let ref_schema = self.names.get(full_name.as_ref()).and_then(|arc_ref| Some(arc_ref.as_ref()));
 
         ref_schema.ok_or_else(|| Details::SchemaResolutionError(full_name.as_ref().clone()).into())
     }
@@ -3314,7 +3314,7 @@ mod tests {
     #[test]
     fn avro_rs_414_serialize_char_as_fixed() -> TestResult {
         let schema = Schema::Fixed(FixedSchema {
-            name: Name::new("char")?,
+            name: Name::new("char")?.into(),
             aliases: None,
             doc: None,
             size: 4,
@@ -3365,7 +3365,7 @@ mod tests {
     #[test]
     fn avro_rs_414_serialize_emoji_char_as_fixed() -> TestResult {
         let schema = Schema::Fixed(FixedSchema {
-            name: Name::new("char")?,
+            name: Name::new("char")?.into(),
             aliases: None,
             doc: None,
             size: 4,
@@ -3388,7 +3388,7 @@ mod tests {
     #[test]
     fn avro_rs_414_serialize_char_as_fixed_wrong_name() -> TestResult {
         let schema = Schema::Fixed(FixedSchema {
-            name: Name::new("characters")?,
+            name: Name::new("characters")?.into(),
             aliases: None,
             doc: None,
             size: 4,
@@ -3410,7 +3410,7 @@ mod tests {
     #[test]
     fn avro_rs_414_serialize_char_as_fixed_wrong_size() -> TestResult {
         let schema = Schema::Fixed(FixedSchema {
-            name: Name::new("char")?,
+            name: Name::new("char")?.into(),
             aliases: None,
             doc: None,
             size: 1,
@@ -3432,7 +3432,7 @@ mod tests {
     #[test]
     fn avro_rs_414_serialize_i128_as_fixed() -> TestResult {
         let schema = Schema::Fixed(FixedSchema {
-            name: Name::new("i128")?,
+            name: Name::new("i128")?.into(),
             aliases: None,
             doc: None,
             size: 16,
@@ -3460,7 +3460,7 @@ mod tests {
     #[test]
     fn avro_rs_414_serialize_i128_as_fixed_wrong_name() -> TestResult {
         let schema = Schema::Fixed(FixedSchema {
-            name: Name::new("onehundredtwentyeight")?,
+            name: Name::new("onehundredtwentyeight")?.into(),
             aliases: None,
             doc: None,
             size: 16,
@@ -3482,7 +3482,7 @@ mod tests {
     #[test]
     fn avro_rs_414_serialize_i128_as_fixed_wrong_size() -> TestResult {
         let schema = Schema::Fixed(FixedSchema {
-            name: Name::new("i128")?,
+            name: Name::new("i128")?.into(),
             aliases: None,
             doc: None,
             size: 8,
@@ -3504,7 +3504,7 @@ mod tests {
     #[test]
     fn avro_rs_414_serialize_u128_as_fixed() -> TestResult {
         let schema = Schema::Fixed(FixedSchema {
-            name: Name::new("u128")?,
+            name: Name::new("u128")?.into(),
             aliases: None,
             doc: None,
             size: 16,
@@ -3532,7 +3532,7 @@ mod tests {
     #[test]
     fn avro_rs_414_serialize_u128_as_fixed_wrong_name() -> TestResult {
         let schema = Schema::Fixed(FixedSchema {
-            name: Name::new("onehundredtwentyeight")?,
+            name: Name::new("onehundredtwentyeight")?.into(),
             aliases: None,
             doc: None,
             size: 16,
@@ -3554,7 +3554,7 @@ mod tests {
     #[test]
     fn avro_rs_414_serialize_u128_as_fixed_wrong_size() -> TestResult {
         let schema = Schema::Fixed(FixedSchema {
-            name: Name::new("u128")?,
+            name: Name::new("u128")?.into(),
             aliases: None,
             doc: None,
             size: 8,

--- a/avro/src/serde/ser_schema/mod.rs
+++ b/avro/src/serde/ser_schema/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     bigdecimal::big_decimal_as_bytes,
     encode::{encode_int, encode_long},
     error::{Details, Error},
-    schema::{Name, NamesRef, Namespace, RecordField, RecordSchema, Schema},
+    schema::{Name, Namespace, RecordField, RecordSchema, Schema},
     serde::util::StringSerializer,
 };
 use bigdecimal::BigDecimal;
@@ -635,7 +635,7 @@ impl<'s, W: Write> SchemaAwareWriteSerializer<'s, W> {
     fn get_ref_schema(&self, name: &'s Name) -> Result<&'s Schema, Error> {
         let full_name = name.fully_qualified_name(self.enclosing_namespace.as_deref());
 
-        let ref_schema = self.names.get(full_name.as_ref()).and_then(|arc_ref| Some(arc_ref.as_ref()));
+        let ref_schema = self.names.get(full_name.as_ref()).map(|arc_ref| arc_ref.as_ref());
 
         ref_schema.ok_or_else(|| Details::SchemaResolutionError(full_name.as_ref().clone()).into())
     }

--- a/avro/src/serde/with.rs
+++ b/avro/src/serde/with.rs
@@ -251,9 +251,9 @@ pub mod fixed {
         )
         .expect("Name is valid");
         if named_schemas.contains(&name) {
-            Schema::Ref { name }
+            Schema::Ref { name: name.into() }
         } else {
-            let schema = Schema::Fixed(FixedSchema::builder().name(name.clone()).size(N).build());
+            let schema = Schema::Fixed(FixedSchema::builder().name(name.clone().into()).size(N).build());
             named_schemas.insert(name);
             schema
         }

--- a/avro/src/types.rs
+++ b/avro/src/types.rs
@@ -1338,26 +1338,6 @@ mod tests {
                 false,
                 r#"Invalid value: Record([("unknown_field_name", Null)]) for schema: Record(RecordSchema { name: Name { name: "record_name", .. }, fields: [RecordField { name: "field_name", schema: Int, .. }], .. }). Reason: There is no schema field for field 'unknown_field_name'"#,
             ),
-            (
-                Value::Record(vec![("field_name".to_string(), Value::Null)]),
-                Schema::Record(RecordSchema {
-                    name: Name::new("record_name")?.into(),
-                    aliases: None,
-                    doc: None,
-                    fields: vec![
-                        RecordField::builder()
-                            .name("field_name".to_string())
-                            .schema(Schema::Ref {
-                                name: Name::new("missing")?.into(),
-                            })
-                            .build(),
-                    ],
-                    lookup: [("field_name".to_string(), 0)].iter().cloned().collect(),
-                    attributes: Default::default(),
-                }),
-                false,
-                r#"Invalid value: Record([("field_name", Null)]) for schema: Record(RecordSchema { name: Name { name: "record_name", .. }, fields: [RecordField { name: "field_name", schema: Ref { name: Name { name: "missing", .. } }, .. }], .. }). Reason: Unresolved schema reference: 'Name { name: "missing", .. }'. Parsed names: []"#,
-            ),
         ];
 
         for (value, schema, valid, expected_err_message) in value_schema_valid.into_iter() {
@@ -1379,17 +1359,17 @@ mod tests {
 
     #[test]
     fn validate_fixed() -> TestResult {
-        let schema = Schema::Fixed(FixedSchema {
+        let schema = ResolvedSchema::try_from(Schema::Fixed(FixedSchema {
             size: 4,
             name: Name::new("some_fixed")?.into(),
             aliases: None,
             doc: None,
             attributes: Default::default(),
-        });
+        }))?;
 
-        assert!(Value::Fixed(4, vec![0, 0, 0, 0]).validate(&schema));
+        assert!(Value::Fixed(4, vec![0, 0, 0, 0]).validate_against_resolved(&schema));
         let value = Value::Fixed(5, vec![0, 0, 0, 0, 0]);
-        assert!(!value.validate(&schema));
+        assert!(!value.validate_against_resolved(&schema));
         assert_logged(
             format!(
                 "Invalid value: {:?} for schema: {:?}. Reason: {}",
@@ -1398,9 +1378,9 @@ mod tests {
             .as_str(),
         );
 
-        assert!(Value::Bytes(vec![0, 0, 0, 0]).validate(&schema));
+        assert!(Value::Bytes(vec![0, 0, 0, 0]).validate_against_resolved(&schema));
         let value = Value::Bytes(vec![0, 0, 0, 0, 0]);
-        assert!(!value.validate(&schema));
+        assert!(!value.validate_against_resolved(&schema));
         assert_logged(
             format!(
                 "Invalid value: {:?} for schema: {:?}. Reason: {}",
@@ -1427,12 +1407,13 @@ mod tests {
             default: None,
             attributes: Default::default(),
         });
+        let [schema] = ResolvedSchema::resolve().build_array([&schema])?;
 
-        assert!(Value::Enum(0, "spades".to_string()).validate(&schema));
-        assert!(Value::String("spades".to_string()).validate(&schema));
+        assert!(Value::Enum(0, "spades".to_string()).validate_against_resolved(&schema));
+        assert!(Value::String("spades".to_string()).validate_against_resolved(&schema));
 
         let value = Value::Enum(1, "spades".to_string());
-        assert!(!value.validate(&schema));
+        assert!(!value.validate_against_resolved(&schema));
         assert_logged(
             format!(
                 "Invalid value: {:?} for schema: {:?}. Reason: {}",
@@ -1442,7 +1423,7 @@ mod tests {
         );
 
         let value = Value::Enum(1000, "spades".to_string());
-        assert!(!value.validate(&schema));
+        assert!(!value.validate_against_resolved(&schema));
         assert_logged(
             format!(
                 "Invalid value: {:?} for schema: {:?}. Reason: {}",
@@ -1452,7 +1433,7 @@ mod tests {
         );
 
         let value = Value::String("lorem".to_string());
-        assert!(!value.validate(&schema));
+        assert!(!value.validate_against_resolved(&schema));
         assert_logged(
             format!(
                 "Invalid value: {:?} for schema: {:?}. Reason: {}",
@@ -1474,9 +1455,10 @@ mod tests {
             default: None,
             attributes: Default::default(),
         });
+        let [other_schema] = ResolvedSchema::resolve().build_array([&other_schema])?;
 
         let value = Value::Enum(0, "spades".to_string());
-        assert!(!value.validate(&other_schema));
+        assert!(!value.validate_against_resolved(&other_schema));
         assert_logged(
             format!(
                 "Invalid value: {:?} for schema: {:?}. Reason: {}",
@@ -1502,7 +1484,7 @@ mod tests {
         //      }
         //    ]
         // }
-        let schema = Schema::Record(RecordSchema {
+        let raw_schema = Schema::Record(RecordSchema {
             name: Name::new("some_record")?.into(),
             aliases: None,
             doc: None,
@@ -1535,36 +1517,46 @@ mod tests {
             attributes: Default::default(),
         });
 
+        let schema = ResolvedSchema::try_from(&raw_schema)?;
+
         assert!(
             Value::Record(vec![
                 ("a".to_string(), Value::Long(42i64)),
                 ("b".to_string(), Value::String("foo".to_string())),
             ])
-            .validate(&schema)
+            .validate_against_resolved(&schema)
         );
 
         let value = Value::Record(vec![
             ("b".to_string(), Value::String("foo".to_string())),
             ("a".to_string(), Value::Long(42i64)),
         ]);
-        assert!(value.validate(&schema));
+        assert!(value.validate_against_resolved(&schema));
 
         let value = Value::Record(vec![
             ("a".to_string(), Value::Boolean(false)),
             ("b".to_string(), Value::String("foo".to_string())),
         ]);
-        assert!(!value.validate(&schema));
+        assert!(!value.validate_against_resolved(&schema));
         assert_logged(
-            r#"Invalid value: Record([("a", Boolean(false)), ("b", String("foo"))]) for schema: Record(RecordSchema { name: Name { name: "some_record", .. }, fields: [RecordField { name: "a", schema: Long, .. }, RecordField { name: "b", schema: String, .. }, RecordField { name: "c", default: Null, schema: Union(UnionSchema { schemas: [Null, Int] }), .. }], .. }). Reason: Unsupported value-schema combination! Value: Boolean(false), schema: Long"#,
+            &format!(
+                "Invalid value: {:?} for schema: {:?}. Reason: {}",
+                value, schema,
+                "Unsupported value-schema combination! Value: Boolean(false), schema: Long"
+            ).to_string(),
         );
 
         let value = Value::Record(vec![
             ("a".to_string(), Value::Long(42i64)),
             ("c".to_string(), Value::String("foo".to_string())),
         ]);
-        assert!(!value.validate(&schema));
+        assert!(!value.validate_against_resolved(&schema));
         assert_logged(
-            r#"Invalid value: Record([("a", Long(42)), ("c", String("foo"))]) for schema: Record(RecordSchema { name: Name { name: "some_record", .. }, fields: [RecordField { name: "a", schema: Long, .. }, RecordField { name: "b", schema: String, .. }, RecordField { name: "c", default: Null, schema: Union(UnionSchema { schemas: [Null, Int] }), .. }], .. }). Reason: Could not find matching type in union"#,
+            &format!(
+                "Invalid value: {:?} for schema: {:?}. Reason: {}",
+                value, schema,
+                "Could not find matching type in union"
+            ).to_string(),
         );
         assert_not_logged(
             r#"Invalid value: String("foo") for schema: Int. Reason: Unsupported value-schema combination"#,
@@ -1574,9 +1566,13 @@ mod tests {
             ("a".to_string(), Value::Long(42i64)),
             ("d".to_string(), Value::String("foo".to_string())),
         ]);
-        assert!(!value.validate(&schema));
+        assert!(!value.validate_against_resolved(&schema));
         assert_logged(
-            r#"Invalid value: Record([("a", Long(42)), ("d", String("foo"))]) for schema: Record(RecordSchema { name: Name { name: "some_record", .. }, fields: [RecordField { name: "a", schema: Long, .. }, RecordField { name: "b", schema: String, .. }, RecordField { name: "c", default: Null, schema: Union(UnionSchema { schemas: [Null, Int] }), .. }], .. }). Reason: There is no schema field for field 'd'"#,
+            &format!(
+                "Invalid value: {:?} for schema: {:?}. Reason: {}",
+                value, schema,
+                "There is no schema field for field 'd'"
+            ).to_string(),
         );
 
         let value = Value::Record(vec![
@@ -1585,9 +1581,13 @@ mod tests {
             ("c".to_string(), Value::Null),
             ("d".to_string(), Value::Null),
         ]);
-        assert!(!value.validate(&schema));
+        assert!(!value.validate_against_resolved(&schema));
         assert_logged(
-            r#"Invalid value: Record([("a", Long(42)), ("b", String("foo")), ("c", Null), ("d", Null)]) for schema: Record(RecordSchema { name: Name { name: "some_record", .. }, fields: [RecordField { name: "a", schema: Long, .. }, RecordField { name: "b", schema: String, .. }, RecordField { name: "c", default: Null, schema: Union(UnionSchema { schemas: [Null, Int] }), .. }], .. }). Reason: The value's records length (4) is greater than the schema's (3 fields)"#,
+            &format!(
+                "Invalid value: {:?} for schema: {:?}. Reason: {}",
+                value, schema,
+                "The value's records length (4) is greater than the schema's (3 fields)"
+            ).to_string(),
         );
 
         assert!(
@@ -1599,23 +1599,28 @@ mod tests {
                 .into_iter()
                 .collect()
             )
-            .validate(&schema)
+            .validate_against_resolved(&schema)
         );
 
-        assert!(
-            !Value::Map(
+        let value = Value::Map(
                 vec![("d".to_string(), Value::Long(123_i64)),]
                     .into_iter()
                     .collect()
-            )
-            .validate(&schema)
-        );
-        assert_logged(
-            r#"Invalid value: Map({"d": Long(123)}) for schema: Record(RecordSchema { name: Name { name: "some_record", .. }, fields: [RecordField { name: "a", schema: Long, .. }, RecordField { name: "b", schema: String, .. }, RecordField { name: "c", default: Null, schema: Union(UnionSchema { schemas: [Null, Int] }), .. }], .. }). Reason: Field with name '"a"' is not a member of the map items
-Field with name '"b"' is not a member of the map items"#,
+            );
+
+        assert!(
+            !value.validate_against_resolved(&schema)
         );
 
-        let union_schema = Schema::Union(UnionSchema::new(vec![Schema::Null, schema])?);
+        assert_logged(
+            &format!(
+                "Invalid value: {:?} for schema: {:?}. Reason: {}",
+                value, schema,
+                "Field with name '\"a\"' is not a member of the map items\nField with name '\"b\"' is not a member of the map items"
+            ).to_string(),
+        );
+
+        let union_schema = ResolvedSchema::try_from(Schema::Union(UnionSchema::new(vec![Schema::Null, raw_schema])?))?;
 
         assert!(
             Value::Union(
@@ -1625,7 +1630,7 @@ Field with name '"b"' is not a member of the map items"#,
                     ("b".to_string(), Value::String("foo".to_string())),
                 ]))
             )
-            .validate(&union_schema)
+            .validate_against_resolved(&union_schema)
         );
 
         assert!(
@@ -1640,7 +1645,7 @@ Field with name '"b"' is not a member of the map items"#,
                     .collect()
                 ))
             )
-            .validate(&union_schema)
+            .validate_against_resolved(&union_schema)
         );
 
         Ok(())
@@ -2991,7 +2996,7 @@ Field with name '"b"' is not a member of the map items"#,
 
         let avro_value = Value::try_from(value)?;
 
-        let [rs] = ResolvedSchema::from_str_array([main_schema], vec![referenced_schema])?;
+        let [rs] = ResolvedSchema::resolve().additional(vec![referenced_schema])?.build_array([main_schema])?;
 
         let resolve_result = avro_value.clone().resolve_against_resolved(rs);
 
@@ -3028,7 +3033,7 @@ Field with name '"b"' is not a member of the map items"#,
 
         let avro_value = Value::try_from(value)?;
 
-        let [rs] = ResolvedSchema::from_str_array([main_schema], vec![referenced_enum, referenced_record])?;
+        let [rs] = ResolvedSchema::resolve().additional(vec![referenced_enum, referenced_record])?.build_array([main_schema])?;
 
         let resolve_result = avro_value.resolve_against_resolved(rs.clone())?;
 

--- a/avro/src/types.rs
+++ b/avro/src/types.rs
@@ -369,9 +369,9 @@ impl TryFrom<Value> for JsonValue {
 
 impl Value {
     /// Validate the value against the given [Schema](../schema/enum.Schema.html).
-    /// This is a convenience method to keep backwards compatibility intact and is slow.
-    /// This method copies the supplied schema and attempts to convert it into ResolvedSchema.
-    /// Prefer using validate_complete if able.
+    /// This is a convenience method to keep backwards compatibility and may not be the fastest option.
+    /// This method copies the supplied schema and attempts to convert it into [`ResolvedSchema`].
+    /// Prefer using [`Self::validate_against_resolved`] if able.
     ///
     /// See the [Avro specification](https://avro.apache.org/docs/++version++/specification)
     /// for the full set of rules of schema validation.
@@ -388,7 +388,10 @@ impl Value {
         }
     }
 
-    /// Validates this value against the given ResolvedSchema.
+    /// Validates this value against the given [`ResolvedSchema`].
+    ///
+    /// See the [Avro specification](https://avro.apache.org/docs/++version++/specification)
+    /// for the full set of rules of schema validation.
     pub fn validate_against_resolved(&self, schema: &ResolvedSchema) -> bool {
         match self.validate_internal(ResolvedNode::new(schema)){
             Some(reason) => {
@@ -632,19 +635,19 @@ impl Value {
 
     /// Resolve this value (self) with provided resolved schema.
     /// This resolution techinically follows a superset of the the schema resolution
-    /// rules defined by the specification. TODO: documentation
+    /// rules defined by the [specification](https://avro.apache.org/docs/++version++/specification/).
     pub fn resolve_against_resolved(self, resolved: ResolvedSchema) -> AvroResult<Self> {
         self.resolve_internal(ResolvedNode::new(&resolved))
     }
 
     /// Resolves value against the provided schema.
     /// This resolution follows a superset of the schema resolution rules defined by the
-    /// specification. TODO: link to docs
-    /// Provided Schema is first cloned then transformed into a ResolvedSchema, which is
-    /// slow and may fail. If succesfull, this function simply calls resolve_complete
-    /// with this new ResolvedSchema.
-    /// Prefer using resolve_complete on a given ResolvedSchema,
-    /// this function exists for convenience and to maintain backwards compatibility.
+    /// [specification](https://avro.apache.org/docs/++version++/specification/).
+    ///
+    /// **Note:** The provided [`Schema`] is first cloned then transformed into a [`ResolvedSchema`], which can
+    /// be slow and may fail. If succesfull, this function simply calls [`Self::resolve_against_resolved`]
+    /// with this new [`ResolvedSchema`].
+    /// Prefer using [`Self::resolve_against_resolved`] on a given [`ResolvedSchema`].
     pub fn resolve(self, schema: &Schema)->AvroResult<Self>{
        self.resolve_against_resolved(schema.clone().try_into()?)
     }
@@ -1407,7 +1410,7 @@ mod tests {
             default: None,
             attributes: Default::default(),
         });
-        let [schema] = ResolvedSchema::resolve().build_array([&schema])?;
+        let [schema] = ResolvedSchema::builder().build_array([&schema])?;
 
         assert!(Value::Enum(0, "spades".to_string()).validate_against_resolved(&schema));
         assert!(Value::String("spades".to_string()).validate_against_resolved(&schema));
@@ -1455,7 +1458,7 @@ mod tests {
             default: None,
             attributes: Default::default(),
         });
-        let [other_schema] = ResolvedSchema::resolve().build_array([&other_schema])?;
+        let [other_schema] = ResolvedSchema::builder().build_array([&other_schema])?;
 
         let value = Value::Enum(0, "spades".to_string());
         assert!(!value.validate_against_resolved(&other_schema));
@@ -2996,7 +2999,7 @@ mod tests {
 
         let avro_value = Value::try_from(value)?;
 
-        let [rs] = ResolvedSchema::resolve().additional(vec![referenced_schema])?.build_array([main_schema])?;
+        let [rs] = ResolvedSchema::builder().additional(vec![referenced_schema])?.build_array([main_schema])?;
 
         let resolve_result = avro_value.clone().resolve_against_resolved(rs);
 
@@ -3005,7 +3008,7 @@ mod tests {
             "result of resolving with schemata should be ok, got: {resolve_result:?}"
         );
 
-        let resolve_result = avro_value.resolve(&Schema::parse_str(&main_schema)?);
+        let resolve_result = avro_value.resolve(&Schema::parse_str(main_schema)?);
         assert!(
             resolve_result.is_err(),
             "result of resolving without schemata should be err, got: {resolve_result:?}"
@@ -3033,7 +3036,7 @@ mod tests {
 
         let avro_value = Value::try_from(value)?;
 
-        let [rs] = ResolvedSchema::resolve().additional(vec![referenced_enum, referenced_record])?.build_array([main_schema])?;
+        let [rs] = ResolvedSchema::builder().additional(vec![referenced_enum, referenced_record])?.build_array([main_schema])?;
 
         let resolve_result = avro_value.resolve_against_resolved(rs.clone())?;
 

--- a/avro/src/types.rs
+++ b/avro/src/types.rs
@@ -16,7 +16,8 @@
 // under the License.
 
 //! Logic handling the intermediate representation of Avro values.
-use crate::schema::{InnerDecimalSchema, NamespaceRef, UuidSchema};
+use crate::schema::{InnerDecimalSchema, UuidSchema, ResolvedNode,
+    ResolvedRecord, ResolvedMap, ResolvedArray, ResolvedUnion};
 use crate::{
     AvroResult, Error,
     bigdecimal::{deserialize_big_decimal, serialize_big_decimal},
@@ -24,15 +25,14 @@ use crate::{
     duration::Duration,
     error::Details,
     schema::{
-        DecimalSchema, EnumSchema, FixedSchema, Name, Precision, RecordField, RecordSchema,
-        ResolvedSchema, Scale, Schema, SchemaKind, UnionSchema,
+        DecimalSchema, EnumSchema, FixedSchema, Precision, RecordSchema,
+        ResolvedSchema, Scale, Schema, SchemaKind,
     },
 };
 use bigdecimal::BigDecimal;
-use log::{debug, error};
+use log::{error};
 use serde_json::{Number, Value as JsonValue};
 use std::{
-    borrow::Borrow,
     collections::{BTreeMap, HashMap},
     fmt::Debug,
     hash::BuildHasher,
@@ -369,32 +369,36 @@ impl TryFrom<Value> for JsonValue {
 
 impl Value {
     /// Validate the value against the given [Schema](../schema/enum.Schema.html).
+    /// This is a convenience method to keep backwards compatibility intact and is slow.
+    /// This method copies the supplied schema and attempts to convert it into ResolvedSchema.
+    /// Prefer using validate_complete if able.
     ///
     /// See the [Avro specification](https://avro.apache.org/docs/++version++/specification)
     /// for the full set of rules of schema validation.
     pub fn validate(&self, schema: &Schema) -> bool {
-        self.validate_schemata(vec![schema])
+        let resolved_schema : Result<ResolvedSchema,_> = schema.clone().try_into();
+        match resolved_schema{
+           Ok(resolved) => {
+               self.validate_against_resolved(&resolved)
+           },
+           Err(error) => {
+               error!("{error:?}");
+               false
+           }
+        }
     }
 
-    pub fn validate_schemata(&self, schemata: Vec<&Schema>) -> bool {
-        let rs = ResolvedSchema::try_from(schemata.clone())
-            .expect("Schemata didn't successfully resolve");
-        let schemata_len = schemata.len();
-        schemata.iter().any(
-            |schema| match self.validate_internal(schema, rs.get_names(), None) {
-                Some(reason) => {
-                    let log_message =
-                        format!("Invalid value: {self:?} for schema: {schema:?}. Reason: {reason}");
-                    if schemata_len == 1 {
-                        error!("{log_message}");
-                    } else {
-                        debug!("{log_message}");
-                    };
-                    false
-                }
-                None => true,
-            },
-        )
+    /// Validates this value against the given ResolvedSchema.
+    pub fn validate_against_resolved(&self, schema: &ResolvedSchema) -> bool {
+        match self.validate_internal(ResolvedNode::new(schema)){
+            Some(reason) => {
+                let log_message =
+                    format!("Invalid value: {self:?} for schema: {schema:?}. Reason: {reason}");
+                error!("{log_message}");
+                false
+            }
+            None => true
+        }
     }
 
     fn accumulate(accumulator: Option<String>, other: Option<String>) -> Option<String> {
@@ -407,57 +411,42 @@ impl Value {
     }
 
     /// Validates the value against the provided schema.
-    pub(crate) fn validate_internal<S: Borrow<Schema> + Debug>(
+    pub(crate) fn validate_internal(
         &self,
-        schema: &Schema,
-        names: &HashMap<Name, S>,
-        enclosing_namespace: NamespaceRef,
+        node: ResolvedNode
     ) -> Option<String> {
-        match (self, schema) {
-            (_, Schema::Ref { name }) => {
-                let name = name.fully_qualified_name(enclosing_namespace);
-                names.get(&name).map_or_else(
-                    || {
-                        Some(format!(
-                            "Unresolved schema reference: '{:?}'. Parsed names: {:?}",
-                            name,
-                            names.keys()
-                        ))
-                    },
-                    |s| self.validate_internal(s.borrow(), names, name.namespace()),
-                )
-            }
-            (&Value::Null, &Schema::Null) => None,
-            (&Value::Boolean(_), &Schema::Boolean) => None,
-            (&Value::Int(_), &Schema::Int) => None,
-            (&Value::Int(_), &Schema::Date) => None,
-            (&Value::Int(_), &Schema::TimeMillis) => None,
-            (&Value::Int(_), &Schema::Long) => None,
-            (&Value::Long(_), &Schema::Long) => None,
-            (&Value::Long(_), &Schema::TimeMicros) => None,
-            (&Value::Long(_), &Schema::TimestampMillis) => None,
-            (&Value::Long(_), &Schema::TimestampMicros) => None,
-            (&Value::Long(_), &Schema::LocalTimestampMillis) => None,
-            (&Value::Long(_), &Schema::LocalTimestampMicros) => None,
-            (&Value::TimestampMicros(_), &Schema::TimestampMicros) => None,
-            (&Value::TimestampMillis(_), &Schema::TimestampMillis) => None,
-            (&Value::TimestampNanos(_), &Schema::TimestampNanos) => None,
-            (&Value::LocalTimestampMicros(_), &Schema::LocalTimestampMicros) => None,
-            (&Value::LocalTimestampMillis(_), &Schema::LocalTimestampMillis) => None,
-            (&Value::LocalTimestampNanos(_), &Schema::LocalTimestampNanos) => None,
-            (&Value::TimeMicros(_), &Schema::TimeMicros) => None,
-            (&Value::TimeMillis(_), &Schema::TimeMillis) => None,
-            (&Value::Date(_), &Schema::Date) => None,
-            (&Value::Decimal(_), &Schema::Decimal { .. }) => None,
-            (&Value::BigDecimal(_), &Schema::BigDecimal) => None,
-            (&Value::Duration(_), &Schema::Duration(_)) => None,
-            (&Value::Uuid(_), &Schema::Uuid(_)) => None,
-            (&Value::Float(_), &Schema::Float) => None,
-            (&Value::Float(_), &Schema::Double) => None,
-            (&Value::Double(_), &Schema::Double) => None,
-            (&Value::Bytes(_), &Schema::Bytes) => None,
-            (&Value::Bytes(_), &Schema::Decimal { .. }) => None,
-            (Value::Bytes(bytes), &Schema::Uuid(UuidSchema::Bytes)) => {
+        match (self, node) {
+            (&Value::Null, ResolvedNode::Null) => None,
+            (&Value::Boolean(_), ResolvedNode::Boolean) => None,
+            (&Value::Int(_), ResolvedNode::Int) => None,
+            (&Value::Int(_), ResolvedNode::Date) => None,
+            (&Value::Int(_), ResolvedNode::TimeMillis) => None,
+            (&Value::Int(_), ResolvedNode::Long) => None,
+            (&Value::Long(_), ResolvedNode::Long) => None,
+            (&Value::Long(_), ResolvedNode::TimeMicros) => None,
+            (&Value::Long(_), ResolvedNode::TimestampMillis) => None,
+            (&Value::Long(_), ResolvedNode::TimestampMicros) => None,
+            (&Value::Long(_), ResolvedNode::LocalTimestampMillis) => None,
+            (&Value::Long(_), ResolvedNode::LocalTimestampMicros) => None,
+            (&Value::TimestampMicros(_), ResolvedNode::TimestampMicros) => None,
+            (&Value::TimestampMillis(_), ResolvedNode::TimestampMillis) => None,
+            (&Value::TimestampNanos(_), ResolvedNode::TimestampNanos) => None,
+            (&Value::LocalTimestampMicros(_), ResolvedNode::LocalTimestampMicros) => None,
+            (&Value::LocalTimestampMillis(_), ResolvedNode::LocalTimestampMillis) => None,
+            (&Value::LocalTimestampNanos(_), ResolvedNode::LocalTimestampNanos) => None,
+            (&Value::TimeMicros(_), ResolvedNode::TimeMicros) => None,
+            (&Value::TimeMillis(_), ResolvedNode::TimeMillis) => None,
+            (&Value::Date(_), ResolvedNode::Date) => None,
+            (&Value::Decimal(_), ResolvedNode::Decimal { .. }) => None,
+            (&Value::BigDecimal(_), ResolvedNode::BigDecimal) => None,
+            (&Value::Duration(_), ResolvedNode::Duration(..)) => None,
+            (&Value::Uuid(_), ResolvedNode::Uuid(..)) => None,
+            (&Value::Float(_), ResolvedNode::Float) => None,
+            (&Value::Float(_), ResolvedNode::Double) => None,
+            (&Value::Double(_), ResolvedNode::Double) => None,
+            (&Value::Bytes(_), ResolvedNode::Bytes) => None,
+            (&Value::Bytes(_), ResolvedNode::Decimal { .. }) => None,
+            (Value::Bytes(bytes), ResolvedNode::Uuid(UuidSchema::Bytes)) => {
                 if bytes.len() != 16 {
                     Some(format!(
                         "The value's size ({}) is not the right length for a bytes UUID (16)",
@@ -467,8 +456,8 @@ impl Value {
                     None
                 }
             }
-            (&Value::String(_), &Schema::String) => None,
-            (Value::String(string), &Schema::Uuid(UuidSchema::String)) => {
+            (&Value::String(_), ResolvedNode::String) => None,
+            (Value::String(string), ResolvedNode::Uuid(UuidSchema::String)) => {
                 // Non-hyphenated is 32 characters, hyphenated is longer
                 if string.len() < 32 {
                     Some(format!(
@@ -479,8 +468,8 @@ impl Value {
                     None
                 }
             }
-            (&Value::Fixed(n, _), &Schema::Fixed(FixedSchema { size, .. })) => {
-                if n != size {
+            (&Value::Fixed(n, _), ResolvedNode::Fixed(FixedSchema { size, .. })) => {
+                if n != *size {
                     Some(format!(
                         "The value's size ({n}) is different than the schema's size ({size})"
                     ))
@@ -488,8 +477,8 @@ impl Value {
                     None
                 }
             }
-            (Value::Bytes(b), &Schema::Fixed(FixedSchema { size, .. })) => {
-                if b.len() != size {
+            (Value::Bytes(b), ResolvedNode::Fixed(FixedSchema { size, .. })) => {
+                if b.len() != *size {
                     Some(format!(
                         "The bytes' length ({}) is different than the schema's size ({})",
                         b.len(),
@@ -499,7 +488,7 @@ impl Value {
                     None
                 }
             }
-            (&Value::Fixed(n, _), &Schema::Duration(_)) => {
+            (&Value::Fixed(n, _), ResolvedNode::Duration(..)) => {
                 if n != 12 {
                     Some(format!(
                         "The value's size ('{n}') must be exactly 12 to be a Duration"
@@ -508,7 +497,7 @@ impl Value {
                     None
                 }
             }
-            (&Value::Fixed(n, _), Schema::Uuid(UuidSchema::Fixed(size, ..))) => {
+            (&Value::Fixed(n, _), ResolvedNode::Uuid(UuidSchema::Fixed(size, ..))) => {
                 if size.size != 16 {
                     Some(format!(
                         "The schema's size ('{}') must be exactly 16 to be a Uuid",
@@ -523,8 +512,8 @@ impl Value {
                 }
             }
             // TODO: check precision against n
-            (&Value::Fixed(_n, _), &Schema::Decimal { .. }) => None,
-            (Value::String(s), Schema::Enum(EnumSchema { symbols, .. })) => {
+            (&Value::Fixed(_n, _), ResolvedNode::Decimal { .. }) => None,
+            (Value::String(s), ResolvedNode::Enum(EnumSchema { symbols, .. })) => {
                 if !symbols.contains(s) {
                     Some(format!("'{s}' is not a member of the possible symbols"))
                 } else {
@@ -533,7 +522,7 @@ impl Value {
             }
             (
                 &Value::Enum(i, ref s),
-                Schema::Enum(EnumSchema {
+                ResolvedNode::Enum(EnumSchema {
                     symbols, default, ..
                 }),
             ) => symbols
@@ -550,39 +539,34 @@ impl Value {
                     None => Some(format!("No symbol at position '{i}'")),
                 }),
             // (&Value::Union(None), &Schema::Union(_)) => None,
-            (&Value::Union(i, ref value), Schema::Union(inner)) => inner
-                .variants()
+            (&Value::Union(i, ref value), ResolvedNode::Union(inner)) => inner
+                .resolve_schemas()
                 .get(i as usize)
-                .map(|schema| value.validate_internal(schema, names, enclosing_namespace))
+                .map(|node| value.validate_internal(node.clone()))
                 .unwrap_or_else(|| Some(format!("No schema in the union at position '{i}'"))),
-            (v, Schema::Union(inner)) => {
-                match inner.find_schema_with_known_schemata(v, Some(names), enclosing_namespace) {
+            (v, ResolvedNode::Union(inner)) => {
+                match inner.structural_match_on_schema(v) {
                     Some(_) => None,
                     None => Some("Could not find matching type in union".to_string()),
                 }
             }
-            (Value::Array(items), Schema::Array(inner)) => items.iter().fold(None, |acc, item| {
+            (Value::Array(items), ResolvedNode::Array(inner)) => items.iter().fold(None, |acc, item| {
                 Value::accumulate(
                     acc,
-                    item.validate_internal(&inner.items, names, enclosing_namespace),
+                    item.validate_internal(inner.resolve_items()),
                 )
             }),
-            (Value::Map(items), Schema::Map(inner)) => {
+            (Value::Map(items), ResolvedNode::Map(inner)) => {
                 items.iter().fold(None, |acc, (_, value)| {
                     Value::accumulate(
                         acc,
-                        value.validate_internal(&inner.types, names, enclosing_namespace),
+                        value.validate_internal(inner.resolve_types()),
                     )
                 })
             }
             (
                 Value::Record(record_fields),
-                Schema::Record(RecordSchema {
-                    fields,
-                    lookup,
-                    name,
-                    ..
-                }),
+                ResolvedNode::Record(ResolvedRecord{fields,lookup, name: _, ..})
             ) => {
                 let non_nullable_fields_count =
                     fields.iter().filter(|&rf| !rf.is_nullable()).count();
@@ -605,16 +589,13 @@ impl Value {
                 record_fields
                     .iter()
                     .fold(None, |acc, (field_name, record_field)| {
-                        let record_namespace = name.namespace().or(enclosing_namespace);
                         match lookup.get(field_name) {
                             Some(idx) => {
-                                let field = &fields[*idx];
+                                let resolved_field = fields.get(*idx).unwrap();
                                 Value::accumulate(
                                     acc,
                                     record_field.validate_internal(
-                                        &field.schema,
-                                        names,
-                                        record_namespace,
+                                        resolved_field.resolve_field()
                                     ),
                                 )
                             }
@@ -625,10 +606,10 @@ impl Value {
                         }
                     })
             }
-            (Value::Map(items), Schema::Record(RecordSchema { fields, .. })) => {
-                fields.iter().fold(None, |acc, field| {
-                    if let Some(item) = items.get(&field.name) {
-                        let res = item.validate_internal(&field.schema, names, enclosing_namespace);
+            (Value::Map(items), ResolvedNode::Record(resolved_record)) => {
+                resolved_record.fields.iter().fold(None, |acc, field| {
+                    if let Some(item) = items.get(field.name) {
+                        let res = item.validate_internal(field.resolve_field());
                         Value::accumulate(acc, res)
                     } else if !field.is_nullable() {
                         Value::accumulate(
@@ -649,42 +630,32 @@ impl Value {
         }
     }
 
-    /// Attempt to perform schema resolution on the value, with the given
-    /// [Schema](../schema/enum.Schema.html).
-    ///
-    /// See [Schema Resolution](https://avro.apache.org/docs/++version++/specification/#schema-resolution)
-    /// in the Avro specification for the full set of rules of schema
-    /// resolution.
-    pub fn resolve(self, schema: &Schema) -> AvroResult<Self> {
-        self.resolve_schemata(schema, Vec::with_capacity(0))
+    /// Resolve this value (self) with provided resolved schema.
+    /// This resolution techinically follows a superset of the the schema resolution
+    /// rules defined by the specification. TODO: documentation
+    pub fn resolve_against_resolved(self, resolved: ResolvedSchema) -> AvroResult<Self> {
+        self.resolve_internal(ResolvedNode::new(&resolved))
     }
 
-    /// Attempt to perform schema resolution on the value, with the given
-    /// [Schema](../schema/enum.Schema.html) and set of schemas to use for Refs resolution.
-    ///
-    /// See [Schema Resolution](https://avro.apache.org/docs/++version++/specification/#schema-resolution)
-    /// in the Avro specification for the full set of rules of schema
-    /// resolution.
-    pub fn resolve_schemata(self, schema: &Schema, schemata: Vec<&Schema>) -> AvroResult<Self> {
-        let enclosing_namespace = schema.namespace();
-        let rs = if schemata.is_empty() {
-            ResolvedSchema::try_from(schema)?
-        } else {
-            ResolvedSchema::try_from(schemata)?
-        };
-        self.resolve_internal(schema, rs.get_names(), enclosing_namespace, &None)
+    /// Resolves value against the provided schema.
+    /// This resolution follows a superset of the schema resolution rules defined by the
+    /// specification. TODO: link to docs
+    /// Provided Schema is first cloned then transformed into a ResolvedSchema, which is
+    /// slow and may fail. If succesfull, this function simply calls resolve_complete
+    /// with this new ResolvedSchema.
+    /// Prefer using resolve_complete on a given ResolvedSchema,
+    /// this function exists for convenience and to maintain backwards compatibility.
+    pub fn resolve(self, schema: &Schema)->AvroResult<Self>{
+       self.resolve_against_resolved(schema.clone().try_into()?)
     }
 
-    pub(crate) fn resolve_internal<S: Borrow<Schema> + Debug>(
+    pub(crate) fn resolve_internal(
         mut self,
-        schema: &Schema,
-        names: &HashMap<Name, S>,
-        enclosing_namespace: NamespaceRef,
-        field_default: &Option<JsonValue>,
+        node: ResolvedNode
     ) -> AvroResult<Self> {
         // Check if this schema is a union, and if the reader schema is not.
         if SchemaKind::from(&self) == SchemaKind::Union
-            && SchemaKind::from(schema) != SchemaKind::Union
+            && SchemaKind::from(&node) != SchemaKind::Union
         {
             // Pull out the Union, and attempt to resolve against it.
             let v = match self {
@@ -693,55 +664,48 @@ impl Value {
             };
             self = v;
         }
-        match schema {
-            Schema::Ref { name } => {
-                let name = name.fully_qualified_name(enclosing_namespace);
-
-                if let Some(resolved) = names.get(&name) {
-                    debug!("Resolved {name:?}");
-                    self.resolve_internal(resolved.borrow(), names, name.namespace(), field_default)
-                } else {
-                    error!("Failed to resolve schema {name:?}");
-                    Err(Details::SchemaResolutionError(name.into_owned()).into())
-                }
-            }
-            Schema::Null => self.resolve_null(),
-            Schema::Boolean => self.resolve_boolean(),
-            Schema::Int => self.resolve_int(),
-            Schema::Long => self.resolve_long(),
-            Schema::Float => self.resolve_float(),
-            Schema::Double => self.resolve_double(),
-            Schema::Bytes => self.resolve_bytes(),
-            Schema::String => self.resolve_string(),
-            Schema::Fixed(FixedSchema { size, .. }) => self.resolve_fixed(*size),
-            Schema::Union(inner) => {
-                self.resolve_union(inner, names, enclosing_namespace, field_default)
-            }
-            Schema::Enum(EnumSchema {
-                symbols, default, ..
-            }) => self.resolve_enum(symbols, default, field_default),
-            Schema::Array(inner) => self.resolve_array(&inner.items, names, enclosing_namespace),
-            Schema::Map(inner) => self.resolve_map(&inner.types, names, enclosing_namespace),
-            Schema::Record(RecordSchema { fields, .. }) => {
-                self.resolve_record(fields, names, enclosing_namespace)
-            }
-            Schema::Decimal(DecimalSchema {
+        match node {
+            ResolvedNode::Null => self.resolve_null(),
+            ResolvedNode::Boolean => self.resolve_boolean(),
+            ResolvedNode::Int => self.resolve_int(),
+            ResolvedNode::Long => self.resolve_long(),
+            ResolvedNode::Float => self.resolve_float(),
+            ResolvedNode::Double => self.resolve_double(),
+            ResolvedNode::Bytes => self.resolve_bytes(),
+            ResolvedNode::String => self.resolve_string(),
+            ResolvedNode::Fixed(FixedSchema { size, .. }) => self.resolve_fixed(*size),
+            ResolvedNode::Enum(EnumSchema {
+                symbols,
+                default,
+                ..
+            }) => self.resolve_enum(symbols, default),
+            ResolvedNode::BigDecimal => self.resolve_bigdecimal(),
+            ResolvedNode::Date => self.resolve_date(),
+            ResolvedNode::TimeMillis => self.resolve_time_millis(),
+            ResolvedNode::TimeMicros => self.resolve_time_micros(),
+            ResolvedNode::TimestampMillis => self.resolve_timestamp_millis(),
+            ResolvedNode::TimestampMicros => self.resolve_timestamp_micros(),
+            ResolvedNode::TimestampNanos => self.resolve_timestamp_nanos(),
+            ResolvedNode::LocalTimestampMillis => self.resolve_local_timestamp_millis(),
+            ResolvedNode::LocalTimestampMicros => self.resolve_local_timestamp_micros(),
+            ResolvedNode::LocalTimestampNanos => self.resolve_local_timestamp_nanos(),
+            ResolvedNode::Duration(_) => self.resolve_duration(),
+            ResolvedNode::Uuid(uuid_schema) => self.resolve_uuid(uuid_schema),
+            ResolvedNode::Decimal(DecimalSchema {
                 scale,
                 precision,
                 inner,
             }) => self.resolve_decimal(*precision, *scale, inner),
-            Schema::BigDecimal => self.resolve_bigdecimal(),
-            Schema::Date => self.resolve_date(),
-            Schema::TimeMillis => self.resolve_time_millis(),
-            Schema::TimeMicros => self.resolve_time_micros(),
-            Schema::TimestampMillis => self.resolve_timestamp_millis(),
-            Schema::TimestampMicros => self.resolve_timestamp_micros(),
-            Schema::TimestampNanos => self.resolve_timestamp_nanos(),
-            Schema::LocalTimestampMillis => self.resolve_local_timestamp_millis(),
-            Schema::LocalTimestampMicros => self.resolve_local_timestamp_micros(),
-            Schema::LocalTimestampNanos => self.resolve_local_timestamp_nanos(),
-            Schema::Duration(_) => self.resolve_duration(),
-            Schema::Uuid(inner) => self.resolve_uuid(inner),
+            ResolvedNode::Union(resolved_union) => {
+                self.resolve_union(resolved_union)
+            }
+            ResolvedNode::Array(resolved_array) => {
+                self.resolve_array(resolved_array)
+            }
+            ResolvedNode::Map(resolved_map) => self.resolve_map(resolved_map),
+            ResolvedNode::Record(resolved_record) => {
+                self.resolve_record(resolved_record)
+            }
         }
     }
 
@@ -1037,8 +1001,7 @@ impl Value {
     pub(crate) fn resolve_enum(
         self,
         symbols: &[String],
-        enum_default: &Option<String>,
-        _field_default: &Option<JsonValue>,
+        enum_default: &Option<String>
     ) -> Result<Self, Error> {
         let validate_symbol = |symbol: String, symbols: &[String]| {
             if let Some(index) = symbols.iter().position(|item| item == &symbol) {
@@ -1072,12 +1035,9 @@ impl Value {
         }
     }
 
-    fn resolve_union<S: Borrow<Schema> + Debug>(
+    fn resolve_union(
         self,
-        schema: &UnionSchema,
-        names: &HashMap<Name, S>,
-        enclosing_namespace: NamespaceRef,
-        field_default: &Option<JsonValue>,
+        resolved_union: ResolvedUnion
     ) -> Result<Self, Error> {
         let v = match self {
             // Both are unions case.
@@ -1085,127 +1045,97 @@ impl Value {
             // Reader is a union, but writer is not.
             v => v,
         };
-        let (i, inner) = schema
-            .find_schema_with_known_schemata(&v, Some(names), enclosing_namespace)
+
+        let (i, inner) = resolved_union
+            .structural_match_on_schema(&v)
             .ok_or_else(|| Details::FindUnionVariant {
-                schema: schema.clone(),
+                schema: resolved_union.get_union_schema().clone(),
                 value: v.clone(),
             })?;
 
-        Ok(Value::Union(
+        Ok( Value::Union(
             i as u32,
-            Box::new(v.resolve_internal(inner, names, enclosing_namespace, field_default)?),
-        ))
+            Box::new(v.resolve_internal(inner)?))
+        )
     }
 
-    fn resolve_array<S: Borrow<Schema> + Debug>(
+    fn resolve_array(
         self,
-        schema: &Schema,
-        names: &HashMap<Name, S>,
-        enclosing_namespace: NamespaceRef,
+        resolved_array: ResolvedArray,
     ) -> Result<Self, Error> {
+        let items_resolved = resolved_array.resolve_items();
         match self {
             Value::Array(items) => Ok(Value::Array(
                 items
                     .into_iter()
-                    .map(|item| item.resolve_internal(schema, names, enclosing_namespace, &None))
+                    .map(|item| item.resolve_internal(items_resolved.clone()))
                     .collect::<Result<_, _>>()?,
             )),
             other => Err(Details::GetArray {
-                expected: schema.into(),
+                expected: SchemaKind::Array,
                 other,
             }
             .into()),
         }
     }
 
-    fn resolve_map<S: Borrow<Schema> + Debug>(
+    fn resolve_map(
         self,
-        schema: &Schema,
-        names: &HashMap<Name, S>,
-        enclosing_namespace: NamespaceRef,
+        resolved_map: ResolvedMap,
     ) -> Result<Self, Error> {
+        let resolved_types = resolved_map.resolve_types();
         match self {
             Value::Map(items) => Ok(Value::Map(
                 items
                     .into_iter()
                     .map(|(key, value)| {
                         value
-                            .resolve_internal(schema, names, enclosing_namespace, &None)
+                            .resolve_internal(resolved_types.clone())
                             .map(|value| (key, value))
                     })
                     .collect::<Result<_, _>>()?,
             )),
             other => Err(Details::GetMap {
-                expected: schema.into(),
+                expected: SchemaKind::Map,
                 other,
             }
             .into()),
         }
     }
 
-    fn resolve_record<S: Borrow<Schema> + Debug>(
+    fn resolve_record(
         self,
-        fields: &[RecordField],
-        names: &HashMap<Name, S>,
-        enclosing_namespace: NamespaceRef,
+        resolved_record: ResolvedRecord
     ) -> Result<Self, Error> {
         let mut items = match self {
             Value::Map(items) => Ok(items),
             Value::Record(fields) => Ok(fields.into_iter().collect::<HashMap<_, _>>()),
             other => Err(Error::new(Details::GetRecord {
-                expected: fields
+                expected: resolved_record.fields
                     .iter()
-                    .map(|field| (field.name.clone(), field.schema.clone().into()))
+                    .map(|field| (field.name.clone(),
+                                SchemaKind::from(&field.resolve_field()))
+                            )
                     .collect(),
                 other,
             })),
         }?;
 
-        let new_fields = fields
+        let new_fields = resolved_record.fields
             .iter()
             .map(|field| {
-                let value = match items.remove(&field.name) {
+                let value = match items.remove(field.name) {
                     Some(value) => value,
-                    None => match field.default {
-                        Some(ref value) => match field.schema {
-                            Schema::Enum(EnumSchema {
-                                ref symbols,
-                                ref default,
-                                ..
-                            }) => Value::try_from(value.clone())?.resolve_enum(
-                                symbols,
-                                default,
-                                &field.default.clone(),
-                            )?,
-                            Schema::Union(ref union_schema) => {
-                                let first = &union_schema.variants()[0];
-                                // NOTE: this match exists only to optimize null defaults for large
-                                // backward-compatible schemas with many nullable fields
-                                match first {
-                                    Schema::Null => Value::Union(0, Box::new(Value::Null)),
-                                    _ => Value::Union(
-                                        0,
-                                        Box::new(
-                                            Value::try_from(value.clone())?.resolve_internal(
-                                                first,
-                                                names,
-                                                enclosing_namespace,
-                                                &field.default,
-                                            )?,
-                                        ),
-                                    ),
-                                }
-                            }
-                            _ => Value::try_from(value.clone())?,
-                        },
+                    None => match &field.default {
+                        Some(value) => value.clone(), // we have already checked that the defualt
+                                                      // agrees with the schema
                         None => {
                             return Err(Details::GetField(field.name.clone()).into());
                         }
                     },
                 };
                 value
-                    .resolve_internal(&field.schema, names, enclosing_namespace, &field.default)
+                    .resolve_internal(field.resolve_field())
                     .map(|value| (field.name.clone(), value))
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -1230,9 +1160,7 @@ impl Value {
 mod tests {
     use super::*;
     use crate::{
-        duration::{Days, Millis, Months},
-        error::Details,
-        to_value,
+        duration::{Days, Millis, Months}, error::Details, schema::{Name, UnionSchema, RecordField}, to_value
     };
     use apache_avro_test_helper::{
         TestResult,
@@ -1241,6 +1169,7 @@ mod tests {
     use num_bigint::BigInt;
     use pretty_assertions::assert_eq;
     use serde_json::json;
+    use std::sync::Arc;
 
     #[test]
     fn avro_3809_validate_nested_records_with_implicit_namespace() -> TestResult {
@@ -1370,7 +1299,7 @@ mod tests {
             (
                 Value::Fixed(12, vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
                 Schema::Duration(FixedSchema {
-                    name: Name::try_from("TestName")?,
+                    name: Name::try_from("TestName")?.into(),
                     aliases: None,
                     doc: None,
                     size: 12,
@@ -1382,7 +1311,7 @@ mod tests {
             (
                 Value::Fixed(11, vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
                 Schema::Duration(FixedSchema {
-                    name: Name::try_from("TestName")?,
+                    name: Name::try_from("TestName")?.into(),
                     aliases: None,
                     doc: None,
                     size: 12,
@@ -1394,7 +1323,7 @@ mod tests {
             (
                 Value::Record(vec![("unknown_field_name".to_string(), Value::Null)]),
                 Schema::Record(RecordSchema {
-                    name: Name::new("record_name")?,
+                    name: Name::new("record_name")?.into(),
                     aliases: None,
                     doc: None,
                     fields: vec![
@@ -1412,14 +1341,14 @@ mod tests {
             (
                 Value::Record(vec![("field_name".to_string(), Value::Null)]),
                 Schema::Record(RecordSchema {
-                    name: Name::new("record_name")?,
+                    name: Name::new("record_name")?.into(),
                     aliases: None,
                     doc: None,
                     fields: vec![
                         RecordField::builder()
                             .name("field_name".to_string())
                             .schema(Schema::Ref {
-                                name: Name::new("missing")?,
+                                name: Name::new("missing")?.into(),
                             })
                             .build(),
                     ],
@@ -1432,7 +1361,7 @@ mod tests {
         ];
 
         for (value, schema, valid, expected_err_message) in value_schema_valid.into_iter() {
-            let err_message = value.validate_internal::<Schema>(&schema, &HashMap::default(), None);
+            let err_message = value.validate_internal(ResolvedNode::new(&ResolvedSchema::try_from(schema.clone())?));
             assert_eq!(valid, err_message.is_none());
             if !valid {
                 let full_err_message = format!(
@@ -1452,7 +1381,7 @@ mod tests {
     fn validate_fixed() -> TestResult {
         let schema = Schema::Fixed(FixedSchema {
             size: 4,
-            name: Name::new("some_fixed")?,
+            name: Name::new("some_fixed")?.into(),
             aliases: None,
             doc: None,
             attributes: Default::default(),
@@ -1486,7 +1415,7 @@ mod tests {
     #[test]
     fn validate_enum() -> TestResult {
         let schema = Schema::Enum(EnumSchema {
-            name: Name::new("some_enum")?,
+            name: Name::new("some_enum")?.into(),
             aliases: None,
             doc: None,
             symbols: vec![
@@ -1533,7 +1462,7 @@ mod tests {
         );
 
         let other_schema = Schema::Enum(EnumSchema {
-            name: Name::new("some_other_enum")?,
+            name: Name::new("some_other_enum")?.into(),
             aliases: None,
             doc: None,
             symbols: vec![
@@ -1574,7 +1503,7 @@ mod tests {
         //    ]
         // }
         let schema = Schema::Record(RecordSchema {
-            name: Name::new("some_record")?,
+            name: Name::new("some_record")?.into(),
             aliases: None,
             doc: None,
             fields: vec![
@@ -1807,7 +1736,7 @@ Field with name '"b"' is not a member of the map items"#,
                     precision: 10,
                     scale: 1,
                     inner: InnerDecimalSchema::Fixed(FixedSchema {
-                        name: Name::new("decimal").unwrap(),
+                        name: Name::new("decimal").unwrap().into(),
                         aliases: None,
                         size: 20,
                         doc: None,
@@ -1911,7 +1840,7 @@ Field with name '"b"' is not a member of the map items"#,
             value
                 .clone()
                 .resolve(&Schema::Duration(FixedSchema {
-                    name: Name::try_from("TestName").expect("Name is valid"),
+                    name: Name::try_from("TestName").expect("Name is valid").into(),
                     aliases: None,
                     doc: None,
                     size: 12,
@@ -1923,7 +1852,7 @@ Field with name '"b"' is not a member of the map items"#,
         assert!(
             Value::Long(1i64)
                 .resolve(&Schema::Duration(FixedSchema {
-                    name: Name::try_from("TestName").expect("Name is valid"),
+                    name: Name::try_from("TestName").expect("Name is valid").into(),
                     aliases: None,
                     doc: None,
                     size: 12,
@@ -1952,7 +1881,7 @@ Field with name '"b"' is not a member of the map items"#,
             value
                 .clone()
                 .resolve(&Schema::Uuid(UuidSchema::Fixed(FixedSchema {
-                    name: Name::new("some_name")?,
+                    name: Name::new("some_name")?.into(),
                     aliases: None,
                     doc: None,
                     size: 16,
@@ -3062,19 +2991,16 @@ Field with name '"b"' is not a member of the map items"#,
 
         let avro_value = Value::try_from(value)?;
 
-        let schemas = Schema::parse_list([main_schema, referenced_schema])?;
+        let [rs] = ResolvedSchema::from_str_array([main_schema], vec![referenced_schema])?;
 
-        let main_schema = schemas.first().unwrap();
-        let schemata: Vec<_> = schemas.iter().skip(1).collect();
-
-        let resolve_result = avro_value.clone().resolve_schemata(main_schema, schemata);
+        let resolve_result = avro_value.clone().resolve_against_resolved(rs);
 
         assert!(
             resolve_result.is_ok(),
             "result of resolving with schemata should be ok, got: {resolve_result:?}"
         );
 
-        let resolve_result = avro_value.resolve(main_schema);
+        let resolve_result = avro_value.resolve(&Schema::parse_str(&main_schema)?);
         assert!(
             resolve_result.is_err(),
             "result of resolving without schemata should be err, got: {resolve_result:?}"
@@ -3102,15 +3028,12 @@ Field with name '"b"' is not a member of the map items"#,
 
         let avro_value = Value::try_from(value)?;
 
-        let schemata = Schema::parse_list([referenced_enum, referenced_record, main_schema])?;
+        let [rs] = ResolvedSchema::from_str_array([main_schema], vec![referenced_enum, referenced_record])?;
 
-        let main_schema = schemata.last().unwrap();
-        let other_schemata: Vec<&Schema> = schemata.iter().take(2).collect();
-
-        let resolve_result = avro_value.resolve_schemata(main_schema, other_schemata)?;
+        let resolve_result = avro_value.resolve_against_resolved(rs.clone())?;
 
         assert!(
-            resolve_result.validate_schemata(schemata.iter().collect()),
+            resolve_result.validate_against_resolved(&rs),
             "result of validation with schemata should be true"
         );
 
@@ -3155,7 +3078,7 @@ Field with name '"b"' is not a member of the map items"#,
         let value = Value::Bytes(vec![97, 98, 99]);
         assert_eq!(
             value.resolve(&Schema::Fixed(FixedSchema {
-                name: "test".try_into()?,
+                name: Arc::new("test".try_into()?),
                 aliases: None,
                 doc: None,
                 size: 3,
@@ -3168,7 +3091,7 @@ Field with name '"b"' is not a member of the map items"#,
         assert!(
             value
                 .resolve(&Schema::Fixed(FixedSchema {
-                    name: "test".try_into()?,
+                    name: Arc::new("test".try_into()?),
                     aliases: None,
                     doc: None,
                     size: 3,
@@ -3181,7 +3104,7 @@ Field with name '"b"' is not a member of the map items"#,
         assert!(
             value
                 .resolve(&Schema::Fixed(FixedSchema {
-                    name: "test".try_into()?,
+                    name: Arc::new("test".try_into()?),
                     aliases: None,
                     doc: None,
                     size: 3,

--- a/avro/src/writer/datum.rs
+++ b/avro/src/writer/datum.rs
@@ -87,7 +87,7 @@ impl<'s, S: generic_datum_writer_builder::State> GenericDatumWriterBuilder<'s, S
     where
         S::ResolvedSchemata: generic_datum_writer_builder::IsUnset,
     {
-        let [resolved] = ResolvedSchema::resolve().additional(schemata)?.build_array([self.schema])?;
+        let [resolved] = ResolvedSchema::builder().additional(schemata)?.build_array([self.schema])?;
         Ok(self.resolved_schemata(resolved))
     }
 }

--- a/avro/src/writer/datum.rs
+++ b/avro/src/writer/datum.rs
@@ -23,7 +23,7 @@ use crate::{
     AvroResult, Schema,
     encode::encode_internal,
     error::Details,
-    schema::{NamesRef, ResolvedSchema},
+    schema::{NameMap, ResolvedNode, ResolvedSchema},
     serde::ser_schema::SchemaAwareWriteSerializer,
     types::Value,
 };
@@ -35,7 +35,7 @@ use crate::{
 /// [`SpecificSingleObjectWriter`][crate::SpecificSingleObjectWriter] instead.
 pub struct GenericDatumWriter<'s> {
     schema: &'s Schema,
-    resolved: ResolvedSchema<'s>,
+    resolved: ResolvedSchema,
     validate: bool,
 }
 
@@ -50,7 +50,7 @@ impl<'s> GenericDatumWriter<'s> {
         /// Already resolved schemata that will be used to resolve references in the writer's schema.
         ///
         /// You can also use [`Self::schemata`] instead.
-        resolved_schemata: Option<ResolvedSchema<'s>>,
+        resolved_schemata: Option<ResolvedSchema>,
         /// Validate values against the writer schema before writing them.
         ///
         /// Defaults to `true`.
@@ -87,7 +87,7 @@ impl<'s, S: generic_datum_writer_builder::State> GenericDatumWriterBuilder<'s, S
     where
         S::ResolvedSchemata: generic_datum_writer_builder::IsUnset,
     {
-        let resolved = ResolvedSchema::new_with_schemata(schemata)?;
+        let [resolved] = ResolvedSchema::from_schema_array([self.schema], schemata)?;
         Ok(self.resolved_schemata(resolved))
     }
 }
@@ -107,12 +107,12 @@ impl GenericDatumWriter<'_> {
     pub fn write_value_ref<W: Write>(&self, writer: &mut W, value: &Value) -> AvroResult<usize> {
         if self.validate
             && value
-                .validate_internal(self.schema, self.resolved.get_names(), None)
+                .validate_internal(ResolvedNode::new(&self.resolved))
                 .is_some()
         {
             return Err(Details::Validation.into());
         }
-        encode_internal(value, self.schema, self.resolved.get_names(), None, writer)
+        encode_internal(value, ResolvedNode::new(&self.resolved), writer)
     }
 
     /// Write a value to a [`Vec`].
@@ -177,7 +177,7 @@ pub fn to_avro_datum<T: Into<Value>>(schema: &Schema, value: T) -> AvroResult<Ve
 /// [`Writer::append_ser`]: crate::Writer::append_ser
 pub fn write_avro_datum_ref<T: Serialize, W: Write>(
     schema: &Schema,
-    names: &NamesRef,
+    names: &NameMap,
     data: &T,
     writer: &mut W,
 ) -> AvroResult<usize> {
@@ -416,7 +416,7 @@ mod tests {
     fn decimal_fixed() -> TestResult {
         let size = 30;
         let fixed = FixedSchema {
-            name: Name::new("decimal")?,
+            name: Name::new("decimal")?.into(),
             aliases: None,
             doc: None,
             size,
@@ -456,7 +456,7 @@ mod tests {
     #[test]
     fn duration() -> TestResult {
         let inner = Schema::Fixed(FixedSchema {
-            name: Name::new("duration")?,
+            name: Name::new("duration")?.into(),
             aliases: None,
             doc: None,
             size: 12,
@@ -470,7 +470,7 @@ mod tests {
         logical_type_test(
             r#"{"type": {"type": "fixed", "name": "duration", "size": 12}, "logicalType": "duration"}"#,
             &Schema::Duration(FixedSchema {
-                name: Name::try_from("duration").expect("Name is valid"),
+                name: Name::try_from("duration").expect("Name is valid").into(),
                 aliases: None,
                 doc: None,
                 size: 12,

--- a/avro/src/writer/datum.rs
+++ b/avro/src/writer/datum.rs
@@ -87,7 +87,7 @@ impl<'s, S: generic_datum_writer_builder::State> GenericDatumWriterBuilder<'s, S
     where
         S::ResolvedSchemata: generic_datum_writer_builder::IsUnset,
     {
-        let [resolved] = ResolvedSchema::from_schema_array([self.schema], schemata)?;
+        let [resolved] = ResolvedSchema::resolve().additional(schemata)?.build_array([self.schema])?;
         Ok(self.resolved_schemata(resolved))
     }
 }
@@ -425,7 +425,7 @@ mod tests {
         let inner = InnerDecimalSchema::Fixed(fixed.clone());
         let value = vec![0u8; size];
         logical_type_test(
-            r#"{"type": {"type": "fixed", "size": 30, "name": "decimal"}, "logicalType": "decimal", "precision": 20, "scale": 5}"#,
+            r#"{"type": "fixed", "size": 30, "name": "decimal", "logicalType": "decimal", "precision": 20, "scale": 5}"#,
             &Schema::Decimal(DecimalSchema {
                 precision: 20,
                 scale: 5,
@@ -468,7 +468,7 @@ mod tests {
             Millis::new(1024),
         ));
         logical_type_test(
-            r#"{"type": {"type": "fixed", "name": "duration", "size": 12}, "logicalType": "duration"}"#,
+            r#"{"type": "fixed", "name": "duration", "size": 12, "logicalType": "duration"}"#,
             &Schema::Duration(FixedSchema {
                 name: Name::try_from("duration").expect("Name is valid").into(),
                 aliases: None,

--- a/avro/src/writer/mod.rs
+++ b/avro/src/writer/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     AvroResult, Codec, Error,
     encode::{encode, encode_internal, encode_to_vec},
     error::Details,
-    schema::{ResolvedSchema, Schema},
+    schema::{ResolvedNode, ResolvedSchema, Schema},
     serde::ser_schema::SchemaAwareWriteSerializer,
     types::Value,
 };
@@ -41,7 +41,7 @@ const AVRO_OBJECT_HEADER: &[u8] = b"Obj\x01";
 pub struct Writer<'a, W: Write> {
     schema: &'a Schema,
     writer: W,
-    resolved_schema: ResolvedSchema<'a>,
+    resolved_schema: ResolvedSchema,
     codec: Codec,
     block_size: usize,
     buffer: Vec<u8>,
@@ -68,10 +68,10 @@ impl<'a, W: Write> Writer<'a, W> {
         has_header: bool,
         #[builder(default)] user_metadata: HashMap<String, Value>,
     ) -> AvroResult<Self> {
-        let resolved_schema = if let Some(schemata) = schemata {
-            ResolvedSchema::try_from(schemata)?
+        let [resolved_schema] = if let Some(schemata) = schemata {
+            ResolvedSchema::from_schema_array([schema], schemata)?
         } else {
-            ResolvedSchema::try_from(schema)?
+            ResolvedSchema::from_schema_array_only([schema])?
         };
         Ok(Self {
             schema,
@@ -199,9 +199,7 @@ impl<'a, W: Write> Writer<'a, W> {
     /// written, then call [`flush`](Writer::flush).
     pub fn append_value_ref(&mut self, value: &Value) -> AvroResult<usize> {
         if let Some(reason) = value.validate_internal(
-            self.schema,
-            self.resolved_schema.get_names(),
-            self.schema.namespace(),
+            ResolvedNode::new(&self.resolved_schema),
         ) {
             return Err(Details::ValidationWithReason {
                 value: value.clone(),
@@ -244,9 +242,7 @@ impl<'a, W: Write> Writer<'a, W> {
         let n = self.maybe_write_header()?;
         encode_internal(
             value,
-            self.schema,
-            self.resolved_schema.get_names(),
-            self.schema.namespace(),
+            ResolvedNode::new(&self.resolved_schema),
             &mut self.buffer,
         )?;
 

--- a/avro/src/writer/mod.rs
+++ b/avro/src/writer/mod.rs
@@ -69,9 +69,9 @@ impl<'a, W: Write> Writer<'a, W> {
         #[builder(default)] user_metadata: HashMap<String, Value>,
     ) -> AvroResult<Self> {
         let [resolved_schema] = if let Some(schemata) = schemata {
-            ResolvedSchema::from_schema_array([schema], schemata)?
+            ResolvedSchema::resolve().additional(schemata)?.build_array([schema])?
         } else {
-            ResolvedSchema::from_schema_array_only([schema])?
+            ResolvedSchema::resolve().build_array([schema])?
         };
         Ok(Self {
             schema,

--- a/avro/src/writer/mod.rs
+++ b/avro/src/writer/mod.rs
@@ -69,9 +69,9 @@ impl<'a, W: Write> Writer<'a, W> {
         #[builder(default)] user_metadata: HashMap<String, Value>,
     ) -> AvroResult<Self> {
         let [resolved_schema] = if let Some(schemata) = schemata {
-            ResolvedSchema::resolve().additional(schemata)?.build_array([schema])?
+            ResolvedSchema::builder().additional(schemata)?.build_array([schema])?
         } else {
-            ResolvedSchema::resolve().build_array([schema])?
+            ResolvedSchema::builder().build_array([schema])?
         };
         Ok(Self {
             schema,

--- a/avro/src/writer/single_object.rs
+++ b/avro/src/writer/single_object.rs
@@ -20,12 +20,12 @@ use std::{io::Write, marker::PhantomData, ops::RangeInclusive};
 use serde::Serialize;
 
 use crate::encode::encode_internal;
+use crate::schema::{ResolvedNode, ResolvedSchema};
 use crate::serde::ser_schema::SchemaAwareWriteSerializer;
 use crate::{
     AvroResult, AvroSchema, Schema,
     error::Details,
     headers::{HeaderBuilder, RabinFingerprintHeader},
-    schema::ResolvedOwnedSchema,
     types::Value,
 };
 
@@ -34,7 +34,7 @@ use crate::{
 /// Writes all object bytes at once, and drains internal buffer
 pub struct GenericSingleObjectWriter {
     buffer: Vec<u8>,
-    resolved: ResolvedOwnedSchema,
+    resolved: ResolvedSchema,
 }
 
 impl GenericSingleObjectWriter {
@@ -57,7 +57,7 @@ impl GenericSingleObjectWriter {
 
         Ok(GenericSingleObjectWriter {
             buffer,
-            resolved: ResolvedOwnedSchema::try_from(schema.clone())?,
+            resolved: ResolvedSchema::try_from(schema.clone())?,
         })
     }
 
@@ -90,7 +90,7 @@ pub struct SpecificSingleObjectWriter<T>
 where
     T: AvroSchema,
 {
-    resolved: ResolvedOwnedSchema,
+    resolved: ResolvedSchema,
     header: Vec<u8>,
     _model: PhantomData<T>,
 }
@@ -102,7 +102,7 @@ where
     pub fn new() -> AvroResult<Self> {
         let schema = T::get_schema();
         let header = RabinFingerprintHeader::from_schema(&schema).build_header();
-        let resolved = ResolvedOwnedSchema::new(schema)?;
+        let resolved = ResolvedSchema::try_from(schema)?;
         // We don't use Self::new_with_header_builder as that would mean calling T::get_schema() twice
         Ok(Self {
             resolved,
@@ -113,7 +113,7 @@ where
 
     pub fn new_with_header_builder(header_builder: impl HeaderBuilder) -> AvroResult<Self> {
         let header = header_builder.build_header();
-        let resolved = ResolvedOwnedSchema::new(T::get_schema())?;
+        let resolved = ResolvedSchema::try_from(T::get_schema())?;
         Ok(Self {
             resolved,
             header,
@@ -165,7 +165,7 @@ where
 
         let mut serializer = SchemaAwareWriteSerializer::new(
             writer,
-            self.resolved.get_root_schema(),
+            &self.resolved.schema,
             self.resolved.get_names(),
             None,
         );
@@ -186,28 +186,23 @@ where
 }
 
 fn write_value_ref_owned_resolved<W: Write>(
-    resolved_schema: &ResolvedOwnedSchema,
+    resolved_schema: &ResolvedSchema,
     value: &Value,
     writer: &mut W,
 ) -> AvroResult<usize> {
-    let root_schema = resolved_schema.get_root_schema();
     if let Some(reason) = value.validate_internal(
-        root_schema,
-        resolved_schema.get_names(),
-        root_schema.namespace(),
+        ResolvedNode::new(resolved_schema)
     ) {
         return Err(Details::ValidationWithReason {
             value: value.clone(),
-            schema: root_schema.clone(),
+            schema: resolved_schema.schema.as_ref().clone(),
             reason,
         }
         .into());
     }
     encode_internal(
         value,
-        root_schema,
-        resolved_schema.get_names(),
-        root_schema.namespace(),
+        ResolvedNode::new(resolved_schema),
         writer,
     )
 }

--- a/avro/src/writer/single_object.rs
+++ b/avro/src/writer/single_object.rs
@@ -165,7 +165,7 @@ where
 
         let mut serializer = SchemaAwareWriteSerializer::new(
             writer,
-            &self.resolved.schema,
+            &self.resolved.stub,
             self.resolved.get_names(),
             None,
         );
@@ -195,7 +195,7 @@ fn write_value_ref_owned_resolved<W: Write>(
     ) {
         return Err(Details::ValidationWithReason {
             value: value.clone(),
-            schema: resolved_schema.schema.as_ref().clone(),
+            schema: resolved_schema.stub.as_ref().clone(),
             reason,
         }
         .into());

--- a/avro/tests/avro-3786.rs
+++ b/avro/tests/avro-3786.rs
@@ -754,9 +754,7 @@ fn deserialize_union_with_record_with_enum_defined_inline_reader_has_different_i
                                         "null",
                                         {
                                             "type": "array",
-                                            "items": {
-                                                "type": "Baz"
-                                            }
+                                            "items": "Baz"
                                         }
                                     ]
                                 },
@@ -846,9 +844,7 @@ fn deserialize_union_with_record_with_enum_defined_inline_reader_has_different_i
                                         "null",
                                         {
                                             "type": "array",
-                                            "items": {
-                                                "type": "Baz"
-                                            }
+                                            "items": "Baz"
                                         }
                                     ]
                                 },

--- a/avro/tests/schema.rs
+++ b/avro/tests/schema.rs
@@ -312,8 +312,8 @@ fn test_parse_list_with_cross_deps_and_namespaces_error() -> TestResult {
 
     let schema_strs_first = [schema_str_1, schema_str_2];
     let schema_strs_second = [schema_str_2, schema_str_1];
-    let _ = ResolvedSchema::resolve().build_array(schema_strs_first).expect_err("Test failed");
-    let _ = ResolvedSchema::resolve().build_array(schema_strs_second).expect_err("Test failed");
+    let _ = ResolvedSchema::builder().build_array(schema_strs_first).expect_err("Test failed");
+    let _ = ResolvedSchema::builder().build_array(schema_strs_second).expect_err("Test failed");
 
     Ok(())
 }
@@ -531,7 +531,7 @@ fn test_name_collision_error() -> TestResult {
         ]
     }"#;
 
-    let _ = ResolvedSchema::resolve().build_array([schema_str_1, schema_str_2]).expect_err("Test failed");
+    let _ = ResolvedSchema::builder().build_array([schema_str_1, schema_str_2]).expect_err("Test failed");
     Ok(())
 }
 
@@ -2136,11 +2136,11 @@ fn avro_rs_66_test_independent_canonical_form_primitives() -> TestResult {
     for schema_str_perm in permutations(&schema_strs) {
         let schema_str_perm: Vec<&str> = schema_str_perm.iter().map(|s| **s).collect();
         let schemata = Schema::parse_list(&schema_str_perm)?;
-        let [resolved_independent_schema] = ResolvedSchema::resolve().build_array([&independent_schema])?;
+        let [resolved_independent_schema] = ResolvedSchema::builder().build_array([&independent_schema])?;
         let complete = CompleteSchema::from(&resolved_independent_schema);
         assert_eq!(schemata.len(), schema_strs.len());
 
-        let [test_resolved] = ResolvedSchema::resolve().additional(schemata.iter())?.build_array([&dependant_schema])?;
+        let [test_resolved] = ResolvedSchema::builder().additional(schemata.iter())?.build_array([&dependant_schema])?;
         let test_complete = CompleteSchema::from(&test_resolved);
 
         assert_eq!(
@@ -2257,7 +2257,7 @@ fn avro_rs_66_test_independent_canonical_form_usages() -> TestResult {
         let schemata = Schema::parse_list(&schema_str_perm)?;
         for schema in &schemata {
             let other_schemata = schemata.iter().filter(|other_schema|{other_schema != &schema});
-            let [resolved] = ResolvedSchema::resolve().additional(other_schemata)?.build_array([schema])?;
+            let [resolved] = ResolvedSchema::builder().additional(other_schemata)?.build_array([schema])?;
             let complete = CompleteSchema::from(&resolved);
             match schema.name().unwrap().to_string().as_str() {
                 "RecUsage" => {
@@ -2353,8 +2353,8 @@ fn avro_rs_66_test_independent_canonical_form_deep_recursion() -> TestResult {
     for schema_str_perm in permutations(&schema_strs) {
         let schema_str_perm: Vec<&str> = schema_str_perm.iter().map(|s| **s).collect();
         let schemata = Schema::parse_list(&schema_str_perm)?;
-        let ruu = Schema::parse_str(&record_usage_usage)?;
-        let [resolved] = ResolvedSchema::resolve().additional(schemata.iter())?.build_array([&ruu])?;
+        let ruu = Schema::parse_str(record_usage_usage)?;
+        let [resolved] = ResolvedSchema::builder().additional(schemata.iter())?.build_array([&ruu])?;
         assert_eq!(
             CompleteSchema::from(&resolved).independent_canonical_form()?,
             Schema::parse_str(record_usage_usage_independent)?.canonical_form()

--- a/avro/tests/schema.rs
+++ b/avro/tests/schema.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use apache_avro::schema::{CompleteSchema, ResolvedSchema};
 use apache_avro::writer::datum::GenericDatumWriter;
 use apache_avro::{
     Codec, Error, Reader, Schema, Writer,
@@ -2134,20 +2135,25 @@ fn avro_rs_66_test_independent_canonical_form_primitives() -> TestResult {
     for schema_str_perm in permutations(&schema_strs) {
         let schema_str_perm: Vec<&str> = schema_str_perm.iter().map(|s| **s).collect();
         let schemata = Schema::parse_list(&schema_str_perm)?;
+        let [resolved_independent_schema] = ResolvedSchema::from_schema_array([&independent_schema], schemata.iter())?;
+        let complete = CompleteSchema::from(&resolved_independent_schema);
         assert_eq!(schemata.len(), schema_strs.len());
         let test_schema = schemata
             .iter()
             .find(|a| a.name().unwrap().to_string() == *"RecWithDeps")
             .unwrap();
 
+        let [test_resolved] = ResolvedSchema::from_schema_array([test_schema], schemata.iter())?;
+        let test_complete = CompleteSchema::from(&test_resolved);
+
         assert_eq!(
-            independent_schema.independent_canonical_form(&schemata)?,
+            complete.independent_canonical_form()?,
             independent_schema.canonical_form()
         );
 
         assert_eq!(
             independent_schema.canonical_form(),
-            test_schema.independent_canonical_form(&schemata)?
+            test_complete.independent_canonical_form()?
         );
     }
     Ok(())
@@ -2253,34 +2259,36 @@ fn avro_rs_66_test_independent_canonical_form_usages() -> TestResult {
         let schema_str_perm: Vec<&str> = schema_str_perm.iter().map(|s| **s).collect();
         let schemata = Schema::parse_list(&schema_str_perm)?;
         for schema in &schemata {
+            let [resolved] = ResolvedSchema::from_schema_array([schema], schemata.iter())?;
+            let complete = CompleteSchema::from(&resolved);
             match schema.name().unwrap().to_string().as_str() {
                 "RecUsage" => {
                     assert_eq!(
-                        schema.independent_canonical_form(&schemata)?,
+                        complete.independent_canonical_form()?,
                         Schema::parse_str(record_usage_independent)?.canonical_form()
                     );
                 }
                 "ArrayUsage" => {
                     assert_eq!(
-                        schema.independent_canonical_form(&schemata)?,
+                        complete.independent_canonical_form()?,
                         Schema::parse_str(array_usage_independent)?.canonical_form()
                     );
                 }
                 "UnionUsage" => {
                     assert_eq!(
-                        schema.independent_canonical_form(&schemata)?,
+                        complete.independent_canonical_form()?,
                         Schema::parse_str(union_usage_independent)?.canonical_form()
                     );
                 }
                 "MapUsage" => {
                     assert_eq!(
-                        schema.independent_canonical_form(&schemata)?,
+                        complete.independent_canonical_form()?,
                         Schema::parse_str(map_usage_independent)?.canonical_form()
                     );
                 }
                 "ns.Rec" => {
                     assert_eq!(
-                        schema.independent_canonical_form(&schemata)?,
+                        complete.independent_canonical_form()?,
                         schema.canonical_form()
                     );
                 }
@@ -2351,8 +2359,9 @@ fn avro_rs_66_test_independent_canonical_form_deep_recursion() -> TestResult {
             .iter()
             .find(|s| s.name().unwrap().to_string().as_str() == "RecUsageUsage")
             .unwrap();
+        let [resolved] = ResolvedSchema::from_schema_array([ruu], schemata.iter())?;
         assert_eq!(
-            ruu.independent_canonical_form(&schemata)?,
+            CompleteSchema::from(&resolved).independent_canonical_form()?,
             Schema::parse_str(record_usage_usage_independent)?.canonical_form()
         );
     }
@@ -2382,8 +2391,8 @@ fn avro_rs_66_test_independent_canonical_form_missing_ref() -> TestResult {
     let schema_strs = [record_primitive, record_usage];
     let schemata = Schema::parse_list(schema_strs)?;
     assert!(matches!(
-        schemata[1]
-            .independent_canonical_form(&Vec::with_capacity(0))
+        CompleteSchema::try_from(schemata[1].clone())?
+            .independent_canonical_form()
             .map_err(Error::into_details), //NOTE - we're passing in an empty schemata
         Err(Details::SchemaResolutionError(..))
     ));

--- a/avro/tests/schema.rs
+++ b/avro/tests/schema.rs
@@ -312,8 +312,8 @@ fn test_parse_list_with_cross_deps_and_namespaces_error() -> TestResult {
 
     let schema_strs_first = [schema_str_1, schema_str_2];
     let schema_strs_second = [schema_str_2, schema_str_1];
-    let _ = Schema::parse_list(schema_strs_first).expect_err("Test failed");
-    let _ = Schema::parse_list(schema_strs_second).expect_err("Test failed");
+    let _ = ResolvedSchema::resolve().build_array(schema_strs_first).expect_err("Test failed");
+    let _ = ResolvedSchema::resolve().build_array(schema_strs_second).expect_err("Test failed");
 
     Ok(())
 }
@@ -531,7 +531,7 @@ fn test_name_collision_error() -> TestResult {
         ]
     }"#;
 
-    let _ = Schema::parse_list([schema_str_1, schema_str_2]).expect_err("Test failed");
+    let _ = ResolvedSchema::resolve().build_array([schema_str_1, schema_str_2]).expect_err("Test failed");
     Ok(())
 }
 
@@ -2125,25 +2125,22 @@ fn avro_rs_66_test_independent_canonical_form_primitives() -> TestResult {
     }"#;
 
     let independent_schema = Schema::parse_str(record_with_no_dependencies)?;
+    let dependant_schema = Schema::parse_str(record_with_dependencies)?;
+
     let schema_strs = [
         fixed_primitive,
         enum_primitive,
         record_primitive,
-        record_with_dependencies,
     ];
 
     for schema_str_perm in permutations(&schema_strs) {
         let schema_str_perm: Vec<&str> = schema_str_perm.iter().map(|s| **s).collect();
         let schemata = Schema::parse_list(&schema_str_perm)?;
-        let [resolved_independent_schema] = ResolvedSchema::from_schema_array([&independent_schema], schemata.iter())?;
+        let [resolved_independent_schema] = ResolvedSchema::resolve().build_array([&independent_schema])?;
         let complete = CompleteSchema::from(&resolved_independent_schema);
         assert_eq!(schemata.len(), schema_strs.len());
-        let test_schema = schemata
-            .iter()
-            .find(|a| a.name().unwrap().to_string() == *"RecWithDeps")
-            .unwrap();
 
-        let [test_resolved] = ResolvedSchema::from_schema_array([test_schema], schemata.iter())?;
+        let [test_resolved] = ResolvedSchema::resolve().additional(schemata.iter())?.build_array([&dependant_schema])?;
         let test_complete = CompleteSchema::from(&test_resolved);
 
         assert_eq!(
@@ -2259,7 +2256,8 @@ fn avro_rs_66_test_independent_canonical_form_usages() -> TestResult {
         let schema_str_perm: Vec<&str> = schema_str_perm.iter().map(|s| **s).collect();
         let schemata = Schema::parse_list(&schema_str_perm)?;
         for schema in &schemata {
-            let [resolved] = ResolvedSchema::from_schema_array([schema], schemata.iter())?;
+            let other_schemata = schemata.iter().filter(|other_schema|{other_schema != &schema});
+            let [resolved] = ResolvedSchema::resolve().additional(other_schemata)?.build_array([schema])?;
             let complete = CompleteSchema::from(&resolved);
             match schema.name().unwrap().to_string().as_str() {
                 "RecUsage" => {
@@ -2350,16 +2348,13 @@ fn avro_rs_66_test_independent_canonical_form_deep_recursion() -> TestResult {
 
     }"#;
 
-    let schema_strs = [record_primitive, record_usage, record_usage_usage];
+    let schema_strs = [record_primitive, record_usage];
 
     for schema_str_perm in permutations(&schema_strs) {
         let schema_str_perm: Vec<&str> = schema_str_perm.iter().map(|s| **s).collect();
         let schemata = Schema::parse_list(&schema_str_perm)?;
-        let ruu = schemata
-            .iter()
-            .find(|s| s.name().unwrap().to_string().as_str() == "RecUsageUsage")
-            .unwrap();
-        let [resolved] = ResolvedSchema::from_schema_array([ruu], schemata.iter())?;
+        let ruu = Schema::parse_str(&record_usage_usage)?;
+        let [resolved] = ResolvedSchema::resolve().additional(schemata.iter())?.build_array([&ruu])?;
         assert_eq!(
             CompleteSchema::from(&resolved).independent_canonical_form()?,
             Schema::parse_str(record_usage_usage_independent)?.canonical_form()
@@ -2391,10 +2386,9 @@ fn avro_rs_66_test_independent_canonical_form_missing_ref() -> TestResult {
     let schema_strs = [record_primitive, record_usage];
     let schemata = Schema::parse_list(schema_strs)?;
     assert!(matches!(
-        CompleteSchema::try_from(schemata[1].clone())?
-            .independent_canonical_form()
-            .map_err(Error::into_details), //NOTE - we're passing in an empty schemata
-        Err(Details::SchemaResolutionError(..))
+        CompleteSchema::try_from(schemata[1].clone())
+            .map_err(Error::into_details),
+        Err(Details::ResolvedSchemaCreationError(..))
     ));
     Ok(())
 }

--- a/avro/tests/to_from_avro_datum_schemata.rs
+++ b/avro/tests/to_from_avro_datum_schemata.rs
@@ -89,8 +89,7 @@ fn avro_rs_106_test_multiple_schemata_to_from_avro_datum_with_resolution() -> Te
 
     let value = GenericDatumReader::builder(schema_b)
         .writer_schemata(schemata.clone())?
-        .reader_schema(schema_b)
-        .reader_schemata(schemata)?
+        .reader_schema_with_schemata(schema_b,schemata)?
         .build()?
         .read_value(&mut actual.as_slice())?;
     assert_eq!(value, record);

--- a/avro/tests/to_from_avro_datum_schemata.rs
+++ b/avro/tests/to_from_avro_datum_schemata.rs
@@ -45,20 +45,18 @@ fn test_avro_3683_multiple_schemata_to_from_avro_datum() -> TestResult {
         Value::Record(vec![(String::from("field_a"), Value::Float(1.0))]),
     )]);
 
-    let schemata: Vec<Schema> = Schema::parse_list([SCHEMA_A_STR, SCHEMA_B_STR])?;
-    let schemata: Vec<&Schema> = schemata.iter().collect();
+    let schema_a = Schema::parse_str(SCHEMA_A_STR)?;
+    let schema_b = Schema::parse_str(SCHEMA_B_STR)?;
 
-    // this is the Schema we want to use for write/read
-    let schema_b = schemata[1];
     let expected: Vec<u8> = vec![0, 0, 128, 63];
-    let actual = GenericDatumWriter::builder(schema_b)
-        .schemata(schemata.clone())?
+    let actual = GenericDatumWriter::builder(&schema_b)
+        .schemata(vec![&schema_a])?
         .build()?
         .write_value_to_vec(record.clone())?;
     assert_eq!(actual, expected);
 
-    let value = GenericDatumReader::builder(schema_b)
-        .writer_schemata(schemata)?
+    let value = GenericDatumReader::builder(&schema_b)
+        .writer_schemata(vec![&schema_a])?
         .build()?
         .read_value(&mut actual.as_slice())?;
     assert_eq!(value, record);
@@ -75,21 +73,19 @@ fn avro_rs_106_test_multiple_schemata_to_from_avro_datum_with_resolution() -> Te
         Value::Record(vec![(String::from("field_a"), Value::Float(1.0))]),
     )]);
 
-    let schemata: Vec<Schema> = Schema::parse_list([SCHEMA_A_STR, SCHEMA_B_STR])?;
-    let schemata: Vec<&Schema> = schemata.iter().collect();
+    let schema_a = Schema::parse_str(SCHEMA_A_STR)?;
+    let schema_b = Schema::parse_str(SCHEMA_B_STR)?;
 
-    // this is the Schema we want to use for write/read
-    let schema_b = schemata[1];
     let expected: Vec<u8> = vec![0, 0, 128, 63];
-    let actual = GenericDatumWriter::builder(schema_b)
-        .schemata(schemata.clone())?
+    let actual = GenericDatumWriter::builder(&schema_b)
+        .schemata(vec![&schema_a])?
         .build()?
         .write_value_to_vec(record.clone())?;
     assert_eq!(actual, expected);
 
-    let value = GenericDatumReader::builder(schema_b)
-        .writer_schemata(schemata.clone())?
-        .reader_schema_with_schemata(schema_b,schemata)?
+    let value = GenericDatumReader::builder(&schema_b)
+        .writer_schemata(vec![&schema_a])?
+        .reader_schema_with_schemata(&schema_b,vec![&schema_a])?
         .build()?
         .read_value(&mut actual.as_slice())?;
     assert_eq!(value, record);
@@ -106,21 +102,19 @@ fn test_avro_3683_multiple_schemata_writer_reader() -> TestResult {
         Value::Record(vec![(String::from("field_a"), Value::Float(1.0))]),
     )]);
 
-    let schemata: Vec<Schema> = Schema::parse_list([SCHEMA_A_STR, SCHEMA_B_STR])?;
-    let schemata: Vec<&Schema> = schemata.iter().collect();
+    let schema_a = Schema::parse_str(SCHEMA_A_STR)?;
+    let schema_b = Schema::parse_str(SCHEMA_B_STR)?;
 
-    // this is the Schema we want to use for write/read
-    let schema_b = schemata[1];
     let mut output: Vec<u8> = Vec::new();
 
-    let mut writer = Writer::with_schemata(schema_b, schemata.clone(), &mut output, Codec::Null)?;
+    let mut writer = Writer::with_schemata(&schema_b, vec![&schema_a], &mut output, Codec::Null)?;
     writer.append_value(record.clone())?;
     writer.flush()?;
     drop(writer); //drop the writer so that `output` is no more referenced mutably
 
     let reader = Reader::builder(output.as_slice())
-        .reader_schema(schema_b)
-        .schemata(schemata)
+        .reader_schema(&schema_b)
+        .schemata(vec![&schema_a])
         .build()?;
     let value = reader.into_iter().next().unwrap()?;
     assert_eq!(value, record);

--- a/avro_derive/src/enums/plain.rs
+++ b/avro_derive/src/enums/plain.rs
@@ -48,7 +48,7 @@ pub fn schema_def(
         }
         Ok(quote! {
             ::apache_avro::schema::Schema::Enum(::apache_avro::schema::EnumSchema {
-                name,
+                name: std::sync::Arc::new(name),
                 aliases: #enum_aliases,
                 doc: #doc,
                 symbols: vec![#(#symbols.to_owned()),*],

--- a/avro_derive/src/lib.rs
+++ b/avro_derive/src/lib.rs
@@ -138,7 +138,7 @@ fn handle_named_schemas(full_schema_name: String, schema_def: TokenStream) -> To
     quote! {
         let name = ::apache_avro::schema::Name::new_with_enclosing_namespace(#full_schema_name, enclosing_namespace).expect(concat!("Unable to parse schema name ", #full_schema_name));
         if named_schemas.contains(&name) {
-            ::apache_avro::schema::Schema::Ref{name}
+            ::apache_avro::schema::Schema::Ref{name: std::sync::Arc::new(name)}
         } else {
             let enclosing_namespace = name.namespace();
             named_schemas.insert(name.clone());
@@ -259,7 +259,7 @@ fn get_struct_schema_def(
                 .map(|(position, field)| (field.name.to_owned(), position))
                 .collect();
             ::apache_avro::schema::Schema::Record(::apache_avro::schema::RecordSchema {
-                name,
+                name: std::sync::Arc::new(name),
                 aliases: #record_aliases,
                 doc: #record_doc,
                 fields: schema_fields,

--- a/avro_derive/tests/derive.rs
+++ b/avro_derive/tests/derive.rs
@@ -1915,7 +1915,7 @@ fn avro_rs_397_with_generic() {
         _enclosing_namespace: NamespaceRef,
     ) -> Schema {
         Schema::Fixed(FixedSchema {
-            name: Name::new(format!("fixed_{N}")).unwrap(),
+            name: Name::new(format!("fixed_{N}")).unwrap().into(),
             aliases: None,
             doc: None,
             size: N,

--- a/avro_test_helper/src/data.rs
+++ b/avro_test_helper/src/data.rs
@@ -36,7 +36,7 @@ pub const PRIMITIVE_EXAMPLES: &[(&str, bool)] = &[
     (r#"{"type": "float"}"#, true),
     (r#""double""#, true),
     (r#"{"type": "double"}"#, true),
-    (r#""true""#, false),
+    (r#""true""#, true),
     (r#"true"#, false),
     (r#"{"no_type": "test"}"#, false),
     (r#"{"type": "panther"}"#, false),
@@ -130,31 +130,31 @@ pub const UNION_EXAMPLES: &[(&str, bool)] = &[
     ),
     // Unions with default values
     (
-        r#"{"name": "foo", "type": ["string", "long"], "default": "bar"}"#,
+        r#"{"name": "test", "type":"record" , "fields": [{"name": "foo", "type": ["string", "long"], "default": "bar"}]}"#,
         true,
     ),
     (
-        r#"{"name": "foo", "type": ["long", "string"], "default": 1}"#,
+        r#"{"name": "test", "type":"record" , "fields": [{"name": "foo", "type": ["long", "string"], "default": 1}]}"#,
         true,
     ),
     (
-        r#"{"name": "foo", "type": ["null", "string"], "default": null}"#,
+        r#"{"name": "test", "type":"record" , "fields": [{"name": "foo", "type": ["null", "string"], "default": null}]}"#,
         true,
     ),
     (
-        r#"{"name": "foo", "type": ["string", "long"], "default": 1}"#,
+        r#"{"name": "test", "type":"record" , "fields": [{"name": "foo", "type": ["string", "long"], "default": 1}]}"#,
         true,
     ),
     (
-        r#"{"name": "foo", "type": ["string", "null"], "default": null}"#,
+        r#"{"name": "test", "type":"record" , "fields": [{"name": "foo", "type": ["string", "null"], "default": null}]}"#,
         true,
     ),
     (
-        r#"{"name": "foo", "type": ["null", "string"], "default": "null"}"#,
+        r#"{"name": "test", "type":"record" , "fields": [{"name": "foo", "type": ["null", "string"], "default": "null"}]}"#,
         true,
     ),
     (
-        r#"{"name": "foo", "type": ["long", "string"], "default": "str"}"#,
+        r#"{"name": "test", "type":"record" , "fields": [{"name": "foo", "type": ["long", "string"], "default": "str"}]}"#,
         true,
     ),
 ];


### PR DESCRIPTION
Hey you all, this PR reworks schema parsing and `ResolvedSchema`.

I apologize for the size of this PR. I tried making it smaller, but I kept finding the changes made to parsing/`ResovledSchema` would trickle into many other sections of the crate.

This PR addresses issues \#531, \#353, and \#508.

Here is the gist of what this PR does:

# The new stuff
## Introduces `SchemaWithSymbols`.

Instead of representing a schema as a single recursive `Schema` variant, `SchemaWithSymbols` represents a schema as a hash map of all defined named schemata and a hash set of all referenced named schemata from that schema. This, coupled with the root schema enum, is enough to represent the entire schema parse tree.

The upshot of this representation is that when we go to check if a set of schemata form a complete context  we don't need to recurse into each schema and can just compare the "symbol tables" directly.

In addition, `SchemaWithSymbols` is essentially just made up of `Arc`'s and `HashMaps` of `Arc`'s. This should make cloning fairly quick compared to `Schema`.

## Introduces `ResolvedContext`.

`ResovledContext` wraps a list of schema definitions that have been checked for compatibility (no double naming of named schemata, all named references have a definition). This is closest to what the original `ResolvedSchema` looked like.

## Completely reworks `ResolvedSchema`.

As can be seen by the diff, `ResolvedSchema` has been essentially replaced in its entirety. `ResolvedSchema` now wraps a schema and all of the definitions needed to uniquely resolve all named schemata. In addition, we can convert `ResolvedSchema` into a `ResolvedNode`.

## Introduces `ResolvedNode`.

The struct `ResolvedNode` allows other code to walk down a schema tree without having to resolve `Schema::Ref` variants themselves. Further, since a `ResolvedNode` can only be created from a `ResolvedSchema`, we can make the type guarantee that this resolution will always find a unique named schema definition. `ResolvedNode` also makes the promise that any default for a record field has been checked against the field's schema.

## Introduces a `Resolver` trait.

This trait is designed to be used to hook up this crate's schema resolution logic to an external schema registry. Struct's implementing this trait can be provided to `ResolvedContext` either directly or through `ResolvedSchema`. If a local definition for a schema can not be found, the `Resolver` is called asking for it to either provide that schema or to signal an error.

# API changes

This PR introduces several breaking API changes, both in the public API and to the private API. I will try to summarize the changes for both layers.

## Semantic changes -- parsing

- Parser now always generates a `SchemaWithSymbols`. To keep compatibility with existing `Schema` based methods, the original schema parsing methods like `Schema::parse_str` will use the parser to generate a `SchemaWithSymbols` which is then unraveled into a normal `Schema` enum. This adds some overhead, but this is already a "slow" path so I don't think this introduces performance concerns.

- `Schema::parse_list` no longer checks if every named schema has a unique definition somewhere in the list. This is due to the conceptual shift mentioned in issue \#353. In this PR, parser methods do nothing more than parse each schema string and check that each one is internally consistent. Checking that a list of schemata is consistent (no duplicate named definitions, all references resolved) is pushed to `ResolvedSchema`.

## API changes -- public facing

- `ResolvedSchema` completely reworked. Any code that relied on the old `ResolvedSchema` would have to be refactored (though I think the needed changes are rather minimal). The new `ResolvedSchema` wraps a single schema and its resolved context, and is created via `ResolvedSchema::builder()`. See the new builder API: `.additional()` to provide
extra schemata, then `.build_one()`, `.build_array()`, or `.build_list()` as the terminal method depending on how many schemas you need resolved. Variants with `_with_resolver` accept a custom `Resolver` implementation for schema registry lookups.
- Elimination of `Schema::parse_str_with_list`. This method parsed a schema string alongside a list of other schema strings and returned the parsed schema plus the resolved list. The same result can now be achieved by parsing each schema independently with `SchemaWithSymbols::parse_str` and then resolving them together via `ResolvedSchema::builder().additional(others)?.build_one(target)?`.
- Elimination of `Schema::denormalize`. Denormalization (inlining named type definitions into references) is now handled via `ResolvedSchema::unravel()` or `SchemaWithSymbols::unravel()`.
- Elimination of `Schema::independent_canonical_form`. This is now accessed through `CompleteSchema::independent_canonical_form()` which requires a `ResolvedSchema`, making the resolved-context dependency explicit.
- `resolve_names` and `resolve_names_with_schemata` (were `pub(crate)`) are removed. Their role is subsumed by `ResolvedContext`.
- `ResolvedOwnedSchema` is removed. `ResolvedSchema` now owns its data (via `Arc`), making the separate owned variant unnecessary.
- `Schema::name()` now returns `Option<&Arc<Name>>` instead of `Option<&Name>`.
- `Value::validate_schemata(schemata)` replaced by `Value::validate_against_resolved(resolved_schema)`.
- `find_schema_with_known_schemata` is removed. Finding a matching element in a union requires that you have a `ResolvedSchema`. The method that performs union element matching is now `structural_match_on_schema` defined on `ResolvedUnion`.

## API changes -- private facing

- `decode_internal` signature changed from `(schema: &Schema, names: &HashMap<Name, S>, enclosing_namespace: NamespaceRef, reader: &mut R)` to
`(node: ResolvedNode, reader: &mut R)`. The `ResolvedNode` carries the schema, its resolved definitions, and handles namespace tracking internally
- `encode_internal` similarly changed from `(value: &Value, schema: &Schema, names: &HashMap<Name, S>, enclosing_namespace: NamespaceRef, writer: &mut W)`
to `(value: &Value, node: ResolvedNode, writer: &mut W)`.
- New functions `decode_complete` and `encode_complete` are added as the preferred entry points for decoding/encoding with a `ResolvedSchema`.
- `Block` now takes a `ResolvedSchema` instead of `Names`.
- `validate_internal` and `resolve_internal` on `Value` changed from generic `<S: Borrow<Schema> + Debug>` with `(schema, names, namespace)` parameters to taking a `ResolvedNode` directly.
- The generic `S: Borrow<Schema>` pattern used throughout decode, encode, and types for referencing named schemas is entirely replaced by `ResolvedNode`'s transparent reference resolution.
- Elimination of `Schema::parse_with_names` (was `pub(crate)`). Internal callers now use `SchemaWithSymbols` and `ResolvedSchema` instead of passing `Names` maps through parsing.
