### PR TITLE
fix: No recursion depth limit in decode_internal / resolve_internal / serde deserializer

### DIFF
--- a/avro/src/decode.rs
+++ b/avro/src/decode.rs
@@ -25,8 +25,8 @@ use crate::{
     schema::{DecimalSchema, EnumSchema, FixedSchema, Name, RecordSchema, ResolvedSchema, Schema},
     types::Value,
     util::{
-        DEFAULT_MAX_ALLOCATION_BYTES, max_allocation_bytes, safe_collection_len, safe_len, zag_i32,
-        zag_i64,
+        DEFAULT_MAX_ALLOCATION_BYTES, decode_recursion_limit, max_allocation_bytes,
+        safe_collection_len, safe_len, zag_i32, zag_i64,
     },
 };
 use std::{
@@ -78,9 +78,12 @@ fn decode_seq_len<R: Read>(reader: &mut R) -> AvroResult<usize> {
 /// every allocation performed while decoding one datum is debited from a
 /// shared budget of [`max_allocation_bytes`] bytes, instead of each
 /// collection only being checked in isolation.
+#[derive(Debug)]
 pub(crate) struct DecodeContext {
     /// Bytes still available for allocations while decoding the current datum.
     remaining_budget: usize,
+    /// Current recursion depth of `decode_internal`.
+    depth: usize,
 }
 
 impl DecodeContext {
@@ -90,6 +93,7 @@ impl DecodeContext {
     pub(crate) fn new() -> Self {
         Self {
             remaining_budget: max_allocation_bytes(DEFAULT_MAX_ALLOCATION_BYTES),
+            depth: 0,
         }
     }
 
@@ -121,6 +125,23 @@ impl DecodeContext {
             .ok_or(Details::IntegerOverflow)?;
         self.debit_bytes(bytes)
     }
+
+    /// Track one level of decoding recursion, erroring once the configured
+    /// maximum depth is exceeded.
+    fn enter(&mut self) -> AvroResult<()> {
+        self.depth += 1;
+        let maximum = decode_recursion_limit();
+        if self.depth > maximum {
+            Err(Details::DecodeRecursionLimit { maximum }.into())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Leave one level of decoding recursion.
+    fn leave(&mut self) {
+        self.depth -= 1;
+    }
 }
 
 /// Decode a `Value` from avro format given its `Schema`.
@@ -136,6 +157,19 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> AvroResult<Value> {
 }
 
 pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
+    schema: &Schema,
+    names: &HashMap<Name, S>,
+    enclosing_namespace: NamespaceRef,
+    reader: &mut R,
+    ctx: &mut DecodeContext,
+) -> AvroResult<Value> {
+    ctx.enter()?;
+    let value = decode_internal_body(schema, names, enclosing_namespace, reader, ctx);
+    ctx.leave();
+    value
+}
+
+fn decode_internal_body<R: Read, S: Borrow<Schema>>(
     schema: &Schema,
     names: &HashMap<Name, S>,
     enclosing_namespace: NamespaceRef,
@@ -456,6 +490,7 @@ pub(crate) fn decode_internal<R: Read, S: Borrow<Schema>>(
 mod tests {
     use crate::error::Details;
     use crate::schema::{InnerDecimalSchema, UuidSchema};
+    use crate::util::decode_recursion_limit;
     use crate::{
         Decimal,
         decode::decode,
@@ -630,6 +665,29 @@ mod tests {
             result.is_err(),
             "a fixed size larger than the allocation budget must be rejected, got {result:?}"
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn avro_rs_642_test_decode_recursion_depth_is_bounded() -> TestResult {
+        // With a recursive schema, one wire byte per level drives unbounded
+        // recursion; the decoder must return an error instead of overflowing
+        // the stack (which would abort the process).
+        let schema = Schema::parse_str(
+            r#"{
+                "type": "record",
+                "name": "Node",
+                "fields": [
+                    {"name": "next", "type": ["null", "Node"]}
+                ]
+            }"#,
+        )?;
+        let recursion_depth_trigger = decode_recursion_limit() + 1;
+        // Each 0x02 byte selects the "Node" union branch, one level deeper.
+        let payload = vec![0x02u8; recursion_depth_trigger];
+        let result = decode(&schema, &mut payload.as_slice());
+        assert!(result.is_err(), "unbounded recursion must be rejected");
 
         Ok(())
     }

--- a/avro/src/error.rs
+++ b/avro/src/error.rs
@@ -569,6 +569,11 @@ pub enum Details {
     #[error("Overflow when decoding integer value")]
     IntegerOverflow,
 
+    #[error(
+        "Maximum decode recursion depth reached (maximum: {maximum}). Change the limit using `apache_avro::util::max_decode_recursion_depth`"
+    )]
+    DecodeRecursionLimit { maximum: usize },
+
     #[error("Failed to read bytes for decoding variable length integer: {0}")]
     ReadVariableIntegerBytes(#[source] std::io::Error),
 

--- a/avro/src/reader/block.rs
+++ b/avro/src/reader/block.rs
@@ -237,6 +237,7 @@ impl<'r, R: Read> Block<'r, R> {
             let config = Config {
                 names: &self.names_refs,
                 human_readable: self.human_readable,
+                recursion_depth: 0,
             };
             T::deserialize(SchemaAwareDeserializer::new(
                 &mut block_bytes,

--- a/avro/src/reader/datum.rs
+++ b/avro/src/reader/datum.rs
@@ -161,6 +161,7 @@ impl<'s> GenericDatumReader<'s> {
                 Config {
                     names: self.resolved.get_names(),
                     human_readable: self.human_readable,
+                    recursion_depth: 0,
                 },
             )?)
         }
@@ -203,6 +204,7 @@ impl<T: AvroSchema + DeserializeOwned> SpecificDatumReader<T> {
             Config {
                 names: self.resolved.get_names(),
                 human_readable: self.human_readable,
+                recursion_depth: 0,
             },
         )?)
     }

--- a/avro/src/reader/single_object.rs
+++ b/avro/src/reader/single_object.rs
@@ -74,6 +74,7 @@ impl GenericSingleObjectReader {
         let config = Config {
             names: self.write_schema.get_names(),
             human_readable: self.human_readable,
+            recursion_depth: 0,
         };
         T::deserialize(SchemaAwareDeserializer::new(
             reader,

--- a/avro/src/serde/deser_schema/mod.rs
+++ b/avro/src/serde/deser_schema/mod.rs
@@ -20,7 +20,7 @@ use std::{borrow::Borrow, collections::HashMap, io::Read};
 use serde::de::{Deserializer, Visitor};
 
 use crate::{
-    Error, Schema,
+    AvroResult, Error, Schema,
     decode::decode_len,
     error::Details,
     schema::{DecimalSchema, InnerDecimalSchema, Name, UnionSchema, UuidSchema},
@@ -60,11 +60,26 @@ pub struct Config<'s, S: Borrow<Schema>> {
 
 impl<'s, S: Borrow<Schema>> Config<'s, S> {
     /// Get the schema for this name.
-    fn get_schema(&self, name: &Name) -> Result<&'s Schema, Error> {
+    fn get_schema(&self, name: &Name) -> AvroResult<&'s Schema> {
         self.names
             .get(name)
             .map(Borrow::borrow)
             .ok_or_else(|| Details::SchemaResolutionError(name.clone()).into())
+    }
+
+    /// Increments the recursion depth counter and checks whether it exceeds the defined recursion limit.
+    ///
+    /// # Errors
+    /// Returns an error of type `AvroError` with `DecodeRecursionLimit` details if the recursion depth
+    /// exceeds the configured maximum.
+    fn recurse(&mut self) -> AvroResult<()> {
+        self.recursion_depth += 1;
+        let maximum = decode_recursion_limit();
+        if self.recursion_depth > maximum {
+            Err(Details::DecodeRecursionLimit { maximum }.into())
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -95,13 +110,8 @@ impl<'s, 'r, R: Read, S: Borrow<Schema>> SchemaAwareDeserializer<'s, 'r, R, S> {
         reader: &'r mut R,
         schema: &'s Schema,
         mut config: Config<'s, S>,
-    ) -> Result<Self, Error> {
-        // Bound the recursion depth to guard against stack exhaustion
-        config.recursion_depth += 1;
-        let maximum = decode_recursion_limit();
-        if config.recursion_depth > maximum {
-            return Err(Details::DecodeRecursionLimit { maximum }.into());
-        }
+    ) -> AvroResult<Self> {
+        config.recurse()?;
         if let Schema::Ref { name } = schema {
             let schema = config.get_schema(name)?;
             Ok(Self {
@@ -132,7 +142,8 @@ impl<'s, 'r, R: Read, S: Borrow<Schema>> SchemaAwareDeserializer<'s, 'r, R, S> {
     /// Create a new deserializer with the existing reader and config.
     ///
     /// This will resolve the schema if it is a reference.
-    fn with_different_schema(mut self, schema: &'s Schema) -> Result<Self, Error> {
+    fn with_different_schema(mut self, schema: &'s Schema) -> AvroResult<Self> {
+        self.config.recurse()?;
         self.schema = if let Schema::Ref { name } = schema {
             self.config.get_schema(name)?
         } else {
@@ -144,7 +155,7 @@ impl<'s, 'r, R: Read, S: Borrow<Schema>> SchemaAwareDeserializer<'s, 'r, R, S> {
     /// Read the union and create a new deserializer with the existing reader and config.
     ///
     /// This will resolve the read schema if it is a reference.
-    fn with_union(self, schema: &'s UnionSchema) -> Result<Self, Error> {
+    fn with_union(self, schema: &'s UnionSchema) -> AvroResult<Self> {
         let index = zag_i32(self.reader)?;
         let index = usize::try_from(index).map_err(|e| Details::ConvertI32ToUsize(e, index))?;
         let variant = schema.get_variant(index)?;
@@ -155,7 +166,7 @@ impl<'s, 'r, R: Read, S: Borrow<Schema>> SchemaAwareDeserializer<'s, 'r, R, S> {
     ///
     /// This will check that the current schema is [`Schema::Int`] or a logical type based on that.
     /// It does not read [`Schema::Union`]s.
-    fn checked_read_int(&mut self, original_ty: &'static str) -> Result<i32, Error> {
+    fn checked_read_int(&mut self, original_ty: &'static str) -> AvroResult<i32> {
         match self.schema {
             Schema::Int | Schema::Date | Schema::TimeMillis => zag_i32(self.reader),
             _ => Err(self.error(
@@ -169,7 +180,7 @@ impl<'s, 'r, R: Read, S: Borrow<Schema>> SchemaAwareDeserializer<'s, 'r, R, S> {
     ///
     /// This will check that the current schema is [`Schema::Long`] or a logical type based on that.
     /// It does not read [`Schema::Union`]s.
-    fn checked_read_long(&mut self, original_ty: &'static str) -> Result<i64, Error> {
+    fn checked_read_long(&mut self, original_ty: &'static str) -> AvroResult<i64> {
         match self.schema {
             Schema::Long | Schema::TimeMicros | Schema::TimestampMillis | Schema::TimestampMicros
             | Schema::TimestampNanos | Schema::LocalTimestampMillis | Schema::LocalTimestampMicros
@@ -185,7 +196,7 @@ impl<'s, 'r, R: Read, S: Borrow<Schema>> SchemaAwareDeserializer<'s, 'r, R, S> {
     /// Read a string from the reader.
     ///
     /// This does not check the current schema.
-    fn read_string(&mut self) -> Result<String, Error> {
+    fn read_string(&mut self) -> AvroResult<String> {
         let bytes = self.read_bytes_with_len()?;
         Ok(String::from_utf8(bytes).map_err(Details::ConvertToUtf8)?)
     }
@@ -193,7 +204,7 @@ impl<'s, 'r, R: Read, S: Borrow<Schema>> SchemaAwareDeserializer<'s, 'r, R, S> {
     /// Read a bytes from the reader.
     ///
     /// This does not check the current schema.
-    fn read_bytes_with_len(&mut self) -> Result<Vec<u8>, Error> {
+    fn read_bytes_with_len(&mut self) -> AvroResult<Vec<u8>> {
         let length = decode_len(self.reader)?;
         self.read_bytes(length)
     }
@@ -201,7 +212,7 @@ impl<'s, 'r, R: Read, S: Borrow<Schema>> SchemaAwareDeserializer<'s, 'r, R, S> {
     /// Read `n` bytes from the reader.
     ///
     /// This does not check the current schema.
-    fn read_bytes(&mut self, length: usize) -> Result<Vec<u8>, Error> {
+    fn read_bytes(&mut self, length: usize) -> AvroResult<Vec<u8>> {
         // `length` may be schema-declared rather than wire-declared (e.g. a
         // fixed size from an attacker-supplied OCF writer schema); always
         // bound it before allocating.
@@ -216,7 +227,7 @@ impl<'s, 'r, R: Read, S: Borrow<Schema>> SchemaAwareDeserializer<'s, 'r, R, S> {
     /// Read `n` bytes from the reader.
     ///
     /// This does not check the current schema.
-    fn read_array<const N: usize>(&mut self) -> Result<[u8; N], Error> {
+    fn read_array<const N: usize>(&mut self) -> AvroResult<[u8; N]> {
         let mut buf = [0; N];
         self.reader
             .read_exact(&mut buf)
@@ -227,10 +238,10 @@ impl<'s, 'r, R: Read, S: Borrow<Schema>> SchemaAwareDeserializer<'s, 'r, R, S> {
 
 /// A static string that will bypass name checks in `deserialize_*` functions.
 ///
-/// This is used so that `deserialize_any` can use the `deserialize_*` implementation which take
+/// This is used so that `deserialize_any` can use the `deserialize_*` implementation that takes
 /// a static string.
 ///
-/// We don't want users to abuse this feature so this value is compared by pointer address, therefore
+/// We don't want users to abuse this feature, so this value is compared by pointer address, therefore,
 /// a user providing the string below will not be able to skip name validation.
 static DESERIALIZE_ANY: &str = "This value is compared by pointer value";
 /// A static array so that `deserialize_any` can call `deserialize_*` functions.

--- a/avro/src/serde/deser_schema/mod.rs
+++ b/avro/src/serde/deser_schema/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     decode::decode_len,
     error::Details,
     schema::{DecimalSchema, InnerDecimalSchema, Name, UnionSchema, UuidSchema},
-    util::{safe_len, zag_i32, zag_i64},
+    util::{decode_recursion_limit, safe_len, zag_i32, zag_i64},
 };
 
 mod block;
@@ -50,6 +50,12 @@ pub struct Config<'s, S: Borrow<Schema>> {
     pub names: &'s HashMap<Name, S>,
     /// Was the data serialized with `human_readable`.
     pub human_readable: bool,
+    /// Current recursion depth of the deserializer.
+    ///
+    /// Every nesting level of the deserialized value creates a new
+    /// [`SchemaAwareDeserializer`], which increments this; the depth is
+    /// bounded by [`crate::util::max_decode_recursion_depth`].
+    pub(crate) recursion_depth: usize,
 }
 
 impl<'s, S: Borrow<Schema>> Config<'s, S> {
@@ -88,8 +94,16 @@ impl<'s, 'r, R: Read, S: Borrow<Schema>> SchemaAwareDeserializer<'s, 'r, R, S> {
     pub fn new(
         reader: &'r mut R,
         schema: &'s Schema,
-        config: Config<'s, S>,
+        mut config: Config<'s, S>,
     ) -> Result<Self, Error> {
+        // Bound the recursion depth so deeply nested (possibly hostile) data
+        // yields an error instead of exhausting the stack. A recursive schema
+        // lets roughly one wire byte drive one nesting level.
+        config.recursion_depth += 1;
+        let maximum = decode_recursion_limit();
+        if config.recursion_depth > maximum {
+            return Err(Details::DecodeRecursionLimit { maximum }.into());
+        }
         if let Schema::Ref { name } = schema {
             let schema = config.get_schema(name)?;
             Ok(Self {

--- a/avro/src/serde/deser_schema/mod.rs
+++ b/avro/src/serde/deser_schema/mod.rs
@@ -55,7 +55,7 @@ pub struct Config<'s, S: Borrow<Schema>> {
     /// Every nesting level of the deserialized value creates a new
     /// [`SchemaAwareDeserializer`], which increments this; the depth is
     /// bounded by [`crate::util::max_decode_recursion_depth`].
-    pub(crate) recursion_depth: usize,
+    pub recursion_depth: usize,
 }
 
 impl<'s, S: Borrow<Schema>> Config<'s, S> {

--- a/avro/src/serde/deser_schema/mod.rs
+++ b/avro/src/serde/deser_schema/mod.rs
@@ -96,9 +96,7 @@ impl<'s, 'r, R: Read, S: Borrow<Schema>> SchemaAwareDeserializer<'s, 'r, R, S> {
         schema: &'s Schema,
         mut config: Config<'s, S>,
     ) -> Result<Self, Error> {
-        // Bound the recursion depth so deeply nested (possibly hostile) data
-        // yields an error instead of exhausting the stack. A recursive schema
-        // lets roughly one wire byte drive one nesting level.
+        // Bound the recursion depth to guard against stack exhaustion
         config.recursion_depth += 1;
         let maximum = decode_recursion_limit();
         if config.recursion_depth > maximum {

--- a/avro/src/types.rs
+++ b/avro/src/types.rs
@@ -27,6 +27,7 @@ use crate::{
         DecimalSchema, EnumSchema, FixedSchema, Name, Precision, RecordField, RecordSchema,
         ResolvedSchema, Scale, Schema, SchemaKind, UnionSchema,
     },
+    util::decode_recursion_limit,
 };
 use bigdecimal::BigDecimal;
 use log::{debug, error};
@@ -744,12 +745,31 @@ impl Value {
     }
 
     pub(crate) fn resolve_internal<S: Borrow<Schema> + Debug>(
-        mut self,
+        self,
         schema: &Schema,
         names: &HashMap<Name, S>,
         enclosing_namespace: NamespaceRef,
         field_default: Option<&JsonValue>,
     ) -> AvroResult<Self> {
+        self.resolve_internal_depth(schema, names, enclosing_namespace, field_default, 0)
+    }
+
+    fn resolve_internal_depth<S: Borrow<Schema> + Debug>(
+        mut self,
+        schema: &Schema,
+        names: &HashMap<Name, S>,
+        enclosing_namespace: NamespaceRef,
+        field_default: Option<&JsonValue>,
+        depth: usize,
+    ) -> AvroResult<Self> {
+        // Resolution recurses over both the value and the (possibly
+        // attacker-supplied) schema; bound the depth so hostile input yields
+        // an error instead of exhausting the stack.
+        let depth = depth + 1;
+        let maximum = decode_recursion_limit();
+        if depth > maximum {
+            return Err(Details::DecodeRecursionLimit { maximum }.into());
+        }
         // Check if this schema is a union, and if the reader schema is not.
         if SchemaKind::from(&self) == SchemaKind::Union
             && SchemaKind::from(schema) != SchemaKind::Union
@@ -767,7 +787,13 @@ impl Value {
 
                 if let Some(resolved) = names.get(&name) {
                     debug!("Resolved {name:?}");
-                    self.resolve_internal(resolved.borrow(), names, name.namespace(), field_default)
+                    self.resolve_internal_depth(
+                        resolved.borrow(),
+                        names,
+                        name.namespace(),
+                        field_default,
+                        depth,
+                    )
                 } else {
                     error!("Failed to resolve schema {name:?}");
                     Err(Details::SchemaResolutionError(name.into_owned()).into())
@@ -783,16 +809,21 @@ impl Value {
             Schema::String => self.resolve_string(),
             Schema::Fixed(FixedSchema { size, .. }) => self.resolve_fixed(*size),
             Schema::Union(inner) => {
-                self.resolve_union(inner, names, enclosing_namespace, field_default)
+                self.resolve_union(inner, names, enclosing_namespace, field_default, depth)
             }
             Schema::Enum(EnumSchema {
                 symbols, default, ..
             }) => self.resolve_enum(symbols, default, field_default),
-            Schema::Array(inner) => self.resolve_array(&inner.items, names, enclosing_namespace),
-            Schema::Map(inner) => self.resolve_map(&inner.types, names, enclosing_namespace),
-            Schema::Record(RecordSchema { fields, name, .. }) => {
-                self.resolve_record(fields, names, name.namespace().or(enclosing_namespace))
+            Schema::Array(inner) => {
+                self.resolve_array(&inner.items, names, enclosing_namespace, depth)
             }
+            Schema::Map(inner) => self.resolve_map(&inner.types, names, enclosing_namespace, depth),
+            Schema::Record(RecordSchema { fields, name, .. }) => self.resolve_record(
+                fields,
+                names,
+                name.namespace().or(enclosing_namespace),
+                depth,
+            ),
             Schema::Decimal(DecimalSchema {
                 scale,
                 precision,
@@ -1166,6 +1197,7 @@ impl Value {
         names: &HashMap<Name, S>,
         enclosing_namespace: NamespaceRef,
         field_default: Option<&JsonValue>,
+        depth: usize,
     ) -> Result<Self, Error> {
         let v = match self {
             // Both are unions case.
@@ -1182,7 +1214,13 @@ impl Value {
 
         Ok(Value::Union(
             i as u32,
-            Box::new(v.resolve_internal(inner, names, enclosing_namespace, field_default)?),
+            Box::new(v.resolve_internal_depth(
+                inner,
+                names,
+                enclosing_namespace,
+                field_default,
+                depth,
+            )?),
         ))
     }
 
@@ -1191,12 +1229,15 @@ impl Value {
         schema: &Schema,
         names: &HashMap<Name, S>,
         enclosing_namespace: NamespaceRef,
+        depth: usize,
     ) -> Result<Self, Error> {
         match self {
             Value::Array(items) => Ok(Value::Array(
                 items
                     .into_iter()
-                    .map(|item| item.resolve_internal(schema, names, enclosing_namespace, None))
+                    .map(|item| {
+                        item.resolve_internal_depth(schema, names, enclosing_namespace, None, depth)
+                    })
                     .collect::<Result<_, _>>()?,
             )),
             other => Err(Details::GetArray {
@@ -1212,6 +1253,7 @@ impl Value {
         schema: &Schema,
         names: &HashMap<Name, S>,
         enclosing_namespace: NamespaceRef,
+        depth: usize,
     ) -> Result<Self, Error> {
         match self {
             Value::Map(items) => Ok(Value::Map(
@@ -1219,7 +1261,7 @@ impl Value {
                     .into_iter()
                     .map(|(key, value)| {
                         value
-                            .resolve_internal(schema, names, enclosing_namespace, None)
+                            .resolve_internal_depth(schema, names, enclosing_namespace, None, depth)
                             .map(|value| (key, value))
                     })
                     .collect::<Result<_, _>>()?,
@@ -1237,6 +1279,7 @@ impl Value {
         fields: &[RecordField],
         names: &HashMap<Name, S>,
         enclosing_namespace: NamespaceRef,
+        depth: usize,
     ) -> Result<Self, Error> {
         let mut items = match self {
             Value::Map(items) => Ok(items),
@@ -1275,12 +1318,14 @@ impl Value {
                                     _ => Value::Union(
                                         0,
                                         Box::new(
-                                            Value::try_from(value.clone())?.resolve_internal(
-                                                first,
-                                                names,
-                                                enclosing_namespace,
-                                                field.default.as_ref(),
-                                            )?,
+                                            Value::try_from(value.clone())?
+                                                .resolve_internal_depth(
+                                                    first,
+                                                    names,
+                                                    enclosing_namespace,
+                                                    field.default.as_ref(),
+                                                    depth,
+                                                )?,
                                         ),
                                     ),
                                 }
@@ -1293,11 +1338,12 @@ impl Value {
                     },
                 };
                 value
-                    .resolve_internal(
+                    .resolve_internal_depth(
                         &field.schema,
                         names,
                         enclosing_namespace,
                         field.default.as_ref(),
+                        depth,
                     )
                     .map(|value| (field.name.clone(), value))
             })

--- a/avro/src/util.rs
+++ b/avro/src/util.rs
@@ -35,8 +35,7 @@ static MAX_ALLOCATION_BYTES: OnceLock<usize> = OnceLock::new();
 
 /// Maximum recursion depth when decoding or resolving Avro-encoded values.
 ///
-/// This protects against stack exhaustion (an abort, not a catchable error) from deeply nested
-/// data: a recursive schema lets an attacker drive one recursion level with roughly one wire byte.
+/// This protects against stack exhaustion aborts from deeply nested data.
 ///
 /// See [`max_decode_recursion_depth`] to change this limit.
 pub const DEFAULT_MAX_DECODE_RECURSION_DEPTH: usize = 32;

--- a/avro/src/util.rs
+++ b/avro/src/util.rs
@@ -18,6 +18,7 @@
 //! Utility functions, like configuring various global settings.
 
 use crate::{AvroResult, error::Details, schema::Documentation};
+use log::warn;
 use serde_json::{Map, Value};
 use std::{
     io::{Read, Write},
@@ -31,6 +32,15 @@ use std::{
 /// See [`max_allocation_bytes`] to change this limit.
 pub const DEFAULT_MAX_ALLOCATION_BYTES: usize = 512 * 1024 * 1024;
 static MAX_ALLOCATION_BYTES: OnceLock<usize> = OnceLock::new();
+
+/// Maximum recursion depth when decoding or resolving Avro-encoded values.
+///
+/// This protects against stack exhaustion (an abort, not a catchable error) from deeply nested
+/// data: a recursive schema lets an attacker drive one recursion level with roughly one wire byte.
+///
+/// See [`max_decode_recursion_depth`] to change this limit.
+pub const DEFAULT_MAX_DECODE_RECURSION_DEPTH: usize = 32;
+static MAX_DECODE_RECURSION_DEPTH: OnceLock<usize> = OnceLock::new();
 
 /// Whether to set serialization & deserialization traits as `human_readable` or not.
 ///
@@ -170,6 +180,30 @@ fn decode_variable<R: Read>(reader: &mut R) -> AvroResult<u64> {
 /// value was already set before.
 pub fn max_allocation_bytes(num_bytes: usize) -> usize {
     *MAX_ALLOCATION_BYTES.get_or_init(|| num_bytes)
+}
+
+/// Set the maximum recursion depth used when decoding or resolving data.
+///
+/// This function only changes the setting once. On subsequent calls the value will stay the same
+/// as the first time it is called. It is automatically called on first decode and defaults to
+/// [`DEFAULT_MAX_DECODE_RECURSION_DEPTH`].
+///
+/// # Returns
+/// The configured maximum, which might be different from what the function was called with if the
+/// value was already set before. In that case a warning is logged.
+pub fn max_decode_recursion_depth(depth: usize) -> usize {
+    let configured = *MAX_DECODE_RECURSION_DEPTH.get_or_init(|| depth);
+    if configured != depth {
+        warn!(
+            "max_decode_recursion_depth({depth}) has no effect: the limit was already set to {configured}"
+        );
+    }
+    configured
+}
+
+/// The effective decode recursion limit, initializing the default if unset.
+pub(crate) fn decode_recursion_limit() -> usize {
+    *MAX_DECODE_RECURSION_DEPTH.get_or_init(|| DEFAULT_MAX_DECODE_RECURSION_DEPTH)
 }
 
 pub(crate) fn safe_len(len: usize) -> AvroResult<usize> {

--- a/avro/tests/recursion_depth_deser.rs
+++ b/avro/tests/recursion_depth_deser.rs
@@ -21,7 +21,7 @@ use apache_avro::util::max_decode_recursion_depth;
 use apache_avro_test_helper::TestResult;
 use serde::{Deserialize, Serialize};
 
-// This is an IT test because it sets the default recursion depth limit (OnceLock).
+// This is an integration test because it sets the default recursion depth limit (OnceLock).
 
 #[test]
 fn avro_rs_642_recursion_depth_is_bounded() -> TestResult {

--- a/avro/tests/recursion_depth_deser.rs
+++ b/avro/tests/recursion_depth_deser.rs
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use apache_avro::Schema;
+use apache_avro::reader::datum::GenericDatumReader;
+use apache_avro::util::max_decode_recursion_depth;
+use apache_avro_test_helper::TestResult;
+use serde::{Deserialize, Serialize};
+
+// This is an IT test because it sets the default recursion depth limit (OnceLock).
+
+#[test]
+fn avro_rs_642_recursion_depth_is_bounded() -> TestResult {
+    #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+    struct Node {
+        next: Option<Box<Node>>,
+    }
+
+    let schema = Schema::parse_str(
+        r#"{
+                "type": "record",
+                "name": "Node",
+                "fields": [
+                    {"name": "next", "type": ["null", "Node"]}
+                ]
+            }"#,
+    )?;
+    let recursion_depth_trigger = max_decode_recursion_depth(16) + 1;
+    // Each 0x02 byte selects the "Node" union branch, one level deeper.
+    let payload = vec![0x02u8; recursion_depth_trigger];
+    let result = GenericDatumReader::builder(&schema)
+        .build()?
+        .read_deser::<Node>(&mut payload.as_slice());
+    assert!(result.is_err(), "unbounded recursion must be rejected");
+
+    Ok(())
+}

--- a/avro/tests/recursion_depth_value_resolve.rs
+++ b/avro/tests/recursion_depth_value_resolve.rs
@@ -20,7 +20,7 @@ use apache_avro::types::Value;
 use apache_avro::util::max_decode_recursion_depth;
 use apache_avro_test_helper::TestResult;
 
-// This is an IT test because it sets the default recursion depth limit (OnceLock).
+// This is an integration test because it sets the default recursion depth limit (OnceLock).
 
 #[test]
 fn avro_rs_642_resolve_recursion_depth_is_bounded() -> TestResult {

--- a/avro/tests/recursion_depth_value_resolve.rs
+++ b/avro/tests/recursion_depth_value_resolve.rs
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use apache_avro::Schema;
+use apache_avro::types::Value;
+use apache_avro::util::max_decode_recursion_depth;
+use apache_avro_test_helper::TestResult;
+
+// This is an IT test because it sets the default recursion depth limit (OnceLock).
+
+#[test]
+fn avro_rs_642_resolve_recursion_depth_is_bounded() -> TestResult {
+    let schema = Schema::parse_str(
+        r#"{
+                "type": "record",
+                "name": "Node",
+                "fields": [
+                    {"name": "next", "type": ["null", "Node"]}
+                ]
+            }"#,
+    )?;
+
+    let recursion_depth_trigger = max_decode_recursion_depth(16) + 1;
+
+    // Build a value that nests deeper than the recursion limit but is
+    // still shallow enough for the test itself to drop safely.
+    let mut value = Value::Record(vec![(
+        "next".into(),
+        Value::Union(0, Box::new(Value::Null)),
+    )]);
+    for _ in 0..recursion_depth_trigger {
+        value = Value::Record(vec![("next".into(), Value::Union(1, Box::new(value)))]);
+    }
+
+    let result = value.resolve(&schema);
+    assert!(result.is_err(), "unbounded resolution must be rejected");
+
+    Ok(())
+}


### PR DESCRIPTION
A recursive schema can lead to stack overflow (i.e. an abort) in OCF decoding, Value resolving and Schema deserialization. Add `util::max_decode_recursion_depth(usize)` to be able to control the recursipn depth

Reported-by: Security scans