### PR TITLE
chore: migrate HawkEye to v7

### DIFF
--- a/.activate.sh
+++ b/.activate.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/.deactivate.sh
+++ b/.deactivate.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/.github/workflows/test-lang-rust-ci.yml
+++ b/.github/workflows/test-lang-rust-ci.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
         with:
-          tool: hawkeye@6.3
+          tool: hawkeye
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -15,13 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
-headerPath = "Apache-2.0-ASF.txt"
+[header]
+builtin = "Apache-2.0-ASF"
+
+[files]
 excludes = [
   "*.stderr",
   "*.expanded.rs",
   "*.avro",
+  "**/*.lock",
+  "**/*.md",
+  "**/.gitignore",
+  "**/LICENSE",
+  # rustfmt removes the separator that HawkEye writes after this header-only placeholder.
+  "wasm-demo/src/lib.rs",
   "NOTICE",
   "README.tpl",
   ".requirements-precommit.txt",
-  "*.proptest-regressions"
+  "*.proptest-regressions",
 ]


### PR DESCRIPTION
## Summary

- migrate the HawkEye configuration and integration to v7
- install HawkEye from its latest release without pinning the tool version
- validate the migrated configuration with HawkEye v7 (176 files, 0 changes, 0 conflicts, 0 unsupported)
- exclude one header-only Rust placeholder where HawkEye's separator conflicts with `rustfmt`
- `cargo fmt --all --check` passes