### PR TITLE
fix: bound array/map allocation by decoded element count

### DIFF
--- a/avro/src/decode.rs
+++ b/avro/src/decode.rs
@@ -242,16 +242,18 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
                 }
 
                 // Bound the cumulative element count against the allocation
-                // budget before reserving: `reserve(len)` allocates
-                // `len * size_of::<Value>()` bytes, and a tiny block count could
-                // otherwise drive a huge allocation. This also caps zero-byte
-                // on-wire elements (e.g. `null`), which consume no input.
+                // budget before reserving: reserving for `len` elements
+                // allocates at least `len * size_of::<Value>()` bytes, and a
+                // tiny block count could otherwise drive a huge allocation. This
+                // also caps zero-byte on-wire elements (e.g. `null`), which
+                // consume no input. `reserve_exact` requests only what is needed,
+                // rather than the amortized (larger) capacity of `reserve`.
                 let total = items
                     .len()
                     .checked_add(len)
                     .ok_or(Details::IntegerOverflow)?;
                 safe_collection_len(total, std::mem::size_of::<Value>())?;
-                items.reserve(len);
+                items.reserve_exact(len);
                 for _ in 0..len {
                     items.push(decode_internal(
                         &inner.items,
@@ -275,6 +277,10 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
 
                 // See the array case above; a map entry additionally carries a
                 // String key, so bound by the size of a `(String, Value)` pair.
+                // This is a lower-bound estimate: `HashMap::reserve` also
+                // allocates hash-table metadata and spare capacity, so the
+                // budget is enforced approximately (not exactly) for maps. There
+                // is no `reserve_exact` for `HashMap`.
                 let total = items
                     .len()
                     .checked_add(len)

--- a/avro/src/decode.rs
+++ b/avro/src/decode.rs
@@ -485,6 +485,25 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_array_int64_min_block_count_is_rejected() -> TestResult {
+        // i64::MIN as a negative block count cannot be negated (checked_neg
+        // returns None); decoding must fail rather than wrap. i64::MIN zig-zag
+        // encodes as the 10-byte varint below, followed by a block byte-size.
+        let payload: &[u8] = &[
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01, // i64::MIN
+            0x00, // block byte-size
+        ];
+        let mut input = payload;
+        let result = decode(&Schema::array(Schema::Int).build(), &mut input);
+        assert!(
+            result.is_err(),
+            "an i64::MIN array block count must be rejected, got {result:?}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn test_decode_map_without_size() -> TestResult {
         let mut input: &[u8] = &[0x02, 0x08, 0x74, 0x65, 0x73, 0x74, 0x02, 0x00];
         let result = decode(&Schema::map(Schema::Int).build(), &mut input);

--- a/avro/src/decode.rs
+++ b/avro/src/decode.rs
@@ -24,7 +24,7 @@ use crate::{
     error::Details,
     schema::{DecimalSchema, EnumSchema, FixedSchema, Name, RecordSchema, ResolvedSchema, Schema},
     types::Value,
-    util::{safe_len, zag_i32, zag_i64},
+    util::{safe_collection_len, safe_len, zag_i32, zag_i64},
 };
 use std::{
     borrow::Borrow,
@@ -241,6 +241,16 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
                     break;
                 }
 
+                // Bound the cumulative element count against the allocation
+                // budget before reserving: `reserve(len)` allocates
+                // `len * size_of::<Value>()` bytes, and a tiny block count could
+                // otherwise drive a huge allocation. This also caps zero-byte
+                // on-wire elements (e.g. `null`), which consume no input.
+                let total = items
+                    .len()
+                    .checked_add(len)
+                    .ok_or(Details::IntegerOverflow)?;
+                safe_collection_len(total, std::mem::size_of::<Value>())?;
                 items.reserve(len);
                 for _ in 0..len {
                     items.push(decode_internal(
@@ -263,6 +273,13 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
                     break;
                 }
 
+                // See the array case above; a map entry additionally carries a
+                // String key, so bound by the size of a `(String, Value)` pair.
+                let total = items
+                    .len()
+                    .checked_add(len)
+                    .ok_or(Details::IntegerOverflow)?;
+                safe_collection_len(total, std::mem::size_of::<(String, Value)>())?;
                 items.reserve(len);
                 for _ in 0..len {
                     match decode_internal(&Schema::String, names, enclosing_namespace, reader)? {
@@ -384,6 +401,85 @@ mod tests {
         let mut input: &[u8] = &[5, 6, 2, 4, 6, 0];
         let result = decode(&Schema::array(Schema::Int).build(), &mut input);
         assert_eq!(Array(vec!(Int(1), Int(2), Int(3))), result?);
+
+        Ok(())
+    }
+
+    // A block count is decoded from a few bytes but drives `items.reserve(len)`,
+    // allocating `len * size_of::<Value>()` bytes. A tiny payload declaring a
+    // huge count must be rejected rather than driving a multi-gigabyte
+    // allocation. Zero-byte elements (null) are the worst case: they consume no
+    // input, so nothing else bounds the count.
+    fn zig_zag(n: i64) -> Vec<u8> {
+        let mut zz = ((n << 1) ^ (n >> 63)) as u64;
+        let mut out = Vec::new();
+        loop {
+            let mut b = (zz & 0x7f) as u8;
+            zz >>= 7;
+            if zz != 0 {
+                b |= 0x80;
+            }
+            out.push(b);
+            if zz == 0 {
+                break;
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn test_decode_array_of_null_huge_count_is_rejected() -> TestResult {
+        // 200,000,000 nulls => ~11 GiB reserve, far above the default budget.
+        let mut payload = zig_zag(200_000_000);
+        payload.push(0x00); // end-of-array marker (unreached)
+        let mut input: &[u8] = &payload;
+        let result = decode(&Schema::array(Schema::Null).build(), &mut input);
+        assert!(
+            result.is_err(),
+            "a huge array<null> block count must be rejected, got {result:?}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_decode_array_of_long_huge_count_is_rejected() -> TestResult {
+        // Non-zero-byte elements are also affected: the reserve happens before
+        // any element is read.
+        let mut payload = zig_zag(200_000_000);
+        payload.push(0x00);
+        let mut input: &[u8] = &payload;
+        let result = decode(&Schema::array(Schema::Long).build(), &mut input);
+        assert!(
+            result.is_err(),
+            "a huge array<long> block count must be rejected, got {result:?}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_decode_map_huge_count_is_rejected() -> TestResult {
+        let mut payload = zig_zag(200_000_000);
+        payload.push(0x00);
+        let mut input: &[u8] = &payload;
+        let result = decode(&Schema::map(Schema::Long).build(), &mut input);
+        assert!(
+            result.is_err(),
+            "a huge map block count must be rejected, got {result:?}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_decode_small_array_of_null_still_decodes() -> TestResult {
+        // A modest array of nulls within the budget must still decode.
+        let mut payload = zig_zag(3);
+        payload.push(0x00);
+        let mut input: &[u8] = &payload;
+        let result = decode(&Schema::array(Schema::Null).build(), &mut input)?;
+        assert_eq!(Array(vec!(Value::Null, Value::Null, Value::Null)), result);
 
         Ok(())
     }

--- a/avro/src/decode.rs
+++ b/avro/src/decode.rs
@@ -411,19 +411,9 @@ mod tests {
     // allocation. Zero-byte elements (null) are the worst case: they consume no
     // input, so nothing else bounds the count.
     fn zig_zag(n: i64) -> Vec<u8> {
-        let mut zz = ((n << 1) ^ (n >> 63)) as u64;
+        // Reuse the crate's encoder so the tests cannot diverge from it.
         let mut out = Vec::new();
-        loop {
-            let mut b = (zz & 0x7f) as u8;
-            zz >>= 7;
-            if zz != 0 {
-                b |= 0x80;
-            }
-            out.push(b);
-            if zz == 0 {
-                break;
-            }
-        }
+        crate::util::zig_i64(n, &mut out).unwrap();
         out
     }
 

--- a/avro/src/decode.rs
+++ b/avro/src/decode.rs
@@ -241,18 +241,14 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
                     break;
                 }
 
-                // Bound the cumulative element count against the allocation
-                // budget before reserving: reserving for `len` elements
-                // allocates at least `len * size_of::<Value>()` bytes, and a
-                // tiny block count could otherwise drive a huge allocation. This
-                // also caps zero-byte on-wire elements (e.g. `null`), which
-                // consume no input. `reserve_exact` requests only what is needed,
-                // rather than the amortized (larger) capacity of `reserve`.
+                // Check that the Vec won't grow past the max allocation size
                 let total = items
                     .len()
                     .checked_add(len)
                     .ok_or(Details::IntegerOverflow)?;
-                safe_collection_len(total, std::mem::size_of::<Value>())?;
+                safe_collection_len::<Value>(total)?;
+                // Use reserve_exact as reserve can allocate more than needed defeating the purpose
+                // of the previous check
                 items.reserve_exact(len);
                 for _ in 0..len {
                     items.push(decode_internal(
@@ -275,17 +271,15 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
                     break;
                 }
 
-                // See the array case above; a map entry additionally carries a
-                // String key, so bound by the size of a `(String, Value)` pair.
-                // This is a lower-bound estimate: `HashMap::reserve` also
-                // allocates hash-table metadata and spare capacity, so the
-                // budget is enforced approximately (not exactly) for maps. There
-                // is no `reserve_exact` for `HashMap`.
+                // Check that the HashMap won't grow past the max allocation size. This is less
+                // precise than the Vec check above as HashMap allocates in buckets and doesn't have
+                // a reserve_exact
                 let total = items
                     .len()
                     .checked_add(len)
                     .ok_or(Details::IntegerOverflow)?;
-                safe_collection_len(total, std::mem::size_of::<(String, Value)>())?;
+                safe_collection_len::<(String, Value)>(total)?;
+
                 items.reserve(len);
                 for _ in 0..len {
                     match decode_internal(&Schema::String, names, enclosing_namespace, reader)? {
@@ -411,25 +405,23 @@ mod tests {
         Ok(())
     }
 
-    // A block count is decoded from a few bytes but drives `items.reserve(len)`,
-    // allocating `len * size_of::<Value>()` bytes. A tiny payload declaring a
-    // huge count must be rejected rather than driving a multi-gigabyte
-    // allocation. Zero-byte elements (null) are the worst case: they consume no
-    // input, so nothing else bounds the count.
-    fn zig_zag(n: i64) -> Vec<u8> {
+    // Create an array/map block with an object count of `n` and no items
+    fn create_block(n: i64) -> Vec<u8> {
         // Reuse the crate's encoder so the tests cannot diverge from it.
         let mut out = Vec::new();
         crate::util::zig_i64(n, &mut out).unwrap();
+        out.push(0x00);
         out
     }
 
     #[test]
     fn test_decode_array_of_null_huge_count_is_rejected() -> TestResult {
         // 200,000,000 nulls => ~11 GiB reserve, far above the default budget.
-        let mut payload = zig_zag(200_000_000);
-        payload.push(0x00); // end-of-array marker (unreached)
-        let mut input: &[u8] = &payload;
-        let result = decode(&Schema::array(Schema::Null).build(), &mut input);
+        let payload = create_block(200_000_000);
+        let result = decode(
+            &Schema::array(Schema::Null).build(),
+            &mut payload.as_slice(),
+        );
         assert!(
             result.is_err(),
             "a huge array<null> block count must be rejected, got {result:?}"
@@ -442,10 +434,11 @@ mod tests {
     fn test_decode_array_of_long_huge_count_is_rejected() -> TestResult {
         // Non-zero-byte elements are also affected: the reserve happens before
         // any element is read.
-        let mut payload = zig_zag(200_000_000);
-        payload.push(0x00);
-        let mut input: &[u8] = &payload;
-        let result = decode(&Schema::array(Schema::Long).build(), &mut input);
+        let payload = create_block(200_000_000);
+        let result = decode(
+            &Schema::array(Schema::Long).build(),
+            &mut payload.as_slice(),
+        );
         assert!(
             result.is_err(),
             "a huge array<long> block count must be rejected, got {result:?}"
@@ -456,10 +449,8 @@ mod tests {
 
     #[test]
     fn test_decode_map_huge_count_is_rejected() -> TestResult {
-        let mut payload = zig_zag(200_000_000);
-        payload.push(0x00);
-        let mut input: &[u8] = &payload;
-        let result = decode(&Schema::map(Schema::Long).build(), &mut input);
+        let payload = create_block(200_000_000);
+        let result = decode(&Schema::map(Schema::Long).build(), &mut payload.as_slice());
         assert!(
             result.is_err(),
             "a huge map block count must be rejected, got {result:?}"
@@ -471,10 +462,11 @@ mod tests {
     #[test]
     fn test_decode_small_array_of_null_still_decodes() -> TestResult {
         // A modest array of nulls within the budget must still decode.
-        let mut payload = zig_zag(3);
-        payload.push(0x00);
-        let mut input: &[u8] = &payload;
-        let result = decode(&Schema::array(Schema::Null).build(), &mut input)?;
+        let payload = create_block(3);
+        let result = decode(
+            &Schema::array(Schema::Null).build(),
+            &mut payload.as_slice(),
+        )?;
         assert_eq!(Array(vec!(Value::Null, Value::Null, Value::Null)), result);
 
         Ok(())
@@ -485,12 +477,8 @@ mod tests {
         // i64::MIN as a negative block count cannot be negated (checked_neg
         // returns None); decoding must fail rather than wrap. i64::MIN zig-zag
         // encodes as the 10-byte varint below, followed by a block byte-size.
-        let payload: &[u8] = &[
-            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01, // i64::MIN
-            0x00, // block byte-size
-        ];
-        let mut input = payload;
-        let result = decode(&Schema::array(Schema::Int).build(), &mut input);
+        let payload = create_block(i64::MIN);
+        let result = decode(&Schema::array(Schema::Int).build(), &mut payload.as_slice());
         assert!(
             result.is_err(),
             "an i64::MIN array block count must be rejected, got {result:?}"

--- a/avro/src/util.rs
+++ b/avro/src/util.rs
@@ -199,7 +199,12 @@ pub(crate) fn safe_len(len: usize) -> AvroResult<usize> {
 /// decoded element count rather than the bytes read.
 pub(crate) fn safe_collection_len(total_items: usize, item_size: usize) -> AvroResult<()> {
     let max_bytes = max_allocation_bytes(DEFAULT_MAX_ALLOCATION_BYTES);
-    let desired = total_items.saturating_mul(item_size.max(1));
+    // Use checked_mul (not saturating_mul): saturating to usize::MAX could pass
+    // the check below when max_bytes is configured to usize::MAX, letting the
+    // subsequent reserve() hit a capacity-overflow panic instead of erroring.
+    let desired = total_items
+        .checked_mul(item_size.max(1))
+        .ok_or(Details::IntegerOverflow)?;
 
     if desired <= max_bytes {
         Ok(())

--- a/avro/src/util.rs
+++ b/avro/src/util.rs
@@ -199,6 +199,10 @@ pub(crate) fn safe_len(len: usize) -> AvroResult<usize> {
 /// on-wire elements (e.g. `null`), which consume no input and so cannot be
 /// bounded by the bytes remaining, since the limit is on the decoded element
 /// count rather than the bytes read.
+///
+/// `item_size` is clamped to at least 1 (a zero-sized element type is treated as
+/// one byte), so the check still bounds the element count for such types; the
+/// reported `desired` allocation is therefore `total_items * max(item_size, 1)`.
 pub(crate) fn safe_collection_len(total_items: usize, item_size: usize) -> AvroResult<()> {
     let max_bytes = max_allocation_bytes(DEFAULT_MAX_ALLOCATION_BYTES);
     // Use checked_mul (not saturating_mul): saturating to usize::MAX could pass

--- a/avro/src/util.rs
+++ b/avro/src/util.rs
@@ -188,35 +188,21 @@ pub(crate) fn safe_len(len: usize) -> AvroResult<usize> {
 
 /// Bound the cumulative number of elements a collection (array or map) may hold.
 ///
-/// [`safe_len`] guards byte-length allocations, but an array or map block is a
-/// count of elements, and reserving capacity for `n` elements allocates at
-/// least `n * item_size` bytes (`item_size` being the in-memory size of a
-/// decoded element; a collection may over-allocate beyond that for growth or
-/// internal metadata, so this is a lower-bound estimate). A malicious or
-/// truncated input can declare a huge block count in a few bytes, so the count
-/// must be validated against the allocation budget, accounting for the
-/// per-element size, before reserving or decoding. This also bounds zero-byte
-/// on-wire elements (e.g. `null`), which consume no input and so cannot be
-/// bounded by the bytes remaining, since the limit is on the decoded element
-/// count rather than the bytes read.
-///
-/// `item_size` is clamped to at least 1 (a zero-sized element type is treated as
-/// one byte), so the check still bounds the element count for such types; the
-/// reported `desired` allocation is therefore `total_items * max(item_size, 1)`.
-pub(crate) fn safe_collection_len(total_items: usize, item_size: usize) -> AvroResult<()> {
+/// This is equivalent to `safe_len(total_items * size_of::<T>)`
+pub(crate) fn safe_collection_len<T>(total_items: usize) -> AvroResult<()> {
     let max_bytes = max_allocation_bytes(DEFAULT_MAX_ALLOCATION_BYTES);
     // Use checked_mul (not saturating_mul): saturating to usize::MAX could pass
     // the check below when max_bytes is configured to usize::MAX, letting the
     // subsequent reserve() hit a capacity-overflow panic instead of erroring.
     let desired = total_items
-        .checked_mul(item_size.max(1))
+        .checked_mul(size_of::<T>())
         .ok_or(Details::IntegerOverflow)?;
 
     if desired <= max_bytes {
         Ok(())
     } else {
         Err(Details::MemoryAllocation {
-            desired,
+            desired: Some(desired),
             maximum: max_bytes,
         }
         .into())

--- a/avro/src/util.rs
+++ b/avro/src/util.rs
@@ -186,6 +186,32 @@ pub(crate) fn safe_len(len: usize) -> AvroResult<usize> {
     }
 }
 
+/// Bound the cumulative number of elements a collection (array or map) may hold.
+///
+/// [`safe_len`] guards byte-length allocations, but an array or map block is a
+/// count of elements, and reserving capacity for `n` elements allocates
+/// `n * item_size` bytes (`item_size` being the in-memory size of a decoded
+/// element). A malicious or truncated input can declare a huge block count in a
+/// few bytes, so the count must be validated against the allocation budget,
+/// accounting for the per-element size, before reserving or decoding. This also
+/// bounds zero-byte on-wire elements (e.g. `null`), which consume no input and
+/// so cannot be bounded by the bytes remaining, since the limit is on the
+/// decoded element count rather than the bytes read.
+pub(crate) fn safe_collection_len(total_items: usize, item_size: usize) -> AvroResult<()> {
+    let max_bytes = max_allocation_bytes(DEFAULT_MAX_ALLOCATION_BYTES);
+    let desired = total_items.saturating_mul(item_size.max(1));
+
+    if desired <= max_bytes {
+        Ok(())
+    } else {
+        Err(Details::MemoryAllocation {
+            desired,
+            maximum: max_bytes,
+        }
+        .into())
+    }
+}
+
 /// Set whether the serializer and deserializer should indicate to types that the format is human-readable.
 ///
 /// This function only changes the setting once. On subsequent calls the value will stay the same

--- a/avro/src/util.rs
+++ b/avro/src/util.rs
@@ -189,14 +189,16 @@ pub(crate) fn safe_len(len: usize) -> AvroResult<usize> {
 /// Bound the cumulative number of elements a collection (array or map) may hold.
 ///
 /// [`safe_len`] guards byte-length allocations, but an array or map block is a
-/// count of elements, and reserving capacity for `n` elements allocates
-/// `n * item_size` bytes (`item_size` being the in-memory size of a decoded
-/// element). A malicious or truncated input can declare a huge block count in a
-/// few bytes, so the count must be validated against the allocation budget,
-/// accounting for the per-element size, before reserving or decoding. This also
-/// bounds zero-byte on-wire elements (e.g. `null`), which consume no input and
-/// so cannot be bounded by the bytes remaining, since the limit is on the
-/// decoded element count rather than the bytes read.
+/// count of elements, and reserving capacity for `n` elements allocates at
+/// least `n * item_size` bytes (`item_size` being the in-memory size of a
+/// decoded element; a collection may over-allocate beyond that for growth or
+/// internal metadata, so this is a lower-bound estimate). A malicious or
+/// truncated input can declare a huge block count in a few bytes, so the count
+/// must be validated against the allocation budget, accounting for the
+/// per-element size, before reserving or decoding. This also bounds zero-byte
+/// on-wire elements (e.g. `null`), which consume no input and so cannot be
+/// bounded by the bytes remaining, since the limit is on the decoded element
+/// count rather than the bytes read.
 pub(crate) fn safe_collection_len(total_items: usize, item_size: usize) -> AvroResult<()> {
     let max_bytes = max_allocation_bytes(DEFAULT_MAX_ALLOCATION_BYTES);
     // Use checked_mul (not saturating_mul): saturating to usize::MAX could pass


### PR DESCRIPTION
## What

An `array` or `map` block is encoded as an element count followed by that many items. When decoding, `items.reserve(len)` allocates `len * size_of::<Value>()` bytes (`Value` is 56 bytes), but the count was only validated with `safe_len`, which bounds it as if it were a *byte* count.

As a result a tiny payload declaring a huge block count could drive a multi-gigabyte allocation far exceeding the configured `max_allocation_bytes` budget. At the `safe_len` ceiling this reaches ~28 GiB. Reproduced with a **5-byte** payload (`array<null>`, block count `10_000_000`) decoding into a 10M-element array (534 MiB) — *exceeding* the default 512 MiB budget while being accepted.

This affects:
- both **arrays and maps**;
- both **zero-byte** on-wire elements (`null`) and **non-zero-byte** elements — the `reserve` happens before any element is read;
- and the zero-byte "flood" where the decode loop grows the collection unboundedly (zero-byte elements consume no input, so nothing else bounds the count).

## How

- Add `util::safe_collection_len(total_items, item_size)`, which bounds the **cumulative** element count against `max_allocation_bytes`, accounting for the in-memory size of each decoded element (mirroring `safe_len`, which only covers byte-length allocations).
- Apply it in the `Schema::Array` and `Schema::Map` decode loops before `reserve`, using `size_of::<Value>()` and `size_of::<(String, Value)>()` respectively, with a `checked_add` guard for the running total.

This caps both the up-front reservation and the total number of decoded elements. The limit stays configurable through `max_allocation_bytes` (the default 512 MiB budget yields ~9.6M `Value`s, close to the item caps used by the other Avro SDKs).

`bytes`/`string` length-prefixed values are already bounded by `safe_len`; since `decode` operates on a bare `Read` with no known remaining size, that budget cap is the appropriate guard (equivalent to the non-seekable path in the other SDKs).

## Tests

- New: huge `array<null>`, `array<long>`, and `map` block counts are rejected instead of allocating; a small `array<null>` still decodes.
- `cargo test -p apache-avro` (564 lib tests) passes; `cargo fmt --check` and `cargo clippy` are clean.
