### PR TITLE
fix: Lints for version 1.100

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,6 @@ dependencies = [
  "apache-avro",
  "console_error_panic_hook",
  "serde",
- "wasm-bindgen",
  "wasm-bindgen-test",
 ]
 

--- a/avro/Cargo.toml
+++ b/avro/Cargo.toml
@@ -18,7 +18,6 @@
 [package]
 name = "apache-avro"
 description = "A library for working with Apache Avro in Rust"
-readme = "README.md"
 version.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/avro_derive/Cargo.toml
+++ b/avro_derive/Cargo.toml
@@ -26,7 +26,6 @@ rust-version.workspace = true
 keywords = ["avro", "data", "serialization", "derive"]
 categories.workspace = true
 documentation = "https://docs.rs/apache-avro-derive"
-readme = "README.md"
 
 [lib]
 proc-macro = true

--- a/avro_test_helper/Cargo.toml
+++ b/avro_test_helper/Cargo.toml
@@ -26,7 +26,6 @@ repository.workspace = true
 keywords = ["avro", "data", "serialization", "test"]
 categories.workspace = true
 documentation = "https://docs.rs/apache-avro-test-helper"
-readme = "README.md"
 
 
 [dependencies]

--- a/wasm-demo/Cargo.toml
+++ b/wasm-demo/Cargo.toml
@@ -20,7 +20,6 @@ name = "hello-wasm"
 version = "0.1.0"
 description = "A demo project for testing apache_avro in WebAssembly"
 license.workspace = true
-readme = "README.md"
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -35,10 +34,10 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 apache-avro = { path = "../avro" }
-serde = { workspace = true }
-wasm-bindgen = "0.2.114"
 
 [dev-dependencies]
+apache-avro = { path = "../avro" }
+serde = { workspace = true }
 console_error_panic_hook = { version = "0.1.7" }
 wasm-bindgen-test = "0.3.64"
 

--- a/wasm-demo/src/lib.rs
+++ b/wasm-demo/src/lib.rs
@@ -14,3 +14,5 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
+pub use apache_avro::Schema;


### PR DESCRIPTION
```
warning: explicit `package.readme` can be inferred
  --> avro_test_helper/Cargo.toml:29:1
   |
29 | readme = "README.md"
   | ^^^^^^^^^^^^^^^^^^^^
   |
   = note: `cargo::manual_readme` is set to `warn` by default
help: consider removing `package.readme`
warning: `apache-avro-test-helper` (manifest) generated 1 warning
warning: explicit `package.readme` can be inferred
  --> avro_derive/Cargo.toml:29:1
   |
29 | readme = "README.md"
   | ^^^^^^^^^^^^^^^^^^^^
   |
   = note: `cargo::manual_readme` is set to `warn` by default
help: consider removing `package.readme`
warning: `apache-avro-derive` (manifest) generated 1 warning
warning: explicit `package.readme` can be inferred
  --> wasm-demo/Cargo.toml:23:1
   |
23 | readme = "README.md"
   | ^^^^^^^^^^^^^^^^^^^^
   |
   = note: `cargo::manual_readme` is set to `warn` by default
help: consider removing `package.readme`
warning: `hello-wasm` (manifest) generated 1 warning
warning: explicit `package.readme` can be inferred
  --> avro/Cargo.toml:21:1
   |
21 | readme = "README.md"
   | ^^^^^^^^^^^^^^^^^^^^
   |
   = note: `cargo::manual_readme` is set to `warn` by default
help: consider removing `package.readme`
warning: `apache-avro` (manifest) generated 1 warning
warning: unused dependency `apache-avro`
  --> wasm-demo/Cargo.toml:37:1
   |
37 | apache-avro = { path = "../avro" }
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `cargo::unused_dependencies` is set to `warn` by default
help: consider removing the dependency on `apache-avro`
warning: `hello-wasm` (manifest) generated 1 warning
```