### PR TITLE
fix: Optimize `Alias::new()` and `Parser::fix_aliases_namespace`

### DIFF
--- a/avro/src/schema/name.rs
+++ b/avro/src/schema/name.rs
@@ -257,13 +257,22 @@ impl<'de> Deserialize<'de> for Name {
 }
 
 /// Newtype pattern for `Name` to better control the `serde_json::Value` representation.
+///
 /// Aliases are serialized as an array of plain strings in the JSON representation.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Alias(Name);
 
 impl Alias {
-    pub fn new(name: &str) -> AvroResult<Self> {
+    pub fn new(name: impl Into<String> + AsRef<str>) -> AvroResult<Self> {
         Name::new(name).map(Self)
+    }
+
+    /// Create a new `Alias` using the namespace from `enclosing_namespace` if absent.
+    pub fn new_with_enclosing_namespace(
+        name: impl Into<String> + AsRef<str>,
+        enclosing_namespace: NamespaceRef,
+    ) -> AvroResult<Self> {
+        Name::new_with_enclosing_namespace(name, enclosing_namespace).map(Self)
     }
 
     pub fn name(&self) -> &str {

--- a/avro/src/schema/parser.rs
+++ b/avro/src/schema/parser.rs
@@ -803,19 +803,12 @@ impl Parser {
         aliases
             .map(|aliases| {
                 aliases
-                    .iter()
+                    .into_iter()
                     .map(|alias| {
                         // An alias that is not a valid Avro name is a schema
                         // error — propagate it instead of unwrapping (which
                         // would panic on attacker-controlled schema JSON).
-                        if alias.contains('.') {
-                            Alias::new(alias.as_str())
-                        } else {
-                            match namespace {
-                                Some(ns) => Alias::new(&format!("{ns}.{alias}")),
-                                None => Alias::new(alias.as_str()),
-                            }
-                        }
+                        Alias::new_with_enclosing_namespace(alias, namespace)
                     })
                     .collect::<AvroResult<Vec<_>>>()
             })


### PR DESCRIPTION
I noticed a missed optimization opportunity.
Using `impl Into<String> + AsRef<str>` allows us to reuse the allocation if the input is a `String`.
And by using `.into_iter()` in `fix_aliases_namespace` we get an allocation we can reuse.