### PR TITLE
Deserializer support for BigDecimal when using apache_avro::serde::bigdecimal

### DIFF
--- a/avro/src/serde/de.rs
+++ b/avro/src/serde/de.rs
@@ -1802,7 +1802,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_bigdecimal_as_bytes() -> TestResult {
+    fn avro_543_deserialize_bigdecimal_as_bytes() -> TestResult {
         #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
         #[serde(transparent)]
         struct WrappedBigDecimal (

--- a/avro/src/serde/de.rs
+++ b/avro/src/serde/de.rs
@@ -1802,6 +1802,25 @@ mod tests {
     }
 
     #[test]
+    fn test_deserialize_bigdecimal_as_bytes() -> TestResult {
+        #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+        #[serde(transparent)]
+        struct WrappedBigDecimal (
+            // crate::serde::bigdecimal serializes/deserializes BigDecimal as bytes
+            #[serde(with="crate::serde::bigdecimal")]
+            bigdecimal::BigDecimal
+        );
+
+        let expected_decimal = WrappedBigDecimal(str::parse("7.45")?);
+        let value = Value::BigDecimal(str::parse("7.45")?);
+        let actual_decimal = from_value::<WrappedBigDecimal>(&value)?;
+
+        assert_eq!(actual_decimal, expected_decimal);
+
+        Ok(())        
+    }
+
+    #[test]
     fn test_avro_3892_deserialize_bytes_from_uuid() -> TestResult {
         let uuid_str = "10101010-2020-2020-2020-101010101010";
         let expected_bytes = Uuid::parse_str(uuid_str)?.as_bytes().to_vec();

--- a/avro/src/serde/de.rs
+++ b/avro/src/serde/de.rs
@@ -16,7 +16,10 @@
 // under the License.
 
 //! Logic for serde-compatible deserialization.
-use crate::{Error, bigdecimal::big_decimal_as_bytes, error::Details, serde::with::DE_BYTES_BORROWED, types::Value};
+use crate::{
+    Error, bigdecimal::big_decimal_as_bytes, error::Details, serde::with::DE_BYTES_BORROWED,
+    types::Value,
+};
 use serde::{
     Deserialize,
     de::{self, DeserializeSeed, Deserializer as _, Visitor},
@@ -1805,10 +1808,9 @@ mod tests {
     fn avro_543_deserialize_bigdecimal_as_bytes() -> TestResult {
         #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
         #[serde(transparent)]
-        struct WrappedBigDecimal (
+        struct WrappedBigDecimal(
             // crate::serde::bigdecimal serializes/deserializes BigDecimal as bytes
-            #[serde(with="crate::serde::bigdecimal")]
-            bigdecimal::BigDecimal
+            #[serde(with = "crate::serde::bigdecimal")] bigdecimal::BigDecimal,
         );
 
         let expected_decimal = WrappedBigDecimal(str::parse("7.45")?);
@@ -1817,7 +1819,7 @@ mod tests {
 
         assert_eq!(actual_decimal, expected_decimal);
 
-        Ok(())        
+        Ok(())
     }
 
     #[test]

--- a/avro/src/serde/de.rs
+++ b/avro/src/serde/de.rs
@@ -1806,7 +1806,7 @@ mod tests {
 
     #[test]
     fn avro_543_deserialize_bigdecimal_as_bytes() -> TestResult {
-        #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+        #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
         #[serde(transparent)]
         struct WrappedBigDecimal(
             // crate::serde::bigdecimal serializes/deserializes BigDecimal as bytes
@@ -1817,7 +1817,11 @@ mod tests {
         let value = Value::BigDecimal(str::parse("7.45")?);
         let actual_decimal = from_value::<WrappedBigDecimal>(&value)?;
 
-        assert_eq!(actual_decimal, expected_decimal);
+        assert_eq!(actual_decimal, expected_decimal.clone());
+
+        let value = Value::Union(0, Box::new(Value::BigDecimal(str::parse("7.45")?)));
+        let raw_bytes = from_value::<Option<WrappedBigDecimal>>(&value)?;
+        assert_eq!(raw_bytes, Some(expected_decimal));
 
         Ok(())
     }

--- a/avro/src/serde/de.rs
+++ b/avro/src/serde/de.rs
@@ -621,7 +621,7 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
                 visitor.visit_bytes(&d_bytes[..])
             }
             _ => Err(de::Error::custom(format!(
-                "Expected a String|Bytes|Fixed|Uuid|Decimal|Duration, but got {:?}",
+                "Expected a String|Bytes|Fixed|Uuid|BigDecimal|Decimal|Duration, but got {:?}",
                 self.input
             ))),
         }
@@ -644,7 +644,7 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
                 visitor.visit_byte_buf(Vec::from(d_bytes))
             }
             _ => Err(de::Error::custom(format!(
-                "Expected a String|Bytes|Fixed|Uuid|Decimal|Duration, but got {:?}",
+                "Expected a String|Bytes|Fixed|Uuid|BigDecimal|Decimal|Duration, but got {:?}",
                 self.input
             ))),
         }

--- a/avro/src/serde/de.rs
+++ b/avro/src/serde/de.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 //! Logic for serde-compatible deserialization.
-use crate::{Error, error::Details, serde::with::DE_BYTES_BORROWED, types::Value};
+use crate::{Error, bigdecimal::big_decimal_as_bytes, error::Details, serde::with::DE_BYTES_BORROWED, types::Value};
 use serde::{
     Deserialize,
     de::{self, DeserializeSeed, Deserializer as _, Visitor},
@@ -612,6 +612,7 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
             }
             Value::Uuid(u) => visitor.visit_bytes(u.as_bytes()),
             Value::Decimal(d) => visitor.visit_bytes(&d.to_vec()?),
+            Value::BigDecimal(d) => visitor.visit_bytes(&big_decimal_as_bytes(d)?),
             Value::Duration(d) => {
                 let d_bytes: [u8; 12] = d.into();
                 visitor.visit_bytes(&d_bytes[..])
@@ -634,6 +635,7 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
             }
             Value::Uuid(u) => visitor.visit_byte_buf(Vec::from(u.as_bytes())),
             Value::Decimal(d) => visitor.visit_byte_buf(d.to_vec()?),
+            Value::BigDecimal(d) => visitor.visit_byte_buf(big_decimal_as_bytes(d)?),
             Value::Duration(d) => {
                 let d_bytes: [u8; 12] = d.into();
                 visitor.visit_byte_buf(Vec::from(d_bytes))

--- a/avro/src/serde/with.rs
+++ b/avro/src/serde/with.rs
@@ -510,7 +510,7 @@ pub mod slice_opt {
 ///
 /// When used with different serialization formats, this will write bytes.
 ///
-/// See usage with below example:
+/// Example usage:
 /// ```
 /// # use apache_avro::{AvroSchema, BigDecimal};
 /// # use serde::{Deserialize, Serialize};


### PR DESCRIPTION
It looks like serialization/deserialization was made more strict, and in the process, Deserializer no longer supports deserializing BigDecimal as a string, (which is what BigDecimal serializes/deserializes to/from by default.)  That's ok, since you can just add `#[serde(with="apache_avro::serde::bigdecimal")]`, but then it appears that deserializing BigDecimal as bytes is missing.  This PR adds the missing support for deserializing BigDecimal as bytes.
