### PR TITLE
Fix for `Value::String` to `Value::Fixed` resolution ignoring the `size` from the schema.

### DIFF
--- a/avro/src/types.rs
+++ b/avro/src/types.rs
@@ -1118,7 +1118,7 @@ impl Value {
                     bytes.resize(size, 0);
                     Ok(Value::Fixed(size, bytes))
                 }
-            },
+            }
             Value::Bytes(s) => {
                 if s.len() == size {
                     Ok(Value::Fixed(size, s))
@@ -3654,7 +3654,8 @@ Field with name '"b"' is not a member of the map items"#,
 
     #[test]
     fn avro_rs_542_test_bigger_string_to_smaller_fixed_resolution() -> TestResult {
-        let schema = Schema::parse_str(r#"
+        let schema = Schema::parse_str(
+            r#"
         {
             "name": "test",
             "type": "record",
@@ -3666,11 +3667,14 @@ Field with name '"b"' is not a member of the map items"#,
                     "size": 2
                 }
             }]
-        }"#)?;
+        }"#,
+        )?;
 
         let long_string = "This string is too long and won't fit!!".to_string();
-        let value = Value::Record(vec![("test_field".to_string(),
-                Value::String(long_string.clone()))]);
+        let value = Value::Record(vec![(
+            "test_field".to_string(),
+            Value::String(long_string.clone()),
+        )]);
 
         assert_eq!(
             value.resolve(&schema)
@@ -3685,7 +3689,8 @@ Field with name '"b"' is not a member of the map items"#,
 
     #[test]
     fn avro_rs_542_test_smaller_string_to_bigger_fixed_resolution() -> TestResult {
-        let schema = Schema::parse_str(r#"
+        let schema = Schema::parse_str(
+            r#"
         {
             "name": "test",
             "type": "record",
@@ -3697,23 +3702,31 @@ Field with name '"b"' is not a member of the map items"#,
                     "size": 6
                 }
             }]
-        }"#)?;
+        }"#,
+        )?;
 
-        let mut value = Value::Record(vec![("test_field".to_string(),
-                Value::String("abc".to_string()))]);
+        let mut value = Value::Record(vec![(
+            "test_field".to_string(),
+            Value::String("abc".to_string()),
+        )]);
 
         value = value.resolve(&schema)?;
 
-        assert_eq!(value,
-             Value::Record(vec![("test_field".to_string() , Value::Fixed(6, vec![97, 98, 99, 0 ,0 , 0]))])
-            );
+        assert_eq!(
+            value,
+            Value::Record(vec![(
+                "test_field".to_string(),
+                Value::Fixed(6, vec![97, 98, 99, 0, 0, 0])
+            )])
+        );
 
         Ok(())
     }
 
     #[test]
     fn avro_rs_542_test_smaller_string_to_bigger_fixed_resolution_idempotence() -> TestResult {
-        let schema = Schema::parse_str(r#"
+        let schema = Schema::parse_str(
+            r#"
         {
             "name": "test",
             "type": "record",
@@ -3725,16 +3738,23 @@ Field with name '"b"' is not a member of the map items"#,
                     "size": 6
                 }
             }]
-        }"#)?;
+        }"#,
+        )?;
 
-        let mut value = Value::Record(vec![("test_field".to_string(),
-                Value::String("abc".to_string()))]);
+        let mut value = Value::Record(vec![(
+            "test_field".to_string(),
+            Value::String("abc".to_string()),
+        )]);
 
         value = value.resolve(&schema)?;
 
-        assert_eq!(value,
-             Value::Record(vec![("test_field".to_string() , Value::Fixed(6, vec![97, 98, 99, 0 ,0 , 0]))])
-            );
+        assert_eq!(
+            value,
+            Value::Record(vec![(
+                "test_field".to_string(),
+                Value::Fixed(6, vec![97, 98, 99, 0, 0, 0])
+            )])
+        );
 
         Ok(())
     }

--- a/avro/src/types.rs
+++ b/avro/src/types.rs
@@ -3653,7 +3653,7 @@ Field with name '"b"' is not a member of the map items"#,
     }
 
     #[test]
-    fn avro_rs_test_biggger_string_to_smaller_fixed_resolution() -> TestResult{
+    fn avro_rs_542_test_bigger_string_to_smaller_fixed_resolution() -> TestResult {
         let schema = Schema::parse_str(r#"
         {
             "name": "test",
@@ -3684,7 +3684,7 @@ Field with name '"b"' is not a member of the map items"#,
     }
 
     #[test]
-    fn avro_rs_test_smaller_string_to_bigger_fixed_resolution() -> TestResult{
+    fn avro_rs_542_test_smaller_string_to_bigger_fixed_resolution() -> TestResult {
         let schema = Schema::parse_str(r#"
         {
             "name": "test",
@@ -3712,7 +3712,7 @@ Field with name '"b"' is not a member of the map items"#,
     }
 
     #[test]
-    fn avro_rs_test_smaller_string_to_bigger_fixed_resolution_idempotence() -> TestResult{
+    fn avro_rs_542_test_smaller_string_to_bigger_fixed_resolution_idempotence() -> TestResult {
         let schema = Schema::parse_str(r#"
         {
             "name": "test",

--- a/avro/src/types.rs
+++ b/avro/src/types.rs
@@ -3747,6 +3747,7 @@ Field with name '"b"' is not a member of the map items"#,
         )]);
 
         value = value.resolve(&schema)?;
+        value = value.resolve(&schema)?;
 
         assert_eq!(
             value,

--- a/avro/src/types.rs
+++ b/avro/src/types.rs
@@ -1110,7 +1110,15 @@ impl Value {
                     Err(Details::CompareFixedSizes { size, n }.into())
                 }
             }
-            Value::String(s) => Ok(Value::Fixed(s.len(), s.into_bytes())),
+            Value::String(s) => {
+                if s.len() > size {
+                    Err(Details::CompareFixedSizes { size, n: s.len() }.into())
+                } else {
+                    let mut bytes = s.into_bytes();
+                    bytes.resize(size, 0);
+                    Ok(Value::Fixed(size, bytes))
+                }
+            },
             Value::Bytes(s) => {
                 if s.len() == size {
                     Ok(Value::Fixed(size, s))
@@ -3642,5 +3650,93 @@ Field with name '"b"' is not a member of the map items"#,
                 .to_string(),
             "JSON number 18446744073709551615 could not be converted into an Avro value as it's too large"
         );
+    }
+
+    #[test]
+    fn avro_rs_test_biggger_string_to_smaller_fixed_resolution() -> TestResult{
+        let schema = Schema::parse_str(r#"
+        {
+            "name": "test",
+            "type": "record",
+            "fields": [{
+                "name": "test_field",
+                "type": {
+                    "name": "myFixed",
+                    "type": "fixed",
+                    "size": 2
+                }
+            }]
+        }"#)?;
+
+        let long_string = "This string is too long and won't fit!!".to_string();
+        let value = Value::Record(vec![("test_field".to_string(),
+                Value::String(long_string.clone()))]);
+
+        assert_eq!(
+            value.resolve(&schema)
+            .expect_err("Expected resolution to fail since string is too large for the given fixed schema size")
+            .into_details()
+            .to_string(),
+            Details::CompareFixedSizes { size: 2, n: long_string.len() }.to_string()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn avro_rs_test_smaller_string_to_bigger_fixed_resolution() -> TestResult{
+        let schema = Schema::parse_str(r#"
+        {
+            "name": "test",
+            "type": "record",
+            "fields": [{
+                "name": "test_field",
+                "type": {
+                    "name": "myFixed",
+                    "type": "fixed",
+                    "size": 6
+                }
+            }]
+        }"#)?;
+
+        let mut value = Value::Record(vec![("test_field".to_string(),
+                Value::String("abc".to_string()))]);
+
+        value = value.resolve(&schema)?;
+
+        assert_eq!(value,
+             Value::Record(vec![("test_field".to_string() , Value::Fixed(6, vec![97, 98, 99, 0 ,0 , 0]))])
+            );
+
+        Ok(())
+    }
+
+    #[test]
+    fn avro_rs_test_smaller_string_to_bigger_fixed_resolution_idempotence() -> TestResult{
+        let schema = Schema::parse_str(r#"
+        {
+            "name": "test",
+            "type": "record",
+            "fields": [{
+                "name": "test_field",
+                "type": {
+                    "name": "myFixed",
+                    "type": "fixed",
+                    "size": 6
+                }
+            }]
+        }"#)?;
+
+        let mut value = Value::Record(vec![("test_field".to_string(),
+                Value::String("abc".to_string()))]);
+
+        value = value.resolve(&schema)?;
+        value = value.resolve(&schema)?;
+
+        assert_eq!(value,
+             Value::Record(vec![("test_field".to_string() , Value::Fixed(6, vec![97, 98, 99, 0 ,0 , 0]))])
+            );
+
+        Ok(())
     }
 }

--- a/avro/src/types.rs
+++ b/avro/src/types.rs
@@ -3731,7 +3731,6 @@ Field with name '"b"' is not a member of the map items"#,
                 Value::String("abc".to_string()))]);
 
         value = value.resolve(&schema)?;
-        value = value.resolve(&schema)?;
 
         assert_eq!(value,
              Value::Record(vec![("test_field".to_string() , Value::Fixed(6, vec![97, 98, 99, 0 ,0 , 0]))])

--- a/avro/tests/io.rs
+++ b/avro/tests/io.rs
@@ -127,7 +127,7 @@ fn default_value_examples() -> &'static Vec<(&'static str, &'static str, Value)>
             (
                 r#"{"type": "fixed", "name": "F", "size": 2}"#,
                 r#""a""#,
-                Value::Fixed(1, vec![97]),
+                Value::Fixed(2, vec![97, 0]),
             ), // ASCII 'a' => one byte
             (
                 r#"{"type": "fixed", "name": "F", "size": 2}"#,


### PR DESCRIPTION
Hey all,

I noticed that the method `resolve_fixed`  with a `Value::String` will ignore the `size`  of the `Schema::Fixed` and will simply accept whatever sized string is provided, even if its actually too long for the provided fixed.

This fix modifies `resolve_fixed` so that it checks the size of the string and rejects if its too long for the `Schema::Fixed`. In addition, if too short of a string is supplied, it is zero padded to the required length.